### PR TITLE
Publish releases to GitHub Pages on tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+name: Deploy
+
+# Tags are production. Merging to main means "this is good"; tagging a release means
+# "this is live". That gap is deliberate — it lets main carry finished work that has
+# not been published yet, without needing a second long-lived branch to track it.
+on:
+  push:
+    tags: ['v*']
+  # Lets you re-publish the current tag without cutting a new one (a broken deploy,
+  # or a Pages outage) without making the tag itself a lie.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Never let two releases publish at once, and never cancel one half-done — a
+# cancelled deploy can leave the site serving a partial build.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: npm
+
+      - run: npm ci
+
+      # CI already ran on main, but a tag can be placed on any commit. Re-running the
+      # suite here means nothing reaches the published site without passing it.
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,35 @@ npm run build     # make sure it still builds
 
 CI runs all four on every PR.
 
+`main` is protected: every change lands through a pull request with CI green and the
+branch up to date. That applies to maintainers too — nobody pushes to `main` directly.
+
+## Releasing
+
+**Merging to `main` means "this is good". Tagging means "this is live".**
+
+`main` is always deployable but is not itself deployed, so finished work can sit there
+unpublished until it is worth a release. Publishing is a tag push:
+
+```bash
+git checkout main && git pull
+npm version minor        # or patch/major — writes package.json and makes the tag
+git push --follow-tags
+```
+
+That fires `.github/workflows/deploy.yml`, which reruns the tests, builds, and
+publishes to GitHub Pages.
+
+`npm version` also runs `scripts/sync-version.js`, which regenerates `src/version.js`
+— the `BUILD_VERSION` shown in the app header and quoted in bug reports — from
+`package.json`, and stages it into the release commit. **Do not edit `src/version.js`
+by hand**; it is generated, and a build that misreports its own version makes every bug
+report from it untrustworthy.
+
+If a deploy fails for reasons that are not the code's fault, re-run the Deploy workflow
+from the Actions tab rather than moving the tag. A tag should keep meaning the commit it
+originally meant.
+
 ## The fingerprint test
 
 `tests/fingerprint.test.js` hashes the whole simulation across a large matrix of

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:fingerprint:update": "node scripts/update-fingerprint.js",
+    "version": "node scripts/sync-version.js && git add src/version.js",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit"
   },

--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -1,0 +1,39 @@
+/**
+ * Rewrites `src/version.js` from the version in `package.json`.
+ *
+ * Run automatically by npm's `version` lifecycle hook, which fires after the version
+ * in package.json is bumped but before the release commit is made — so the bump, the
+ * source change and the tag all land in one commit. See the Releasing section of
+ * CONTRIBUTING.md.
+ *
+ * This exists because the build version is shown in the app header and quoted in bug
+ * reports. Kept by hand it silently drifts, and a published build that misreports its
+ * own version makes every bug report from it untrustworthy.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const { version } = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+
+const contents = `/**
+ * Build version, shown on the start screen and in the header so a tester can confirm
+ * which build they are actually running.
+ *
+ * GENERATED — do not edit by hand. Run \`npm version <patch|minor|major>\`, which
+ * rewrites this file from package.json via scripts/sync-version.js.
+ */
+export const BUILD_VERSION = 'v${version}';
+`;
+
+const target = join(root, 'src', 'version.js');
+const before = readFileSync(target, 'utf8');
+
+if (before === contents) {
+  console.log(`src/version.js already at v${version}`);
+} else {
+  writeFileSync(target, contents);
+  console.log(`src/version.js -> v${version}`);
+}

--- a/src/version.js
+++ b/src/version.js
@@ -2,6 +2,7 @@
  * Build version, shown on the start screen and in the header so a tester can confirm
  * which build they are actually running.
  *
- * Bump this whenever behaviour changes, and keep it in step with `package.json`.
+ * GENERATED — do not edit by hand. Run `npm version <patch|minor|major>`, which
+ * rewrites this file from package.json via scripts/sync-version.js.
  */
-export const BUILD_VERSION = 'v1.2';
+export const BUILD_VERSION = 'v1.2.0';


### PR DESCRIPTION
Sets up dev/prod separation without a second long-lived branch: **merging to `main` means "this is good", tagging means "this is live".**

`main` is protected and always deployable, but nothing published it. Now a `v*` tag reruns the suite, builds, and deploys to GitHub Pages — so finished work can sit on `main` unreleased without a `develop` branch to keep in sync (and without doubling `fingerprint.sha256` conflicts).

## Changes

- **`.github/workflows/deploy.yml`** — on `v*` tag push (plus `workflow_dispatch` to re-publish a tag without moving it). Reruns `npm test` before building, because a tag can be placed on any commit. `concurrency: pages` with `cancel-in-progress: false`, since a cancelled deploy can leave the site serving a partial build.
- **`scripts/sync-version.js` + `version` lifecycle hook** — see below.
- **CONTRIBUTING.md** — a Releasing section, and a note that `main` is protected.

## The version bug this uncovered

`BUILD_VERSION` in `src/version.js` was a hand-maintained literal (`'v1.2'`) that `npm version` would not have touched. Under the new pipeline the published site would have announced a stale version, making every bug report quoting it untrustworthy — `src/version.js` even says "keep it in step with package.json", which is precisely the kind of instruction that rots.

It is now generated from `package.json` by npm's `version` lifecycle hook, staged into the release commit. It also gains the patch component (`v1.2.0`), which is strictly better for the bug reports CONTRIBUTING asks people to quote it in. No test referenced `BUILD_VERSION`.

## Verification

`npm version patch` was run locally end to end, then rolled back:

```
src/version.js -> v1.2.1
2c2c812 1.2.1
 package-lock.json | 4 ++--
 package.json      | 2 +-
 src/version.js    | 2 +-
```

One commit, all three files, tagged `v1.2.1`. Rolled back to 1.2.0 with no tags left behind.

| Check | Result |
| --- | --- |
| `npm test` | exit 0 |
| `npm run lint` | exit 0 |
| `npm run typecheck` | exit 0 |
| `npm run build` | exit 0 |

## Repo settings already applied (not in this diff)

- Pages enabled with `build_type: workflow` → https://dniev.github.io/ecu-lab/
- `github-pages` environment restricted to `v*` **tags only**; the auto-created `main` branch policy was removed so `main` cannot deploy.

Nothing is published until the first `v*` tag is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)