### PR TITLE
Release v1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ecu-lab",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ecu-lab",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "lucide-react": "^0.460.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecu-lab",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "An engine management and tuning simulator. Design an engine, edit the same three calibration tables a real tuner edits, run a dyno pull, and read a log that explains what went right or wrong.",
   "keywords": [
     "engine",

--- a/src/version.js
+++ b/src/version.js
@@ -5,4 +5,4 @@
  * GENERATED — do not edit by hand. Run `npm version <patch|minor|major>`, which
  * rewrites this file from package.json via scripts/sync-version.js.
  */
-export const BUILD_VERSION = 'v1.3.0';
+export const BUILD_VERSION = 'v1.4.0';


### PR DESCRIPTION
Weekly release. **71 commits** since `v1.3.0`.

Approve and merge, then tag the merge commit to publish:

```bash
git checkout main && git pull
git tag v1.4.0 && git push origin v1.4.0
```

The tag is what deploys — merging this PR does not publish anything.

> Opened by hand: the scheduled workflow built and pushed this branch correctly, but `gh pr create` was refused with *"GitHub Actions is not permitted to create or approve pull requests"*. That is a repository setting, not a workflow bug. See the run [31969450651](https://github.com/DNiev/ecu-lab/actions/runs/31969450651).

## What is in it

- Release v1.4.0
- Pin the Node version, guard the fingerprint, and open the release PR weekly
- Point the documented defect at its issue
- Hold back the fuel-mass fix, and rebaseline the fingerprint on Node 20
- Apply whole-branch review findings: vacuous test, comment, fingerprint gap
- Judge a spark cell's knock at the pressure its row is indexed by
- Bring the advisors inside the behavioural fingerprint
- Plan the spark advisor's knock basis fix
- Record the closed limitations and the re-anchored pressure scale in the design spec
- Cut the commentary back to the size of the code it explains
- WIP: two-zone cycle, compressor map, shaft inertia, crevice and blowby
- Fit the Rev-Up's cam instead of inheriting the custom-build default
- Add VQ35DE Rev-Up engine preset
- Regenerate the fingerprint against the merged knock-coefficient refactor
- Point the descope notes at the issue that now tracks it
- Re-measure against the merged peak-pressure model, and widen its anchor
- Correct the counts the B58s invalidated, and disclose what they do not reproduce
- Make the engine picker a dropdown grouped by manufacturer
- Group presets by manufacturer, in the sim rather than the JSX
- Add both B58 variants as validated factory presets
- Record the pre-flight adjudication on Task 3's ordering test
- Plan the B58 preset pair, injector catalogue and grouped picker
- Design the B58 preset pair and a manufacturer-grouped picker
- Stop the spark advisor contradicting the calibration the app generated
- Measure charge heat from the model's own ambient, not a stray 25
- Move the knock model's constants into coefficients.js
- Re-derive the fingerprint report against the new MBT model
- Close the physics gaps the cycle exposed: Woschni, a turbo power balance, and one exhaust temperature
- Clear out what the cycle orphaned, and stop teaching a retired formula
- Replace the algebraic combustion model with a crank-angle cycle
- Add VQ35DE Rev-Up engine preset
- Measure charge heat from the model's own ambient, not a stray 25
- Move the knock model's constants into coefficients.js
- Charge peak cylinder pressure for compression, not just boost
- Judge spark danger by the player's own number, not by ceiling order
- Update the fingerprint for the burn-duration MBT model
- Cover the live engine's idle, which the burn model moves
- Distinguish a legitimate absent reading from a physics blow-up in the fingerprint
- Report no BSFC reading instead of zero when the engine makes no power
- Report cells that are past MBT rather than past the knock limit
- Bound the spark advisor by MBT, and stop calling safe cells dangerous
- Derive MBT from burn duration instead of a six-degree load term
- Record the two pre-flight adjudications in the plan
- Add the implementation plan for light-load MBT
- Add the design for light-load MBT and the datalog sentinels
- Fix wave 2: correct comment claims that outran the code
- Fix wave: correct DI physics, gate compression rule on actual boost
- Refresh the fingerprint for the new compression rule
- Judge compression under boost against octane and charge cooling
- Correct a false claim about where the compression base sits
- Correct two errors in the compression-rule plan
- Add compression-under-boost coefficients for the Engineer Score
- Implementation plan for the DI-aware compression rule
- Point the compression-rule spec at #24 for real DI modelling
- Design: DI-aware compression rule for the Engineer Score
