### PR TITLE
Actually apply the release workflow change #51 only claimed to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,14 @@ on:
   push:
     branches: [main]
   pull_request:
-  # Lets the weekly release workflow run these checks on the branch it just pushed.
-  # A pull request opened by GITHUB_TOKEN does NOT raise a `pull_request` event — that
-  # is GitHub's recursion guard — so without this the release PR would sit with no
-  # checks at all and could never satisfy the required-status-check rule on main.
-  # `workflow_dispatch` is the documented exception to that guard.
+  # Run the checks by hand from the Actions tab, against any ref. Useful for a branch
+  # pushed by automation before anyone has opened a pull request for it.
+  #
+  # This was originally added so the release workflow could dispatch CI onto a branch
+  # whose PR it had opened itself — a PR opened by GITHUB_TOKEN raises no
+  # `pull_request` event, so the required checks never reported. That workflow no
+  # longer opens the PR, so the workaround is not needed; the trigger stays because
+  # being able to run CI on demand is worth having on its own.
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,19 @@
-name: Weekly release PR
+name: Weekly release
 
-# Opens the version-bump pull request every Thursday night, so a release is sitting
-# ready to approve on Friday morning.
+# Prepares a release every Thursday night, so it is ready to open on Friday morning.
 #
-# It deliberately stops at the PR. Tagging is what publishes (see deploy.yml), and that
-# stays a human decision — "merging to main means this is good, tagging means this is
-# live" only means something if somebody decides. This automates the tedious half:
-# working out the next version, bumping it, and writing down what is in the release.
+# It bumps the version on a branch, pushes it, and files an issue with the notes and a
+# one-click link to open the pull request. It deliberately does NOT open the PR itself.
+#
+# WHY NOT. `gh pr create` needs the repository setting "Allow GitHub Actions to create
+# and approve pull requests", which is off. Turning it on grants every workflow here the
+# right to APPROVE pull requests too — the same toggle covers both — which would quietly
+# undercut the review requirement on main. A fine-grained PAT would dodge that, but it
+# expires within a year and fails silently when it does, putting a scheduled outage
+# inside the machinery meant to reduce toil.
+#
+# Opening the PR yourself also costs nothing and gains something: a PR you open raises a
+# normal `pull_request` event, so CI attaches by itself with no dispatch workaround.
 #
 # 02:00 UTC Friday is 22:00 Thursday US Eastern during daylight saving, 21:00 outside
 # it. GitHub cron has no timezone support, so the winter hour drifts by one; that is
@@ -24,13 +31,14 @@ on:
         type: choice
         options: [patch, minor, major]
 
+# Only what it actually does: push a branch, and file an issue. Notably NOT
+# `pull-requests: write` — see the note above.
 permissions:
   contents: write
-  pull-requests: write
-  actions: write        # to dispatch the CI run on the branch we push
+  issues: write
 
 jobs:
-  open-release-pr:
+  prepare-release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -42,8 +50,8 @@ jobs:
         with:
           node-version-file: .nvmrc
 
-      # Nothing to release is the normal case on a quiet week, and an empty release PR
-      # is worse than none: it burns a version number and an approval on no change.
+      # Nothing to release is the normal case on a quiet week, and an empty release is
+      # worse than none: it burns a version number and an approval on no change.
       - name: Check for unreleased commits
         id: unreleased
         run: |
@@ -58,9 +66,7 @@ jobs:
 
       - name: Stop if there is nothing to release
         if: steps.unreleased.outputs.count == '0'
-        run: |
-          echo "::notice::No commits since ${{ steps.unreleased.outputs.last }} — no release PR this week."
-          exit 0
+        run: echo "::notice::No commits since ${{ steps.unreleased.outputs.last }} — nothing to prepare this week."
 
       - name: Bump the version on a branch
         if: steps.unreleased.outputs.count != '0'
@@ -90,39 +96,45 @@ jobs:
           git commit -am "Release ${{ steps.bump.outputs.version }}"
           git push origin "${{ steps.bump.outputs.branch }}"
 
-      - name: Open the pull request
+      - name: Assemble the release notes
         if: steps.unreleased.outputs.count != '0'
+        id: notes
         env:
-          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.bump.outputs.version }}
           BRANCH: ${{ steps.bump.outputs.branch }}
           LAST: ${{ steps.unreleased.outputs.last }}
           COUNT: ${{ steps.unreleased.outputs.count }}
         run: |
+          COMPARE="${{ github.server_url }}/${{ github.repository }}/compare/main...${BRANCH}?expand=1"
+          echo "compare=$COMPARE" >> "$GITHUB_OUTPUT"
           {
-            echo "Weekly release. **$COUNT commits** since \`${LAST:-the beginning}\`."
+            echo "\`$BRANCH\` is pushed and ready. **$COUNT commits** since \`${LAST:-the beginning}\`."
             echo
-            echo "Approve and merge, then tag the merge commit to publish:"
+            echo "**[Open the release pull request]($COMPARE)**"
+            echo
+            echo "Then approve, merge, and tag the merge commit — the tag is what deploys:"
             echo
             echo '```bash'
             echo "git checkout main && git pull"
             echo "git tag $VERSION && git push origin $VERSION"
             echo '```'
             echo
-            echo "The tag is what deploys — merging this PR does not publish anything."
+            echo "Merging the PR publishes nothing on its own."
             echo
             echo "## What is in it"
             echo
             git log --no-merges --pretty='- %s' "${LAST:+$LAST..}HEAD"
-          } > body.md
-          gh pr create --base main --head "$BRANCH" --title "Release $VERSION" --body-file body.md
+          } > notes.md
+          cat notes.md >> "$GITHUB_STEP_SUMMARY"
 
-      # See the note on ci.yml's workflow_dispatch trigger: the PR above was opened by
-      # GITHUB_TOKEN, so it raised no `pull_request` event and CI has not run. Dispatch
-      # it explicitly against the branch, or the required checks never report and the
-      # PR cannot merge.
-      - name: Trigger CI on the release branch
+      # The run summary alone is easy to miss on a quiet Friday. An issue lands in the
+      # normal notification stream, and filing one needs no permission beyond the
+      # `issues: write` above — unlike opening a pull request.
+      - name: File the release issue
         if: steps.unreleased.outputs.count != '0'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run ci.yml --ref "${{ steps.bump.outputs.branch }}"
+        run: |
+          gh issue create \
+            --title "Release ${{ steps.bump.outputs.version }} is ready to open" \
+            --body-file notes.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,14 +71,26 @@ branch up to date. That applies to maintainers too — nobody pushes to `main` d
 `main` is always deployable but is not itself deployed, so finished work can sit there
 unpublished until it is worth a release.
 
-**This is normally done for you.** `.github/workflows/release-pr.yml` runs every
+**The bump is normally prepared for you.** `.github/workflows/release.yml` runs every
 Thursday at 02:00 UTC — 22:00 Thursday US Eastern in summer, 21:00 in winter, since
-GitHub cron has no timezone — and opens the version-bump PR if there is anything
-unreleased, so it is waiting on Friday morning. It stops at the PR on purpose: approving
-and tagging stay yours, because tagging is what publishes. Run it off-cadence, or with a
-`patch`/`major` bump, from the Actions tab.
+GitHub cron has no timezone. If anything is unreleased it bumps the version on a
+`release/vX.Y.Z` branch, pushes it, and files an issue with the notes and a one-click
+link to open the pull request. Quiet weeks are skipped rather than burning a version
+number on an empty diff. Run it off-cadence, or with a `patch`/`major` bump, from the
+Actions tab.
 
-The rest of this section is the manual path — for a hotfix, or if the workflow fails.
+You open the PR, approve, merge and tag. That is three deliberate steps and they stay
+manual: tagging is what publishes.
+
+It stops short of opening the PR itself for a specific reason. `gh pr create` from a
+workflow needs the repository setting *"Allow GitHub Actions to create and approve pull
+requests"*, and that one toggle also grants every workflow here the right to **approve**
+pull requests — which would quietly undercut the review requirement on `main`. Opening
+it yourself costs a click and gains something too: a PR you open raises a normal
+`pull_request` event, so CI attaches without any dispatch workaround.
+
+The rest of this section is what that automation does, and the path to follow by hand
+for a hotfix or if the workflow fails.
 
 The version bump is an ordinary pull request — `main` takes no direct pushes, from
 anyone. So do **not** use a bare `npm version`, which commits and tags straight onto


### PR DESCRIPTION
**#51 shipped an empty rename.** Its diff was `1 file changed, 0 insertions(+), 0 deletions(-)`.

`git mv` stages a rename, but my edits to the file's *contents* were still unstaged, and I committed without `-a`. So the rename landed and nothing else did — not the workflow rewrite, not the `ci.yml` comment, not the CONTRIBUTING update. The PR body described work that was not in the diff.

It surfaced when I dispatched the supposedly-new workflow and it ran the **old** job (`open-release-pr`) and failed on `gh pr create` exactly as before:

```
GitHub Actions is not permitted to create or approve pull requests
```

This PR is that change, for real. `git show --stat`:

```
.github/workflows/ci.yml      | 13 +++++----
.github/workflows/release.yml | 68 +++++++++++++++++++++++++------------------
CONTRIBUTING.md               | 26 ++++++++++++-----
```

## What it does

- **`gh pr create` → `gh issue create`**, so the workflow stops needing a permission that cannot be granted without also letting every workflow here *approve* pull requests.
- **`permissions` drops `pull-requests: write` and `actions: write`**, keeping only `contents: write` and `issues: write`.
- Notes and a one-click compare link go to the run summary **and** the issue — the summary alone is easy to miss on a quiet Friday.
- Job renamed `open-release-pr` → `prepare-release`; workflow name → "Weekly release".
- `ci.yml` keeps `workflow_dispatch`, with a comment that no longer states a rationale that stopped being true.
- `CONTRIBUTING.md` describes what the automation now does and why it stops short of opening the PR.

## Verification

Checked the **staged** tree this time rather than the worktree — that was the actual failure mode:

```
-  pull-requests: write
-  actions: write
+  issues: write
-  open-release-pr:
+  prepare-release:
-          gh pr create --base main ...
+          gh issue create \
```

Node 22 `lint` and `typecheck` pass. Both workflows parse with the expected triggers, jobs and permissions (`release.yml` → `prepare-release`, `contents`+`issues` only).

The scheduled path still needs one real dispatch to be proven, which I'll run once this merges. The stale `release/v1.4.1` branch left by the failed run has been deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vs8ohJjwqS4pEKNEoQaTAy