### PR TITLE
Describe ECU Lab as a partnership

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,10 +3,15 @@
 Thanks for being here. This project is a teaching tool, so contributions that make the
 physics more honest or the explanations clearer are worth as much as new features.
 
-**ECU Lab was created by CaribouTuning** — the engine model and everything it teaches
-are his work. Turtle.GTI maintains the repository, tests and tooling. When a change
-touches the physics or the teaching material, CaribouTuning's read on it is the one
-that settles it; he is the domain authority here.
+**ECU Lab is built by CaribouTuning and Turtle.GTI, as partners.** CaribouTuning created
+it — the engine model and everything it teaches started with him, the domain knowledge
+behind them is his, and he still works on the physics. Turtle.GTI develops and maintains
+it: the physics added since, the test suite and its fingerprint gate, the tooling, and
+the current rework of the app.
+
+A change that touches the physics or the teaching material is settled between them. If a
+pull request raises a question neither the code nor the tests can answer on their own,
+expect that conversation rather than a single verdict.
 
 ## The one rule that matters
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Caribou Tuning
+Copyright (c) 2026 Caribou Tuning and Turtle.GTI
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # ECU Lab
 
-### An engine management and tuning simulator, created by **CaribouTuning**.
+### An engine management and tuning simulator.
 
-> **CaribouTuning** Designed it, and wrote the engine
-> model — the physics, the calibration tables, the pull log, the teaching material,
-> the whole thing. Every number this simulator produces comes from his work.
+> **CaribouTuning** and **Turtle.GTI** build ECU Lab together.
 >
-> **Turtle.GTI** is hosting the repository and handling the engineering, scaffolding,
-> and scaling around it: packaging it as a project, adding the test suite, and setting up
-> CI, so the app has somewhere to live and grow.
+> CaribouTuning created it. The concept, the engine model, the calibration tables, the
+> pull log and the teaching material started with him, the domain knowledge behind them
+> is his, and he still works on the physics.
+>
+> Turtle.GTI develops and maintains it: the physics added since, the test suite and its
+> behavioural fingerprint gate, the tooling and CI, and the current rework of the app.
 
 Design an engine, edit the same three calibration tables a real tuner edits, run a dyno
 pull, and read a log that explains what went right or wrong.
@@ -122,24 +123,30 @@ UI is still one large component pending decomposition, and accessibility needs w
 
 ## Credits
 
-**ECU Lab was created by [CaribouTuning](#credits).**
+**ECU Lab is built by CaribouTuning and Turtle.GTI, as partners.**
 
-The simulator is his. The engine model, the calibration tables, the knock envelope, the
-pull log, the scoring, the tutorial and the design — all of it originated with him, and
-the domain knowledge behind it is his too. Anything this app teaches, it teaches because
-he knew it first.
+It began as CaribouTuning's. The engine model, the calibration tables, the knock
+envelope, the pull log, the scoring, the tutorial and the original design all originated
+with him, and so did the domain knowledge behind them. Anything this app teaches at its
+core, it teaches because he knew it first — and he is still working on the physics.
+
+Turtle.GTI develops and maintains it: the physics added since, the behavioural
+fingerprint that pins the model against drift, the intent test suite, CI, the release
+pipeline, and the current rebuild of the interface.
+
+Decisions that touch the physics or the teaching material are made between them.
 
 | | |
 |---|---|
-| **CaribouTuning** | Creator and author. Engine model, physics, calibration design, UI, teaching material. |
-| **Turtle.GTI** | Repository, build tooling, test suite, CI, packaging. |
+| **CaribouTuning** | Created it. Engine model, calibration design, pull log, scoring, teaching material, ongoing physics. |
+| **Turtle.GTI** | Develops and maintains it. Physics, test suite and fingerprint gate, tooling, CI, and the UI rework. |
 
 Contributions from anyone else are very welcome — see
 [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Licence
 
-[MIT](LICENSE) — copyright Caribou Tuning.
+[MIT](LICENSE) — copyright Caribou Tuning and Turtle.GTI.
 
 ## A note on real engines
 


### PR DESCRIPTION
The README still split the project the way it was on day one — CaribouTuning as creator
and author, Turtle.GTI "hosting the repository" and handling packaging and CI. That is
not how we work on it now, and it flattered neither side: it read as though one of us had
stopped and the other only kept the lights on.

## What this changes

**Both of us, as partners.** The header and Credits now say ECU Lab is built by
CaribouTuning and Turtle.GTI together, rather than presenting one as the author and the
other as infrastructure.

**CaribouTuning created it, and still works on the physics.** The engine model, the
calibration tables, the knock envelope, the pull log, the scoring and the teaching
material started with him, and the domain knowledge behind them is his. The
peak-cylinder-pressure model (#35) and the knock coefficients (#36) came in from his
branches. The README says both halves of that — where it came from, and that he is still
at it.

**Turtle.GTI develops and maintains it.** The physics added since, the behavioural
fingerprint that pins the model against drift, the intent test suite, CI, the release
pipeline, and the current rebuild of the interface. "Repository, build tooling, test
suite, CI, packaging" undersold that considerably.

**`CONTRIBUTING.md` is brought into agreement.** It carried a stronger claim than the
README — *"CaribouTuning's read on it is the one that settles it; he is the domain
authority here."* Changing credit in one document while leaving a governance clause in
the other would have left them contradicting each other about who decides a physics
question. Both now say it is settled between the two of us.

## One thing to confirm before merging

**The `LICENSE` copyright line now names both parties** (`Caribou Tuning and
Turtle.GTI`), and the README's licence line matches. That is an ownership statement
rather than a credit line, and it is the one change here worth confirming with
CaribouTuning directly rather than letting it land as a surprise. If he would rather it
stayed as it was, that hunk drops cleanly without affecting the rest.

## Verification

Documentation only — no source changes. `npm test` (251 passing) and `npm run build`
both green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd