### PR TITLE
UI overhaul PR 1: design system and azure palette

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Thumbs.db
 
 # Python bytecode from scripts/
 __pycache__/
+
+# Superpowers brainstorming session artifacts
+.superpowers/

--- a/docs/superpowers/plans/2026-08-19-ui-design-system.md
+++ b/docs/superpowers/plans/2026-08-19-ui-design-system.md
@@ -1,0 +1,2619 @@
+# UI Design System (PR 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace ECU Lab's ad-hoc inline styling with a single token layer and a tested primitives library, turning the whole app azure in the process — without changing any physics.
+
+**Architecture:** `src/ui/tokens.js` holds every colour as the one source of truth; `src/ui/tokens.css` mirrors it as CSS custom properties and a test proves the two cannot drift. The existing `theme.js` is re-pointed at those tokens, which recolours all 500+ existing `T.*` call sites at once. New primitives are built as React components with co-located CSS Modules, then proven by converting the two entry screens.
+
+**Tech Stack:** React 18, Vite 5 (native CSS Modules), Vitest 2, `@testing-library/react` + `jsdom` (new devDependencies), JSDoc types checked by `tsc --checkJs`.
+
+## Global Constraints
+
+- **Node 20 or 22 only — never 26.** `.nvmrc` pins 22. Newer V8 shifts float results and invalidates the fingerprint hash.
+- **`tests/fingerprint.test.js` must stay green and must NOT be regenerated.** This is a UI-only change; a moved fingerprint means the change broke physics. Never run `npm run test:fingerprint:update`.
+- **No changes to `src/sim/` in this PR** except where a task explicitly says so (no task in this plan does).
+- **No new runtime dependencies.** Only `@testing-library/react` and `jsdom` as devDependencies.
+- **Nothing adds horsepower** (`CONTRIBUTING.md`). No task here touches physics at all.
+- **Full gate before the PR:** `npm test`, `npm run lint`, `npm run typecheck`, `npm run build`.
+- Branch is `feat/6-ui-design-system`, already created. Never commit to `main`.
+- Every commit message ends with the repo's `Co-Authored-By:` and `Claude-Session:` trailers.
+
+## Scope note — one deliberate deviation from the spec
+
+The design doc says PR 1 makes "no screen changes". This plan makes two, on purpose,
+and they are worth understanding before starting:
+
+**Task 3 recolours every existing screen.** Re-pointing `theme.js` was always going to
+do that — 500+ `T.*` call sites change value the moment the tokens change. There is no
+version of "add the token layer" that leaves the running app looking the same, short of
+shipping a palette nothing uses. Taking the recolour now means the loudest complaint in
+the issue is fixed in PR 1 rather than PR 3.
+
+**Task 9 converts the start and tutorial screens.** Without it, every primitive in this
+PR is unused code and the reviewer has nothing to look at. These two screens were chosen
+because they are self-contained, are the first thing a user sees, and touch none of the
+four main tabs — so they prove the system without pre-empting the IA work in PR 3.
+
+What the spec's "no screen changes" actually protects — the navigation, the four tabs,
+the tuning grids — is untouched here.
+
+---
+
+### Task 1: Token source of truth
+
+**Files:**
+- Create: `src/ui/tokens.js`
+- Create: `src/ui/tokens.css`
+- Test: `tests/tokens.test.js`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `tokens` — a frozen object of `{[name: string]: string}` where every value is a CSS colour or font stack. Key names are camelCase (`accInk`); the CSS custom property is the kebab-case form (`--acc-ink`). Also exports `camelToKebab(s: string): string`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/tokens.test.js`:
+
+```js
+/**
+ * Token contract tests.
+ *
+ * `tokens.js` and `tokens.css` describe the same palette in two languages, and
+ * nothing but a test can stop them drifting. These also pin the one rule the whole
+ * colour system rests on: the accent is never a status colour.
+ */
+
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import { camelToKebab, tokens } from '../src/ui/tokens.js';
+
+const css = readFileSync(new URL('../src/ui/tokens.css', import.meta.url), 'utf8');
+
+/** @returns {Map<string,string>} every `--name: value` declared in tokens.css */
+function parseCss() {
+  const out = new Map();
+  for (const m of css.matchAll(/--([a-z0-9-]+)\s*:\s*([^;]+);/g)) {
+    out.set(m[1], m[2].trim());
+  }
+  return out;
+}
+
+describe('token contract', () => {
+  it('declares every JS token as a CSS custom property with the same value', () => {
+    const declared = parseCss();
+    for (const [key, value] of Object.entries(tokens)) {
+      const cssName = camelToKebab(key);
+      expect(declared.get(cssName), `--${cssName} missing from tokens.css`).toBe(value);
+    }
+  });
+
+  it('declares no CSS custom property that JS does not know about', () => {
+    const known = new Set(Object.keys(tokens).map(camelToKebab));
+    for (const name of parseCss().keys()) {
+      expect(known.has(name), `--${name} exists in CSS but not in tokens.js`).toBe(true);
+    }
+  });
+
+  it('never uses a status colour as the accent', () => {
+    // The defect this whole overhaul exists to fix: when the accent IS the alarm
+    // colour, a real alarm has nowhere to escalate to.
+    for (const status of [tokens.ok, tokens.warn, tokens.danger]) {
+      expect(tokens.acc).not.toBe(status);
+      expect(tokens.accInk).not.toBe(status);
+    }
+  });
+
+  it('is frozen so no screen can mutate the palette at runtime', () => {
+    expect(Object.isFrozen(tokens)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- tests/tokens.test.js`
+Expected: FAIL — `Failed to resolve import "../src/ui/tokens.js"`.
+
+- [ ] **Step 3: Create the JS token source**
+
+Create `src/ui/tokens.js`:
+
+```js
+/**
+ * The palette, and the single place it is defined.
+ *
+ * `tokens.css` mirrors this file as CSS custom properties for stylesheets, and
+ * `tests/tokens.test.js` proves the two never drift. Add a colour here first.
+ *
+ * The organising rule: THE ACCENT IS NEVER A STATUS, AND A STATUS IS NEVER
+ * DECORATION. `acc` means "this is the action" or "this is the live value".
+ * `ok`/`warn`/`danger` mean engine state and nothing else. The previous palette
+ * spent its alarm colour on chrome — 84 uses of the same hot orange on the
+ * wordmark, the nav, the focus ring and genuine warnings alike — which left a real
+ * warning nothing to escalate to.
+ */
+
+/** @param {string} s camelCase token name @returns {string} its kebab-case CSS name */
+export const camelToKebab = (s) => s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+
+/** @type {Readonly<Record<string,string>>} */
+export const tokens = Object.freeze({
+  // Surfaces, darkest to lightest. The base is blue-black rather than neutral grey
+  // because red reads harder against blue than against grey.
+  bg: '#0a0d14',
+  panel: '#131824',
+  panel2: '#1a2130',
+  panel3: '#212a3c',
+
+  // Borders.
+  line: '#262f42',
+  lineHi: '#33405a',
+
+  // Text, four steps from primary to faintest.
+  ink: '#e9eef8',
+  inkSoft: '#c8d2e2',
+  ink2: '#8792a8',
+  ink3: '#5c6880',
+
+  // Accent. `accOn` is text placed ON an accent fill — it must never be a grey.
+  acc: '#4c9eff',
+  accInk: '#8fc2ff',
+  accBg: '#0f2033',
+  accOn: '#04162e',
+
+  // Status. Reserved for engine state. Never used as decoration.
+  ok: '#35e08a',
+  okInk: '#7fe8b4',
+  okBg: '#0d2419',
+  warn: '#ffb020',
+  warnInk: '#ffd07a',
+  warnBg: '#2a2110',
+  danger: '#ff4d4d',
+  dangerInk: '#ff9d9d',
+  dangerBg: '#2a1414',
+
+  // Secondary data hue, for charts that must plot two series at once (power vs
+  // torque). Distinct from `acc` on purpose so a chart never looks like a control.
+  cyan: '#38d9f0',
+  cyanBg: '#0b2630',
+  violet: '#a78bfa',
+  violetBg: '#1d1a33',
+
+  // Type.
+  mono: "ui-monospace, 'SF Mono', Menlo, Consolas, monospace",
+  sans: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+
+  // Bare RGB triplets, so translucent washes can be built from the same colours
+  // rather than re-typing them at a new alpha. See accAlpha/shadowAlpha below.
+  accRgb: '76, 158, 255',
+  shadowRgb: '0, 0, 0',
+});
+
+/**
+ * A translucent accent wash — glows, focus halos, the shadow under a primary button.
+ *
+ * Lives here rather than in a screen because an `rgba()` literal in a component is
+ * precisely what this system exists to prevent, and `tests/no-hardcoded-colours.test.js`
+ * rejects one.
+ *
+ * @param {number} alpha 0-1
+ * @returns {string} an rgba() colour
+ */
+export const accAlpha = (alpha) => `rgba(${tokens.accRgb}, ${alpha})`;
+
+/**
+ * A plain black scrim, for drop shadows and cell borders that must darken whatever
+ * is underneath rather than tint it.
+ *
+ * @param {number} alpha 0-1
+ * @returns {string} an rgba() colour
+ */
+export const shadowAlpha = (alpha) => `rgba(${tokens.shadowRgb}, ${alpha})`;
+```
+
+- [ ] **Step 4: Create the CSS mirror**
+
+Create `src/ui/tokens.css`:
+
+```css
+/* Mirrors src/ui/tokens.js. Both are checked against each other by
+   tests/tokens.test.js — change one and you must change the other. */
+
+:root {
+  --bg: #0a0d14;
+  --panel: #131824;
+  --panel2: #1a2130;
+  --panel3: #212a3c;
+
+  --line: #262f42;
+  --line-hi: #33405a;
+
+  --ink: #e9eef8;
+  --ink-soft: #c8d2e2;
+  --ink2: #8792a8;
+  --ink3: #5c6880;
+
+  --acc: #4c9eff;
+  --acc-ink: #8fc2ff;
+  --acc-bg: #0f2033;
+  --acc-on: #04162e;
+
+  --ok: #35e08a;
+  --ok-ink: #7fe8b4;
+  --ok-bg: #0d2419;
+  --warn: #ffb020;
+  --warn-ink: #ffd07a;
+  --warn-bg: #2a2110;
+  --danger: #ff4d4d;
+  --danger-ink: #ff9d9d;
+  --danger-bg: #2a1414;
+
+  --cyan: #38d9f0;
+  --cyan-bg: #0b2630;
+  --violet: #a78bfa;
+  --violet-bg: #1d1a33;
+
+  --mono: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+
+  --acc-rgb: 76, 158, 255;
+  --shadow-rgb: 0, 0, 0;
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm test -- tests/tokens.test.js`
+Expected: PASS, 4 tests.
+
+Note: `--ink2` and `--ink3` come from keys `ink2`/`ink3`, which `camelToKebab` leaves unchanged because there is no lowercase-to-uppercase boundary. That is intended.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/tokens.js src/ui/tokens.css tests/tokens.test.js
+git commit -m "Add the azure token layer as one source of truth
+
+tokens.js and tokens.css describe the same palette in two languages; a
+contract test proves they cannot drift, and pins the rule the system rests
+on — the accent is never a status colour.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd"
+```
+
+---
+
+### Task 2: Re-point theme.js at the tokens
+
+This is the task where the running app turns azure. `EcuLab.jsx` is not edited at all — the old key names (`amber`, `amberInk`, `amberBg`, `yellow`, `green`, `red`) survive as aliases so all 500+ existing call sites keep working. Task 3 renames them.
+
+**Files:**
+- Modify: `src/ui/theme.js` (whole file)
+- Test: `tests/theme.test.js`
+
+**Interfaces:**
+- Consumes: `tokens` from `src/ui/tokens.js`.
+- Produces: `T` (same shape as before, now token-backed, plus the new keys `acc`, `accInk`, `accBg`, `accOn`, `inkSoft`, `ok`, `okInk`, `okBg`, `warn`, `warnInk`, `warnBg`, `danger`, `dangerInk`, `dangerBg`, `panel3`); `statusColor(v: number): string`; `heat(value: number, min: number, max: number): string`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/theme.test.js`:
+
+```js
+/**
+ * Theme tests.
+ *
+ * `T` is consumed at 500+ call sites in the UI, so a missing key is a blank screen
+ * rather than a type error. These pin the whole surface, plus the two functions
+ * that turn a number into a colour.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { tokens } from '../src/ui/tokens.js';
+import { T, heat, statusColor } from '../src/ui/theme.js';
+
+describe('T', () => {
+  it('exposes every key the existing screens read', () => {
+    const required = [
+      'bg', 'panel', 'panel2', 'panel3', 'line', 'lineHi',
+      'ink', 'inkSoft', 'ink2', 'ink3',
+      'acc', 'accInk', 'accBg', 'accOn',
+      'ok', 'okInk', 'okBg', 'warn', 'warnInk', 'warnBg',
+      'danger', 'dangerInk', 'dangerBg',
+      'amber', 'amberInk', 'amberBg', 'green', 'greenBg',
+      'yellow', 'yellowBg', 'red', 'redBg',
+      'cyan', 'cyanBg', 'violet', 'violetBg', 'mono', 'sans',
+    ];
+    for (const key of required) {
+      expect(T[key], `T.${key} is missing`).toBeTruthy();
+    }
+  });
+
+  it('aliases the retired amber keys onto the accent', () => {
+    // Kept so this commit recolours the app without editing 500 call sites.
+    expect(T.amber).toBe(tokens.acc);
+    expect(T.amberInk).toBe(tokens.accInk);
+    expect(T.amberBg).toBe(tokens.accBg);
+  });
+
+  it('no longer contains the old orange anywhere', () => {
+    expect(Object.values(T)).not.toContain('#ff6a2c');
+    expect(Object.values(T)).not.toContain('#ffab7a');
+  });
+});
+
+describe('statusColor', () => {
+  it('is green at and above 90', () => {
+    expect(statusColor(90)).toBe(tokens.ok);
+    expect(statusColor(100)).toBe(tokens.ok);
+  });
+
+  it('is amber between 55 and 89', () => {
+    expect(statusColor(55)).toBe(tokens.warn);
+    expect(statusColor(89)).toBe(tokens.warn);
+  });
+
+  it('is red below 55', () => {
+    expect(statusColor(54)).toBe(tokens.danger);
+    expect(statusColor(0)).toBe(tokens.danger);
+  });
+});
+
+describe('heat', () => {
+  it('returns an hsl string', () => {
+    expect(heat(50, 0, 100)).toMatch(/^hsl\(/);
+  });
+
+  it('clamps out-of-range values instead of running off the scale', () => {
+    expect(heat(-999, 0, 100)).toBe(heat(0, 0, 100));
+    expect(heat(999, 0, 100)).toBe(heat(100, 0, 100));
+  });
+
+  it('moves monotonically from cool to warm across the range', () => {
+    const hue = (v) => Number(heat(v, 0, 100).match(/hsl\((-?[\d.]+)/)[1]);
+    expect(hue(0)).toBeGreaterThan(hue(50));
+    expect(hue(50)).toBeGreaterThan(hue(100));
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- tests/theme.test.js`
+Expected: FAIL — `T.panel3 is missing` (and the alias assertions fail, since `T.amber` is still `#ff6a2c`).
+
+- [ ] **Step 3: Rewrite theme.js**
+
+Replace the whole of `src/ui/theme.js`:
+
+```js
+/**
+ * The shared visual language, assembled from the tokens.
+ *
+ * Every colour in the app resolves to `src/ui/tokens.js`. Screens must not hard-code
+ * hex values — `tests/no-hardcoded-colours.test.js` enforces that, because the rule
+ * was stated here for a long time and quietly broken 58 times.
+ *
+ * The `amber*`/`yellow`/`green`/`red` keys are ALIASES kept so the pre-overhaul
+ * screens keep rendering while they are migrated. Write new code against
+ * `acc`/`warn`/`ok`/`danger` and delete an alias the moment its last caller goes.
+ */
+
+import { clamp } from '../sim/index.js';
+
+import { tokens } from './tokens.js';
+
+const T = {
+  bg: tokens.bg,
+  panel: tokens.panel,
+  panel2: tokens.panel2,
+  panel3: tokens.panel3,
+  panelHi: tokens.panel3,
+  line: tokens.line,
+  lineHi: tokens.lineHi,
+
+  ink: tokens.ink,
+  inkSoft: tokens.inkSoft,
+  ink2: tokens.ink2,
+  ink3: tokens.ink3,
+
+  acc: tokens.acc,
+  accInk: tokens.accInk,
+  accBg: tokens.accBg,
+  accOn: tokens.accOn,
+
+  ok: tokens.ok,
+  okInk: tokens.okInk,
+  okBg: tokens.okBg,
+  warn: tokens.warn,
+  warnInk: tokens.warnInk,
+  warnBg: tokens.warnBg,
+  danger: tokens.danger,
+  dangerInk: tokens.dangerInk,
+  dangerBg: tokens.dangerBg,
+
+  cyan: tokens.cyan,
+  cyanBg: tokens.cyanBg,
+  violet: tokens.violet,
+  violetBg: tokens.violetBg,
+
+  // --- aliases retired during the overhaul; see the file comment above ---
+  amber: tokens.acc,
+  amberInk: tokens.accInk,
+  amberBg: tokens.accBg,
+  green: tokens.ok,
+  greenBg: tokens.okBg,
+  yellow: tokens.warn,
+  yellowBg: tokens.warnBg,
+  red: tokens.danger,
+  redBg: tokens.dangerBg,
+
+  mono: tokens.mono,
+  sans: tokens.sans,
+};
+
+/** Maps a 0-100 health/quality value onto the green/amber/red status scale. */
+export const statusColor = (v) => (v >= 90 ? T.ok : v >= 55 ? T.warn : T.danger);
+
+/**
+ * Heat-map colour for a table cell, cool (low) through warm (high).
+ *
+ * Deliberately its own ramp rather than the status scale: a hot VE cell is not a
+ * fault, and it must never compete visually with a real warning.
+ *
+ * @param {number} value cell value
+ * @param {number} min low end of the scale
+ * @param {number} max high end of the scale
+ * @returns {string} an hsl() colour
+ */
+function heat(value, min, max) {
+  const t = clamp((value - min) / (max - min), 0, 1);
+  const hue = 214 - t * 214;
+  return `hsl(${hue.toFixed(0)}, 68%, ${26 + t * 12}%)`;
+}
+
+export { T, heat };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm test -- tests/theme.test.js`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Verify the physics did not move**
+
+Run: `npm test`
+Expected: PASS, every suite including `fingerprint.test.js`. If the fingerprint fails here, something is badly wrong — this task touched no physics. Do NOT regenerate it; find the real cause.
+
+- [ ] **Step 6: Look at the app**
+
+Run: `npm run dev`, open the printed URL.
+Expected: the app is recognisably the same layout, now blue instead of orange. Buttons will have **dark brown text** (`#1a0f08`) on azure fills — that is expected and Task 3 fixes it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui/theme.js tests/theme.test.js
+git commit -m "Point theme.js at the azure tokens
+
+Recolours all 500+ existing T.* call sites at once. The retired amber/yellow/
+green/red keys stay as aliases so no screen needs editing yet; Task 3 renames
+them and purges the hard-coded hexes that bypass this file entirely.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd"
+```
+
+---
+
+### Task 3: Purge the hard-coded colours
+
+`EcuLab.jsx` contains 58 hex literals and 9 `rgba()` literals that bypass `theme.js` completely, despite that file having always said not to. Nine of them are `'#1a0f08'`, the brown text that sits on amber fills — leave those and every azure button has brown text.
+
+**Files:**
+- Modify: `src/ui/EcuLab.jsx` (throughout)
+- Test: `tests/no-hardcoded-colours.test.js`
+
+**Interfaces:**
+- Consumes: `T` from `src/ui/theme.js`.
+- Produces: nothing importable. Establishes the invariant that `src/ui/**` contains no colour literal outside `tokens.js`/`tokens.css`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/no-hardcoded-colours.test.js`:
+
+```js
+/**
+ * Guards the rule theme.js has always stated and nothing ever enforced.
+ *
+ * A hard-coded colour is invisible to the token layer, so a palette change silently
+ * misses it. That is exactly how 58 stray hexes accumulated in one component.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const UI_DIR = new URL('../src/ui/', import.meta.url);
+
+/** Files allowed to name a colour literally: the token layer itself. */
+const ALLOWED = new Set(['tokens.js', 'tokens.css']);
+
+/** @returns {string[]} every source file under src/ui that must not name a colour */
+function sourceFiles() {
+  return readdirSync(UI_DIR, { withFileTypes: true, recursive: true })
+    .filter((e) => e.isFile() && /\.(jsx?|css)$/.test(e.name) && !ALLOWED.has(e.name))
+    .map((e) => `${e.parentPath ?? e.path}/${e.name}`);
+}
+
+describe('src/ui contains no hard-coded colours', () => {
+  for (const file of sourceFiles()) {
+    const rel = file.slice(file.indexOf('src/ui'));
+
+    it(`${rel} names no hex colour`, () => {
+      const hits = readFileSync(file, 'utf8').match(/#[0-9a-fA-F]{3,8}\b/g) ?? [];
+      expect(hits, `use a token from theme.js instead of ${hits.join(', ')}`).toEqual([]);
+    });
+
+    it(`${rel} names no rgb/rgba colour`, () => {
+      const hits = readFileSync(file, 'utf8').match(/\brgba?\(\s*\d/g) ?? [];
+      expect(hits, 'use a token, or a colour-mix on one, instead').toEqual([]);
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- tests/no-hardcoded-colours.test.js`
+Expected: FAIL — `src/ui/EcuLab.jsx names no hex colour` reports 58 literals.
+
+- [ ] **Step 3: Re-export the alpha helpers from theme.js**
+
+Task 1 already defined `accAlpha` and `shadowAlpha` in `tokens.js`. Re-export them from
+`src/ui/theme.js` so screens have one import for everything colour-related. Add to the
+imports:
+
+```js
+import { accAlpha, shadowAlpha, tokens } from './tokens.js';
+```
+
+and change the final export line to:
+
+```js
+export { T, accAlpha, heat, shadowAlpha };
+```
+
+`tests/no-hardcoded-colours.test.js` skips `tokens.js` and `tokens.css`, so the two
+`rgba()` templates are legal exactly there and nowhere else.
+
+- [ ] **Step 4: Replace every literal in EcuLab.jsx**
+
+Apply this mapping. Each is a plain find-and-replace of the quoted literal with the token expression.
+
+| Literal | Count | Replace with |
+|---|---|---|
+| `'#1a0f08'` | 9 | `T.accOn` |
+| `'#a5aebb'` | 10 | `T.ink2` |
+| `'#c3cad2'` | 9 | `T.inkSoft` |
+| `'#ff9d9d'` | 7 | `T.dangerInk` |
+| `'#9aa4b0'` | 3 | `T.ink2` |
+| `'#ff9d7a'` | 2 | `T.accInk` |
+| `'#ff8f8f'` | 2 | `T.dangerInk` |
+| `'#3a2f16'` | 2 | `T.warnBg` |
+| `'#fff'` | 2 | `T.ink` |
+| `'#ffcf8a'` | 1 | `T.warnInk` |
+| `'#f2f5f7'` | 1 | `T.ink` |
+| `'#b7c0c9'` | 1 | `T.inkSoft` |
+| `'#7a4526'` | 1 | `T.lineHi` |
+| `'#3a4149'` | 1 | `T.ink3` |
+| `'#3a2c1c'` | 1 | `T.warnBg` |
+| `'#3a2020'` | 1 | `T.dangerBg` |
+| `'#382a4a'` | 1 | `T.violetBg` |
+| `'#2a323a'` | 1 | `T.panel3` |
+| `'#2a1206'` | 1 | `T.accBg` |
+| `'#1f4a30'` | 1 | `T.okBg` |
+| `'#06210f'` | 1 | `T.okBg` |
+
+And the nine `rgba()` literals, all of them, exactly:
+
+| Literal | Count | Replace with |
+|---|---|---|
+| `rgba(255,106,44,0.10)` | 1 | `accAlpha(0.10)` |
+| `rgba(255,106,44,0.16)` | 1 | `accAlpha(0.16)` |
+| `rgba(255,106,44,0.18)` | 1 | `accAlpha(0.18)` |
+| `rgba(255,106,44,0.22)` | 1 | `accAlpha(0.22)` |
+| `rgba(255,106,44,0.25)` | 1 | `accAlpha(0.25)` |
+| `rgba(0,0,0,.4)` | 1 | `shadowAlpha(0.4)` |
+| `rgba(0,0,0,0.35)` | 2 | `shadowAlpha(0.35)` |
+| `rgba(0,0,0,0.45)` | 1 | `shadowAlpha(0.45)` |
+
+Import the helpers alongside `T` at the top of `EcuLab.jsx`:
+
+```jsx
+import { T, accAlpha, heat, shadowAlpha, statusColor } from './theme.js';
+```
+
+(Keep whichever of `heat`/`statusColor` the file already imports; add only what is new.)
+
+Because these sit inside template literals as often as bare values, check each site
+compiles — `border: \`1px solid ${T.line}\`` rather than `border: '1px solid T.line'`.
+
+Confirm the counts before and after, so nothing is missed:
+
+```bash
+grep -o "'#[0-9a-fA-F]\{3,8\}'" src/ui/EcuLab.jsx | wc -l   # 58 before, 0 after
+grep -o "rgba([^)]*)" src/ui/EcuLab.jsx | wc -l             # 9 before, 0 after
+```
+
+- [ ] **Step 5: Rename the retired aliases at their call sites**
+
+Now that the literals are gone, rename the alias keys so `theme.js` can eventually drop them:
+
+```bash
+# Order matters: amberInk and amberBg before amber, or the shorter name eats them.
+sed -i '' 's/T\.amberInk/T.accInk/g; s/T\.amberBg/T.accBg/g; s/T\.amber\b/T.acc/g' src/ui/EcuLab.jsx
+sed -i '' 's/T\.greenBg/T.okBg/g; s/T\.green\b/T.ok/g' src/ui/EcuLab.jsx
+sed -i '' 's/T\.yellowBg/T.warnBg/g; s/T\.yellow\b/T.warn/g' src/ui/EcuLab.jsx
+sed -i '' 's/T\.redBg/T.dangerBg/g; s/T\.red\b/T.danger/g' src/ui/EcuLab.jsx
+```
+
+Then delete the alias block from `src/ui/theme.js` (the nine lines under
+`// --- aliases retired during the overhaul ---`), and delete the
+`aliases the retired amber keys onto the accent` test from `tests/theme.test.js`
+along with the `amber`/`green`/`yellow`/`red` entries in its `required` array.
+
+- [ ] **Step 6: Update the focus-ring colour in index.html**
+
+`index.html` hard-codes the old orange in two places. Change:
+
+```css
+      button:focus-visible, [role="gridcell"]:focus-visible {
+        outline: 2px solid #4c9eff;
+        outline-offset: 2px;
+      }
+```
+
+and in the `<head>`:
+
+```html
+    <meta name="theme-color" content="#0a0d14" />
+```
+
+plus the pre-mount background:
+
+```css
+      html, body { margin: 0; padding: 0; background: #0a0d14; }
+```
+
+`index.html` is outside `src/ui/`, so the guard test does not cover it — this step is
+the reason to check it by hand.
+
+- [ ] **Step 7: Run the guard test**
+
+Run: `npm test -- tests/no-hardcoded-colours.test.js`
+Expected: PASS.
+
+- [ ] **Step 8: Run the full suite**
+
+Run: `npm test`
+Expected: PASS, fingerprint included. Then `npm run lint` and `npm run typecheck` — both clean.
+
+- [ ] **Step 9: Look at the app**
+
+Run: `npm run dev`.
+Expected: azure throughout, **button text now dark navy rather than brown**, warnings red, health green. No orange anywhere.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/ui/ tests/ index.html
+git commit -m "Route every colour in the UI through the token layer
+
+Replaces 58 hex literals and 9 rgba() literals that bypassed theme.js, and
+renames the retired amber/yellow/green/red aliases to acc/warn/ok/danger. A
+guard test now enforces the rule theme.js has always stated.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd"
+```
+
+---
+
+### Task 4: CSS Modules and component-test infrastructure
+
+**Files:**
+- Modify: `package.json` (devDependencies)
+- Modify: `vite.config.js:15-20` (test block)
+- Modify: `tsconfig.json` (include)
+- Create: `src/css-modules.d.ts`
+- Modify: `src/main.jsx` (import tokens.css)
+- Test: `tests/ui/infrastructure.test.jsx`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the ability to `import styles from './X.module.css'` in a typechecked `.jsx` file, and to render a component in a `jsdom` test via `// @vitest-environment jsdom`.
+
+- [ ] **Step 1: Install the devDependencies**
+
+```bash
+npm install --save-dev @testing-library/react@^16.1.0 jsdom@^25.0.1
+```
+
+Expected: two devDependencies added, no production dependencies changed. Verify with
+`git diff package.json` — the `dependencies` block must be untouched.
+
+- [ ] **Step 2: Widen the test glob to include JSX tests**
+
+In `vite.config.js`, change the `include` line inside `test`:
+
+```js
+  test: {
+    // The simulation is pure JS with no DOM dependency, so the default Node
+    // environment is both correct and much faster than jsdom. Component tests opt
+    // into jsdom per-file with `// @vitest-environment jsdom` rather than slowing
+    // the physics suite down for everyone.
+    environment: 'node',
+    include: ['tests/**/*.test.{js,jsx}'],
+  },
+```
+
+- [ ] **Step 3: Declare CSS Modules for the typechecker**
+
+Create `src/css-modules.d.ts`:
+
+```ts
+/**
+ * Vite resolves `*.module.css` to an object of generated class names at build time.
+ * `tsc` knows nothing about that, so without this declaration every stylesheet
+ * import is a "cannot find module" error under `npm run typecheck`.
+ */
+
+declare module '*.module.css' {
+  const classes: Record<string, string>;
+  export default classes;
+}
+
+declare module '*.css';
+```
+
+- [ ] **Step 4: Put the new UI directories under the typechecker**
+
+In `tsconfig.json`, replace the `include` array and its preceding comment:
+
+```json
+  "//include": "src/sim is fully typed. src/ui/EcuLab.jsx is still one large untyped component and stays excluded until the screen split; everything built during the overhaul — tokens, primitives, screens — is typed from the start so the exclusion never has to grow again.",
+  "include": [
+    "src/sim",
+    "src/ui/tokens.js",
+    "src/ui/theme.js",
+    "src/ui/primitives",
+    "src/storage.js",
+    "src/version.js",
+    "src/globals.d.ts",
+    "src/css-modules.d.ts",
+    "tests",
+    "scripts"
+  ],
+```
+
+- [ ] **Step 5: Load the tokens stylesheet at the app root**
+
+In `src/main.jsx`, add the import after the React imports and before the local ones:
+
+```jsx
+import './ui/tokens.css';
+```
+
+- [ ] **Step 6: Write a test that proves the infrastructure works**
+
+Create `tests/ui/infrastructure.test.jsx`:
+
+```jsx
+// @vitest-environment jsdom
+
+/**
+ * Proves the component-test setup itself works before any primitive depends on it:
+ * jsdom provides a document, React renders into it, and @testing-library queries it.
+ *
+ * CSS Module resolution is proven by the Button test in Task 5, which is the first
+ * file that actually imports a stylesheet — this task must not depend on a file a
+ * later task creates, or it cannot end green.
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+describe('component test infrastructure', () => {
+  it('provides a DOM', () => {
+    expect(typeof document).toBe('object');
+  });
+
+  it('renders React into jsdom', () => {
+    render(<button type="button">RUN DYNO PULL</button>);
+    expect(screen.getByRole('button', { name: 'RUN DYNO PULL' })).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `npm test -- tests/ui/infrastructure.test.jsx`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 8: Confirm the physics suite still runs in the fast node environment**
+
+Run: `npm test`
+Expected: PASS throughout. The physics suites must NOT have switched to jsdom — only
+files carrying the `// @vitest-environment jsdom` comment do.
+
+- [ ] **Step 9: Commit the infrastructure**
+
+```bash
+git add package.json package-lock.json vite.config.js tsconfig.json src/css-modules.d.ts src/main.jsx tests/ui/infrastructure.test.jsx
+git commit -m "Add CSS Modules typing and jsdom component-test setup
+
+Component tests opt into jsdom per-file so the physics suite keeps running in
+the fast node environment. Everything built during the overhaul goes under the
+typechecker from the start, so tsconfig's src/ui exclusion never has to grow.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd"
+```
+
+---
+
+### Task 5: Button primitive
+
+The single most visible fix: today every call-to-action is `width: '100%'`, which is
+why buttons span a monitor. This Button is content-width by default and full-width only
+when explicitly asked.
+
+**Files:**
+- Create: `src/ui/primitives/Button.jsx`
+- Create: `src/ui/primitives/Button.module.css`
+- Test: `tests/ui/Button.test.jsx`
+
+**Interfaces:**
+- Consumes: `tokens.css` custom properties (already loaded by `main.jsx`).
+- Produces: `Button({ children, variant, size, block, disabled, onClick, type, ...rest })` — `variant` is `'primary' | 'ghost' | 'danger'` (default `'primary'`), `size` is `'sm' | 'md' | 'lg'` (default `'md'`), `block` is a boolean defaulting to `false`. Renders a real `<button>`; unknown props pass through.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/ui/Button.test.jsx`:
+
+```jsx
+// @vitest-environment jsdom
+
+/**
+ * Button tests.
+ *
+ * The `block` assertions are the point of this component: the pre-overhaul UI made
+ * every action full-width, which is why a primary button spanned a 27-inch monitor.
+ * Full-width is now opt-in.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Button } from '../../src/ui/primitives/Button.jsx';
+import styles from '../../src/ui/primitives/Button.module.css';
+
+describe('Button', () => {
+  it('renders a real button element with its label', () => {
+    render(<Button>RUN DYNO PULL</Button>);
+    const el = screen.getByRole('button', { name: 'RUN DYNO PULL' });
+    expect(el.tagName).toBe('BUTTON');
+  });
+
+  it('defaults to type="button" so it never submits a form by accident', () => {
+    render(<Button>RESET</Button>);
+    expect(screen.getByRole('button').getAttribute('type')).toBe('button');
+  });
+
+  it('is not full-width unless asked', () => {
+    render(<Button>RESET</Button>);
+    expect(screen.getByRole('button').className).not.toContain(styles.block);
+  });
+
+  it('is full-width when block is set', () => {
+    render(<Button block>RUN DYNO PULL</Button>);
+    expect(screen.getByRole('button').className).toContain(styles.block);
+  });
+
+  it('applies the primary variant by default', () => {
+    render(<Button>GO</Button>);
+    expect(screen.getByRole('button').className).toContain(styles.primary);
+  });
+
+  it('applies the variant it is given', () => {
+    render(<Button variant="danger">RESET ENGINE</Button>);
+    expect(screen.getByRole('button').className).toContain(styles.danger);
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>GO</Button>);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClick when disabled', () => {
+    const onClick = vi.fn();
+    render(<Button disabled onClick={onClick}>GO</Button>);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('passes unknown props through to the element', () => {
+    render(<Button aria-label="Run a dyno pull">GO</Button>);
+    expect(screen.getByLabelText('Run a dyno pull')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- tests/ui/Button.test.jsx`
+Expected: FAIL — cannot resolve `../../src/ui/primitives/Button.jsx`.
+
+- [ ] **Step 3: Write the stylesheet**
+
+Create `src/ui/primitives/Button.module.css`:
+
+```css
+/* Content-width by default. `block` is opt-in — see Button.jsx. */
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  font-family: var(--sans);
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background-color 0.14s ease, border-color 0.14s ease, color 0.14s ease;
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--acc);
+  outline-offset: 2px;
+}
+
+.button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* --- variants --- */
+
+.primary {
+  background: var(--acc);
+  color: var(--acc-on);
+}
+.primary:hover:not(:disabled) { background: var(--acc-ink); }
+
+.ghost {
+  background: transparent;
+  border-color: var(--line);
+  color: var(--ink2);
+}
+.ghost:hover:not(:disabled) {
+  border-color: var(--line-hi);
+  color: var(--ink);
+}
+
+/* Reserved for genuinely destructive actions, never for emphasis. */
+.danger {
+  background: var(--danger-bg);
+  border-color: var(--danger);
+  color: var(--danger-ink);
+}
+.danger:hover:not(:disabled) { background: var(--danger); color: var(--bg); }
+
+/* --- sizes --- */
+
+.sm { padding: 6px 11px; font-size: 10px; }
+.md { padding: 9px 16px; font-size: 11.5px; }
+.lg { padding: 13px 22px; font-size: 13.5px; }
+
+/* --- full width, opt-in only --- */
+
+.block { display: flex; width: 100%; }
+```
+
+- [ ] **Step 4: Write the component**
+
+Create `src/ui/primitives/Button.jsx`:
+
+```jsx
+/**
+ * The app's only button.
+ *
+ * Content-width by default. The pre-overhaul UI set `width: '100%'` on every
+ * call-to-action, which is why a primary action spanned the whole window on a
+ * desktop monitor — so full-width is opt-in via `block`, and worth justifying each
+ * time you reach for it.
+ *
+ * `danger` is for destructive actions only. It is not an emphasis variant; the
+ * status colours mean engine state and must not be spent on decoration.
+ */
+
+import React from 'react';
+
+import styles from './Button.module.css';
+
+/**
+ * @param {object} props
+ * @param {React.ReactNode} props.children
+ * @param {'primary'|'ghost'|'danger'} [props.variant]
+ * @param {'sm'|'md'|'lg'} [props.size]
+ * @param {boolean} [props.block] stretch to the full width of the container
+ * @param {string} [props.type]
+ * @returns {React.ReactElement}
+ */
+export function Button({
+  children,
+  variant = 'primary',
+  size = 'md',
+  block = false,
+  type = 'button',
+  ...rest
+}) {
+  const className = [styles.button, styles[variant], styles[size], block && styles.block]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button type={type} className={className} {...rest}>
+      {children}
+    </button>
+  );
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm test -- tests/ui/Button.test.jsx tests/ui/infrastructure.test.jsx`
+Expected: PASS, 11 tests across the two files (the infrastructure test from Task 4 goes green here too).
+
+- [ ] **Step 6: Verify the guard test still holds**
+
+Run: `npm test -- tests/no-hardcoded-colours.test.js`
+Expected: PASS — `Button.module.css` uses `var(--…)` throughout and names no colour.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui/primitives/Button.jsx src/ui/primitives/Button.module.css tests/ui/
+git commit -m "Add the Button primitive
+
+Content-width by default; full-width is opt-in via block. The old UI made every
+call-to-action width:100%, which is why primary actions spanned the window on a
+desktop monitor.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd"
+```
+
+---
+
+### Task 6: Surface primitives — Panel, Eyebrow, Note
+
+Replaces the inline `Panel`, `Eyebrow` and `Note` defined at `EcuLab.jsx:39-62`.
+
+**Files:**
+- Create: `src/ui/primitives/Panel.jsx`, `src/ui/primitives/Panel.module.css`
+- Create: `src/ui/primitives/Eyebrow.jsx`, `src/ui/primitives/Eyebrow.module.css`
+- Create: `src/ui/primitives/Note.jsx`, `src/ui/primitives/Note.module.css`
+- Test: `tests/ui/surfaces.test.jsx`
+
+**Interfaces:**
+- Consumes: `tokens.css`.
+- Produces:
+  - `Panel({ children, tight, as, ...rest })` — `tight` reduces padding; `as` defaults to `'div'`.
+  - `Eyebrow({ children, icon })` — `icon` is an optional Lucide component.
+  - `Note({ children, tone })` — `tone` is `'info' | 'warn' | 'danger'`, default `'info'`; renders `role="note"`, and `role="alert"` when tone is `'danger'`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/ui/surfaces.test.jsx`:
+
+```jsx
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Eyebrow } from '../../src/ui/primitives/Eyebrow.jsx';
+import { Note } from '../../src/ui/primitives/Note.jsx';
+import noteStyles from '../../src/ui/primitives/Note.module.css';
+import { Panel } from '../../src/ui/primitives/Panel.jsx';
+import panelStyles from '../../src/ui/primitives/Panel.module.css';
+
+describe('Panel', () => {
+  it('renders its children', () => {
+    render(<Panel>peak power</Panel>);
+    expect(screen.getByText('peak power')).toBeTruthy();
+  });
+
+  it('uses the tight padding modifier only when asked', () => {
+    const { rerender } = render(<Panel>x</Panel>);
+    expect(screen.getByText('x').className).not.toContain(panelStyles.tight);
+    rerender(<Panel tight>x</Panel>);
+    expect(screen.getByText('x').className).toContain(panelStyles.tight);
+  });
+
+  it('can render as another element', () => {
+    render(<Panel as="section">x</Panel>);
+    expect(screen.getByText('x').tagName).toBe('SECTION');
+  });
+});
+
+describe('Eyebrow', () => {
+  it('renders its label', () => {
+    render(<Eyebrow>Forced induction</Eyebrow>);
+    expect(screen.getByText('Forced induction')).toBeTruthy();
+  });
+
+  it('renders an icon when given one', () => {
+    const Icon = (props) => <svg data-testid="icon" {...props} />;
+    render(<Eyebrow icon={Icon}>Boost</Eyebrow>);
+    expect(screen.getByTestId('icon')).toBeTruthy();
+  });
+});
+
+describe('Note', () => {
+  it('defaults to the info tone', () => {
+    render(<Note>Speed density indexes VE by RPM and MAP.</Note>);
+    expect(screen.getByRole('note').className).toContain(noteStyles.info);
+  });
+
+  it('applies the warn tone', () => {
+    render(<Note tone="warn">Injector duty is above 90%.</Note>);
+    expect(screen.getByRole('note').className).toContain(noteStyles.warn);
+  });
+
+  it('announces a danger note as an alert', () => {
+    // A danger note reports engine distress; a screen reader should not have to
+    // stumble across it.
+    render(<Note tone="danger">Knock retard active.</Note>);
+    expect(screen.getByRole('alert')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- tests/ui/surfaces.test.jsx`
+Expected: FAIL — cannot resolve `../../src/ui/primitives/Eyebrow.jsx`.
+
+- [ ] **Step 3: Write Panel**
+
+`src/ui/primitives/Panel.module.css`:
+
+```css
+.panel {
+  background: var(--panel2);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 14px;
+}
+
+.tight { padding: 10px 12px; }
+```
+
+`src/ui/primitives/Panel.jsx`:
+
+```jsx
+/** A bordered surface. The app's default container for a group of related controls. */
+
+import React from 'react';
+
+import styles from './Panel.module.css';
+
+/**
+ * @param {object} props
+ * @param {React.ReactNode} props.children
+ * @param {boolean} [props.tight] reduce the padding
+ * @param {string} [props.as] element to render, defaults to a div
+ * @returns {React.ReactElement}
+ */
+export function Panel({ children, tight = false, as: As = 'div', ...rest }) {
+  const className = [styles.panel, tight && styles.tight].filter(Boolean).join(' ');
+  return <As className={className} {...rest}>{children}</As>;
+}
+```
+
+- [ ] **Step 4: Write Eyebrow**
+
+`src/ui/primitives/Eyebrow.module.css`:
+
+```css
+.eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+  font-family: var(--sans);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--acc-ink);
+}
+
+.rule {
+  width: 3px;
+  height: 13px;
+  border-radius: 2px;
+  background: var(--acc);
+}
+```
+
+`src/ui/primitives/Eyebrow.jsx`:
+
+```jsx
+/** Small uppercase section label with an accent rule. Labels a group; never a status. */
+
+import React from 'react';
+
+import styles from './Eyebrow.module.css';
+
+/**
+ * @param {object} props
+ * @param {React.ReactNode} props.children
+ * @param {React.ElementType} [props.icon] optional Lucide icon component
+ * @returns {React.ReactElement}
+ */
+export function Eyebrow({ children, icon: Icon }) {
+  return (
+    <div className={styles.eyebrow}>
+      <span className={styles.rule} />
+      {Icon && <Icon size={13} />}
+      <span>{children}</span>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Write Note**
+
+`src/ui/primitives/Note.module.css`:
+
+```css
+.note {
+  display: flex;
+  gap: 9px;
+  margin: 10px 0;
+  padding: 11px 13px;
+  border: 1px solid;
+  border-radius: 10px;
+  font-family: var(--sans);
+  font-size: 12.5px;
+  line-height: 1.55;
+}
+
+.icon { flex-shrink: 0; margin-top: 1px; }
+
+.info { background: var(--panel2); border-color: var(--line); color: var(--ink-soft); }
+.warn { background: var(--warn-bg); border-color: var(--warn); color: var(--warn-ink); }
+.danger { background: var(--danger-bg); border-color: var(--danger); color: var(--danger-ink); }
+```
+
+`src/ui/primitives/Note.jsx`:
+
+```jsx
+/**
+ * An inline explanatory box.
+ *
+ * `warn` and `danger` carry engine meaning, so they are not emphasis levels — do not
+ * reach for `danger` to make a paragraph louder.
+ */
+
+import { Info } from 'lucide-react';
+import React from 'react';
+
+import styles from './Note.module.css';
+
+/**
+ * @param {object} props
+ * @param {React.ReactNode} props.children
+ * @param {'info'|'warn'|'danger'} [props.tone]
+ * @returns {React.ReactElement}
+ */
+export function Note({ children, tone = 'info' }) {
+  const className = [styles.note, styles[tone] ?? styles.info].join(' ');
+  return (
+    <div className={className} role={tone === 'danger' ? 'alert' : 'note'}>
+      <Info size={15} className={styles.icon} aria-hidden="true" />
+      <div>{children}</div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `npm test -- tests/ui/surfaces.test.jsx`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui/primitives/ tests/ui/surfaces.test.jsx
+git commit -m "Add Panel, Eyebrow and Note primitives
+
+A danger-toned Note announces as role=alert, so engine distress is not
+something a screen-reader user has to stumble across.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd"
+```
+
+---
+
+### Task 7: Readout primitives — StatTile and Bar
+
+Replaces `StatTile` (`EcuLab.jsx:174`) and `HealthBar` (`:183`).
+
+**Files:**
+- Create: `src/ui/primitives/StatTile.jsx`, `src/ui/primitives/StatTile.module.css`
+- Create: `src/ui/primitives/Bar.jsx`, `src/ui/primitives/Bar.module.css`
+- Test: `tests/ui/readouts.test.jsx`
+
+**Interfaces:**
+- Consumes: `statusColor` from `src/ui/theme.js`.
+- Produces:
+  - `StatTile({ label, value, unit, tone })` — `tone` is `'neutral' | 'acc' | 'ok' | 'warn' | 'danger'`, default `'neutral'`.
+  - `Bar({ label, value, max })` — `value` and `max` are numbers; `max` defaults to `100`. Colour comes from `statusColor(percent)`. Renders `role="meter"` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/ui/readouts.test.jsx`:
+
+```jsx
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Bar } from '../../src/ui/primitives/Bar.jsx';
+import { StatTile } from '../../src/ui/primitives/StatTile.jsx';
+import tileStyles from '../../src/ui/primitives/StatTile.module.css';
+
+describe('StatTile', () => {
+  it('renders label, value and unit', () => {
+    render(<StatTile label="PEAK HP" value={412} unit="whp" />);
+    expect(screen.getByText('PEAK HP')).toBeTruthy();
+    expect(screen.getByText('412')).toBeTruthy();
+    expect(screen.getByText('whp')).toBeTruthy();
+  });
+
+  it('omits the unit element entirely when no unit is given', () => {
+    const { container } = render(<StatTile label="PULLS" value={7} />);
+    expect(container.querySelector(`.${tileStyles.unit}`)).toBeNull();
+  });
+
+  it('applies the tone it is given', () => {
+    const { container } = render(<StatTile label="KNOCK" value="0.4" tone="warn" />);
+    expect(container.querySelector(`.${tileStyles.warn}`)).toBeTruthy();
+  });
+});
+
+describe('Bar', () => {
+  it('exposes itself as a meter with its current value', () => {
+    render(<Bar label="Pistons" value={86} />);
+    const meter = screen.getByRole('meter');
+    expect(meter.getAttribute('aria-valuenow')).toBe('86');
+    expect(meter.getAttribute('aria-valuemin')).toBe('0');
+    expect(meter.getAttribute('aria-valuemax')).toBe('100');
+  });
+
+  it('names the meter after its label', () => {
+    render(<Bar label="Bearings" value={71} />);
+    expect(screen.getByRole('meter', { name: 'Bearings' })).toBeTruthy();
+  });
+
+  it('scales the fill to the percentage of max', () => {
+    const { container } = render(<Bar label="Duty" value={40} max={80} />);
+    expect(container.querySelector('[data-fill]').style.width).toBe('50%');
+  });
+
+  it('clamps a value above max instead of overflowing the track', () => {
+    const { container } = render(<Bar label="Duty" value={150} max={100} />);
+    expect(container.querySelector('[data-fill]').style.width).toBe('100%');
+  });
+
+  it('clamps a negative value to zero', () => {
+    const { container } = render(<Bar label="Duty" value={-20} max={100} />);
+    expect(container.querySelector('[data-fill]').style.width).toBe('0%');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- tests/ui/readouts.test.jsx`
+Expected: FAIL — cannot resolve `../../src/ui/primitives/Bar.jsx`.
+
+- [ ] **Step 3: Write StatTile**
+
+`src/ui/primitives/StatTile.module.css`:
+
+```css
+.tile {
+  flex: 1;
+  min-width: 74px;
+  padding: 9px 10px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  font-family: var(--sans);
+}
+
+.label {
+  font-size: 8.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--ink3);
+}
+
+.value {
+  margin-top: 3px;
+  font-family: var(--mono);
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--ink);
+}
+
+.unit {
+  margin-left: 2px;
+  font-size: 9.5px;
+  font-weight: 600;
+  color: var(--ink2);
+}
+
+.acc .value { color: var(--acc); }
+.ok .value { color: var(--ok); }
+.warn .value { color: var(--warn); }
+.danger .value { color: var(--danger); }
+```
+
+`src/ui/primitives/StatTile.jsx`:
+
+```jsx
+/** A single labelled number. The app's unit of measured output. */
+
+import React from 'react';
+
+import styles from './StatTile.module.css';
+
+/**
+ * @param {object} props
+ * @param {string} props.label
+ * @param {string|number} props.value
+ * @param {string} [props.unit]
+ * @param {'neutral'|'acc'|'ok'|'warn'|'danger'} [props.tone]
+ * @returns {React.ReactElement}
+ */
+export function StatTile({ label, value, unit, tone = 'neutral' }) {
+  const className = [styles.tile, styles[tone]].filter(Boolean).join(' ');
+  return (
+    <div className={className}>
+      <div className={styles.label}>{label}</div>
+      <div className={styles.value}>
+        {value}
+        {unit && <span className={styles.unit}>{unit}</span>}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Write Bar**
+
+`src/ui/primitives/Bar.module.css`:
+
+```css
+.wrap { font-family: var(--sans); }
+
+.label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 9.5px;
+  color: var(--ink2);
+  margin-bottom: 4px;
+}
+
+.pct { font-family: var(--mono); font-weight: 700; }
+
+.track {
+  height: 5px;
+  border-radius: 3px;
+  background: var(--panel3);
+  overflow: hidden;
+}
+
+.fill { height: 100%; transition: width 0.4s ease; }
+```
+
+`src/ui/primitives/Bar.jsx`:
+
+```jsx
+/**
+ * A horizontal meter for a 0-max quantity: component health, injector duty.
+ *
+ * The fill colour comes from `statusColor`, so it is a STATUS, never decoration.
+ * Do not use this for a value that has no good/bad reading.
+ */
+
+import React from 'react';
+
+import { clamp } from '../../sim/index.js';
+import { statusColor } from '../theme.js';
+
+import styles from './Bar.module.css';
+
+/**
+ * @param {object} props
+ * @param {string} props.label
+ * @param {number} props.value
+ * @param {number} [props.max]
+ * @returns {React.ReactElement}
+ */
+export function Bar({ label, value, max = 100 }) {
+  const pct = clamp((value / max) * 100, 0, 100);
+  return (
+    <div className={styles.wrap}>
+      <div className={styles.label}>
+        <span>{label}</span>
+        <span className={styles.pct} style={{ color: statusColor(pct) }}>
+          {Math.round(pct)}%
+        </span>
+      </div>
+      <div
+        className={styles.track}
+        role="meter"
+        aria-label={label}
+        aria-valuenow={value}
+        aria-valuemin={0}
+        aria-valuemax={max}
+      >
+        <div
+          data-fill=""
+          className={styles.fill}
+          style={{ width: `${pct}%`, background: statusColor(pct) }}
+        />
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm test -- tests/ui/readouts.test.jsx`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/primitives/ tests/ui/readouts.test.jsx
+git commit -m "Add StatTile and Bar readout primitives
+
+Bar exposes role=meter with real aria value attributes and clamps out-of-range
+input rather than overflowing its track.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd"
+```
+
+---
+
+### Task 8: Control primitives — Seg, Select, Toggle
+
+Replaces `Seg` (`EcuLab.jsx:83`), `GroupedSelect` (`:125`) and `ToggleRow` (`:160`).
+
+**Files:**
+- Create: `src/ui/primitives/Seg.jsx`, `src/ui/primitives/Seg.module.css`
+- Create: `src/ui/primitives/Select.jsx`, `src/ui/primitives/Select.module.css`
+- Create: `src/ui/primitives/Toggle.jsx`, `src/ui/primitives/Toggle.module.css`
+- Test: `tests/ui/controls.test.jsx`
+
+**Interfaces:**
+- Consumes: `Button` is NOT used here — segments need their own pressed semantics.
+- Produces:
+  - `Seg({ options, value, onChange, label })` — `options` is `Array<{id: string, label: string, icon?: React.ElementType}>`. Renders `role="tablist"`-free plain buttons carrying `aria-pressed`.
+  - `Select({ groups, extra, value, onChange, label })` — `groups` is `Array<{label: string, options: Array<{value: string, label: string}>}>`, `extra` is a flat `Array<{value, label}>` appended after the groups.
+  - `Toggle({ label, sub, checked, onChange })` — renders a `role="switch"` button with `aria-checked`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/ui/controls.test.jsx`:
+
+```jsx
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Seg } from '../../src/ui/primitives/Seg.jsx';
+import { Select } from '../../src/ui/primitives/Select.jsx';
+import { Toggle } from '../../src/ui/primitives/Toggle.jsx';
+
+const SEG_OPTIONS = [
+  { id: 've', label: 'AIR' },
+  { id: 'timing', label: 'SPARK' },
+  { id: 'afr', label: 'FUEL' },
+];
+
+describe('Seg', () => {
+  it('renders one button per option', () => {
+    render(<Seg label="Table" options={SEG_OPTIONS} value="ve" onChange={() => {}} />);
+    expect(screen.getAllByRole('button')).toHaveLength(3);
+  });
+
+  it('marks only the selected option as pressed', () => {
+    render(<Seg label="Table" options={SEG_OPTIONS} value="timing" onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: 'SPARK' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('button', { name: 'AIR' }).getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('reports the id of the option clicked', () => {
+    const onChange = vi.fn();
+    render(<Seg label="Table" options={SEG_OPTIONS} value="ve" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'FUEL' }));
+    expect(onChange).toHaveBeenCalledWith('afr');
+  });
+
+  it('names the group for assistive technology', () => {
+    render(<Seg label="Table" options={SEG_OPTIONS} value="ve" onChange={() => {}} />);
+    expect(screen.getByRole('group', { name: 'Table' })).toBeTruthy();
+  });
+});
+
+describe('Select', () => {
+  const GROUPS = [
+    { label: 'BMW', options: [{ value: 'n54', label: 'N54 3.0' }, { value: 'b58', label: 'B58 3.0' }] },
+    { label: 'Nissan', options: [{ value: 'vq35', label: 'VQ35DE' }] },
+  ];
+
+  it('renders every option inside its group', () => {
+    render(<Select label="Engine" groups={GROUPS} value="n54" onChange={() => {}} />);
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+  });
+
+  it('appends the extra options after the groups', () => {
+    render(
+      <Select
+        label="Engine"
+        groups={GROUPS}
+        extra={[{ value: 'custom', label: 'Custom build' }]}
+        value="n54"
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getAllByRole('option')).toHaveLength(4);
+    expect(screen.getByRole('option', { name: 'Custom build' })).toBeTruthy();
+  });
+
+  it('reports the selected value', () => {
+    const onChange = vi.fn();
+    render(<Select label="Engine" groups={GROUPS} value="n54" onChange={onChange} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'b58' } });
+    expect(onChange).toHaveBeenCalledWith('b58');
+  });
+
+  it('is labelled', () => {
+    render(<Select label="Engine" groups={GROUPS} value="n54" onChange={() => {}} />);
+    expect(screen.getByRole('combobox', { name: 'Engine' })).toBeTruthy();
+  });
+});
+
+describe('Toggle', () => {
+  it('exposes itself as a switch reflecting its state', () => {
+    render(<Toggle label="Intake" checked onChange={() => {}} />);
+    expect(screen.getByRole('switch', { name: /Intake/ }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('reports the flipped value when clicked', () => {
+    const onChange = vi.fn();
+    render(<Toggle label="Intake" checked={false} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('switch'));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('renders its sub-label', () => {
+    render(<Toggle label="Intake" sub="+4% VE above 4000 RPM" checked onChange={() => {}} />);
+    expect(screen.getByText('+4% VE above 4000 RPM')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- tests/ui/controls.test.jsx`
+Expected: FAIL — cannot resolve `../../src/ui/primitives/Seg.jsx`.
+
+- [ ] **Step 3: Write Seg**
+
+`src/ui/primitives/Seg.module.css`:
+
+```css
+.seg {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 3px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+}
+
+.item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 7px 13px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ink3);
+  font-family: var(--sans);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  transition: background-color 0.14s ease, color 0.14s ease;
+}
+
+.item:hover { color: var(--ink2); }
+.item:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; }
+
+.item[aria-pressed='true'] {
+  background: var(--acc-bg);
+  color: var(--acc-ink);
+  box-shadow: inset 0 0 0 1px var(--acc);
+}
+```
+
+`src/ui/primitives/Seg.jsx`:
+
+```jsx
+/**
+ * A segmented control: pick exactly one of a small set.
+ *
+ * Plain buttons carrying `aria-pressed` rather than a radio group, because these
+ * switch a view rather than submit a value.
+ */
+
+import React from 'react';
+
+import styles from './Seg.module.css';
+
+/**
+ * @param {object} props
+ * @param {string} props.label accessible name for the group
+ * @param {Array<{id: string, label: string, icon?: React.ElementType}>} props.options
+ * @param {string} props.value id of the selected option
+ * @param {(id: string) => void} props.onChange
+ * @returns {React.ReactElement}
+ */
+export function Seg({ label, options, value, onChange }) {
+  return (
+    <div className={styles.seg} role="group" aria-label={label}>
+      {options.map(({ id, label: text, icon: Icon }) => (
+        <button
+          key={id}
+          type="button"
+          className={styles.item}
+          aria-pressed={id === value}
+          onClick={() => onChange(id)}
+        >
+          {Icon && <Icon size={13} aria-hidden="true" />}
+          {text}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Write Select**
+
+`src/ui/primitives/Select.module.css`:
+
+```css
+.wrap { position: relative; display: inline-block; min-width: 200px; }
+
+.select {
+  width: 100%;
+  padding: 11px 34px 11px 13px;
+  appearance: none;
+  -webkit-appearance: none;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--panel2);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.select:hover { border-color: var(--line-hi); }
+.select:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; }
+
+.chevron {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--ink2);
+  pointer-events: none;
+}
+```
+
+`src/ui/primitives/Select.jsx`:
+
+```jsx
+/**
+ * A grouped dropdown built on a real `<select>`.
+ *
+ * Deliberately native: keyboard navigation, type-ahead and screen-reader semantics
+ * come free, and on a phone it opens the platform picker. Only the chevron is ours.
+ */
+
+import { ChevronDown } from 'lucide-react';
+import React from 'react';
+
+import styles from './Select.module.css';
+
+/**
+ * @param {object} props
+ * @param {string} props.label accessible name
+ * @param {Array<{label: string, options: Array<{value: string, label: string}>}>} props.groups
+ * @param {Array<{value: string, label: string}>} [props.extra] ungrouped options, appended last
+ * @param {string} props.value
+ * @param {(value: string) => void} props.onChange
+ * @returns {React.ReactElement}
+ */
+export function Select({ label, groups, extra = [], value, onChange }) {
+  return (
+    <div className={styles.wrap}>
+      <select
+        className={styles.select}
+        aria-label={label}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        {groups.map((g) => (
+          <optgroup key={g.label} label={g.label}>
+            {g.options.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </optgroup>
+        ))}
+        {extra.map((o) => (
+          <option key={o.value} value={o.value}>{o.label}</option>
+        ))}
+      </select>
+      <ChevronDown size={16} className={styles.chevron} aria-hidden="true" />
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Write Toggle**
+
+`src/ui/primitives/Toggle.module.css`:
+
+```css
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 11px 13px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--panel2);
+  color: inherit;
+  font-family: var(--sans);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.14s ease;
+}
+
+.row:hover { border-color: var(--line-hi); }
+.row:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; }
+.row[aria-checked='true'] { border-color: var(--acc); }
+
+.label { font-size: 13px; font-weight: 700; color: var(--ink); }
+.sub { margin-top: 2px; font-size: 11px; color: var(--ink2); }
+
+.track {
+  flex-shrink: 0;
+  width: 38px;
+  height: 22px;
+  padding: 2px;
+  border-radius: 11px;
+  background: var(--panel3);
+  transition: background-color 0.16s ease;
+}
+
+.row[aria-checked='true'] .track { background: var(--acc); }
+
+.knob {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--ink2);
+  transition: transform 0.16s ease, background-color 0.16s ease;
+}
+
+.row[aria-checked='true'] .knob {
+  transform: translateX(16px);
+  background: var(--acc-on);
+}
+```
+
+`src/ui/primitives/Toggle.jsx`:
+
+```jsx
+/** An on/off row for a single hardware option. */
+
+import React from 'react';
+
+import styles from './Toggle.module.css';
+
+/**
+ * @param {object} props
+ * @param {string} props.label
+ * @param {string} [props.sub] one line on what the option physically does
+ * @param {boolean} props.checked
+ * @param {(next: boolean) => void} props.onChange
+ * @returns {React.ReactElement}
+ */
+export function Toggle({ label, sub, checked, onChange }) {
+  return (
+    <button
+      type="button"
+      className={styles.row}
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+    >
+      <span>
+        <span className={styles.label}>{label}</span>
+        {sub && <span className={styles.sub} style={{ display: 'block' }}>{sub}</span>}
+      </span>
+      <span className={styles.track}>
+        <span className={styles.knob} />
+      </span>
+    </button>
+  );
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `npm test -- tests/ui/controls.test.jsx`
+Expected: PASS, 12 tests.
+
+Note: `<button role="switch">` gets its accessible name from its text content, so
+`getByRole('switch', { name: /Intake/ })` matches on the label — the regex is there
+because the sub-label joins the accessible name when present.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui/primitives/ tests/ui/controls.test.jsx
+git commit -m "Add Seg, Select and Toggle control primitives
+
+Select stays a native <select> so keyboard navigation, type-ahead and the
+platform picker on mobile come for free. Toggle is a real role=switch.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd"
+```
+
+---
+
+### Task 9: Convert the entry screens
+
+Proves the primitives against real screens. `StartScreen` (`EcuLab.jsx:519-539`) and
+`TutorialScreen` (`:488-517`) are self-contained, are the first thing a user sees, and
+touch none of the four main tabs — so this validates the system without pre-empting the
+IA work in PR 3.
+
+**Files:**
+- Create: `src/ui/screens/StartScreen.jsx`, `src/ui/screens/StartScreen.module.css`
+- Create: `src/ui/screens/TutorialScreen.jsx`, `src/ui/screens/TutorialScreen.module.css`
+- Modify: `src/ui/EcuLab.jsx` — delete both inline components, import the new ones
+- Modify: `tsconfig.json` — add `src/ui/screens` to `include`
+- Test: `tests/ui/screens.test.jsx`
+
+**Interfaces:**
+- Consumes: `Button` from Task 5; `TUTORIAL_STEPS` and `DialMark` stay in `EcuLab.jsx` and are passed in as props so this task does not have to move them.
+- Produces:
+  - `StartScreen({ onStart, onTutorial, version, dial })` — `dial` is a rendered node.
+  - `TutorialScreen({ steps, onDone })` — `steps` is `Array<{title: string, body: string}>`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/ui/screens.test.jsx`:
+
+```jsx
+// @vitest-environment jsdom
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { StartScreen } from '../../src/ui/screens/StartScreen.jsx';
+import { TutorialScreen } from '../../src/ui/screens/TutorialScreen.jsx';
+
+const STEPS = [
+  { title: 'This is an air pump', body: 'Everything starts with airflow.' },
+  { title: 'Design it on BUILD', body: 'None of it is cosmetic.' },
+];
+
+describe('StartScreen', () => {
+  it('starts the app', () => {
+    const onStart = vi.fn();
+    render(<StartScreen onStart={onStart} onTutorial={() => {}} version="v1.4.0" />);
+    fireEvent.click(screen.getByRole('button', { name: 'START' }));
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the tutorial', () => {
+    const onTutorial = vi.fn();
+    render(<StartScreen onStart={() => {}} onTutorial={onTutorial} version="v1.4.0" />);
+    fireEvent.click(screen.getByRole('button', { name: 'TUTORIAL' }));
+    expect(onTutorial).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the build version', () => {
+    render(<StartScreen onStart={() => {}} onTutorial={() => {}} version="v1.4.0" />);
+    expect(screen.getByText('v1.4.0')).toBeTruthy();
+  });
+});
+
+describe('TutorialScreen', () => {
+  it('opens on the first step', () => {
+    render(<TutorialScreen steps={STEPS} onDone={() => {}} />);
+    expect(screen.getByText('This is an air pump')).toBeTruthy();
+  });
+
+  it('advances to the next step', () => {
+    render(<TutorialScreen steps={STEPS} onDone={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: 'NEXT' }));
+    expect(screen.getByText('Design it on BUILD')).toBeTruthy();
+  });
+
+  it('offers no BACK on the first step', () => {
+    render(<TutorialScreen steps={STEPS} onDone={() => {}} />);
+    expect(screen.queryByRole('button', { name: 'BACK' })).toBeNull();
+  });
+
+  it('goes back', () => {
+    render(<TutorialScreen steps={STEPS} onDone={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: 'NEXT' }));
+    fireEvent.click(screen.getByRole('button', { name: 'BACK' }));
+    expect(screen.getByText('This is an air pump')).toBeTruthy();
+  });
+
+  it('finishes from the last step', () => {
+    const onDone = vi.fn();
+    render(<TutorialScreen steps={STEPS} onDone={onDone} />);
+    fireEvent.click(screen.getByRole('button', { name: 'NEXT' }));
+    fireEvent.click(screen.getByRole('button', { name: 'START TUNING' }));
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips out at any point', () => {
+    const onDone = vi.fn();
+    render(<TutorialScreen steps={STEPS} onDone={onDone} />);
+    fireEvent.click(screen.getByRole('button', { name: 'SKIP' }));
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports progress through the steps', () => {
+    render(<TutorialScreen steps={STEPS} onDone={() => {}} />);
+    expect(screen.getByText('TUTORIAL · 1/2')).toBeTruthy();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm test -- tests/ui/screens.test.jsx`
+Expected: FAIL — cannot resolve `../../src/ui/screens/StartScreen.jsx`.
+
+- [ ] **Step 3: Write StartScreen**
+
+`src/ui/screens/StartScreen.module.css`:
+
+```css
+.screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100dvh;
+  padding: 24px;
+  position: relative;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--sans);
+  text-align: center;
+}
+
+.glow {
+  position: absolute;
+  top: -15%;
+  left: 50%;
+  width: 420px;
+  height: 420px;
+  transform: translateX(-50%);
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--acc-glow) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.inner { position: relative; display: flex; flex-direction: column; align-items: center; }
+
+.dial { margin-bottom: 22px; }
+
+.eyebrow {
+  margin-bottom: 7px;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.28em;
+  color: var(--acc-ink);
+}
+
+.title {
+  max-width: 22ch;
+  margin-bottom: 15px;
+  font-size: 25px;
+  font-weight: 800;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+}
+
+.blurb {
+  max-width: 42ch;
+  margin-bottom: 34px;
+  font-size: 13.5px;
+  line-height: 1.65;
+  color: var(--ink2);
+}
+
+.actions { display: flex; flex-direction: column; gap: 12px; width: 100%; max-width: 300px; }
+
+.version { margin-top: 18px; font-family: var(--mono); font-size: 10.5px; color: var(--ink3); }
+
+/* From the small-tablet breakpoint up there is room to sit the two actions side by
+   side, which is also where a full-width button starts looking wrong. */
+@media (min-width: 560px) {
+  .title { font-size: 34px; }
+  .actions { flex-direction: row; max-width: none; justify-content: center; }
+}
+```
+
+`src/ui/screens/StartScreen.jsx`:
+
+```jsx
+/** The first screen: what this is, and the two ways in. */
+
+import React from 'react';
+
+import { Button } from '../primitives/Button.jsx';
+
+import styles from './StartScreen.module.css';
+
+/**
+ * @param {object} props
+ * @param {() => void} props.onStart
+ * @param {() => void} props.onTutorial
+ * @param {string} props.version
+ * @param {React.ReactNode} [props.dial] decorative dial mark
+ * @returns {React.ReactElement}
+ */
+export function StartScreen({ onStart, onTutorial, version, dial }) {
+  return (
+    <div className={styles.screen}>
+      <div className={styles.glow} aria-hidden="true" />
+      <div className={styles.inner}>
+        {dial && <div className={styles.dial}>{dial}</div>}
+        <div className={styles.eyebrow}>CARIBOU TUNING</div>
+        <h1 className={styles.title}>Engine Management Sandbox</h1>
+        <p className={styles.blurb}>
+          Design an engine. Tune it. Log it. Improve it. A free-tune sandbox built to
+          teach real engine management, not just move sliders.
+        </p>
+        <div className={styles.actions}>
+          <Button size="lg" onClick={onStart}>START</Button>
+          <Button size="lg" variant="ghost" onClick={onTutorial}>TUTORIAL</Button>
+        </div>
+        <div className={styles.version}>{version}</div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Write TutorialScreen**
+
+`src/ui/screens/TutorialScreen.module.css`:
+
+```css
+.screen {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--sans);
+}
+
+.bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+}
+
+.count {
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  color: var(--acc-ink);
+}
+
+.skip {
+  border: none;
+  background: none;
+  color: var(--ink3);
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.skip:hover { color: var(--ink2); }
+.skip:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; }
+
+.body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 0 24px;
+}
+
+.inner { width: 100%; max-width: 60ch; }
+
+.title { margin: 0 0 13px; font-size: 21px; font-weight: 800; letter-spacing: -0.01em; }
+.text { margin: 0; font-size: 14.5px; line-height: 1.7; color: var(--ink-soft); }
+
+.dots { display: flex; gap: 6px; justify-content: center; padding-bottom: 18px; }
+
+.dot { width: 6px; height: 6px; border-radius: 3px; background: var(--line); transition: width 0.2s ease; }
+.dotOn { width: 20px; background: var(--acc); }
+
+.actions {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  padding: 0 16px calc(16px + env(safe-area-inset-bottom));
+}
+
+@media (min-width: 560px) {
+  .title { font-size: 27px; }
+}
+```
+
+`src/ui/screens/TutorialScreen.jsx`:
+
+```jsx
+/** The eight-card walkthrough, shown before the first run and from the header. */
+
+import React, { useState } from 'react';
+
+import { Button } from '../primitives/Button.jsx';
+
+import styles from './TutorialScreen.module.css';
+
+/**
+ * @param {object} props
+ * @param {Array<{title: string, body: string}>} props.steps
+ * @param {() => void} props.onDone
+ * @returns {React.ReactElement}
+ */
+export function TutorialScreen({ steps, onDone }) {
+  const [step, setStep] = useState(0);
+  const current = steps[step];
+  const last = step === steps.length - 1;
+
+  return (
+    <div className={styles.screen}>
+      <div className={styles.bar}>
+        <div className={styles.count}>TUTORIAL · {step + 1}/{steps.length}</div>
+        <button type="button" className={styles.skip} onClick={onDone}>SKIP</button>
+      </div>
+
+      <div className={styles.body}>
+        <div className={styles.inner}>
+          <h2 className={styles.title}>{current.title}</h2>
+          <p className={styles.text}>{current.body}</p>
+        </div>
+      </div>
+
+      <div className={styles.dots} aria-hidden="true">
+        {steps.map((s, i) => (
+          <span
+            key={s.title}
+            className={[styles.dot, i === step && styles.dotOn].filter(Boolean).join(' ')}
+          />
+        ))}
+      </div>
+
+      <div className={styles.actions}>
+        {step > 0 && (
+          <Button size="lg" variant="ghost" onClick={() => setStep((v) => v - 1)}>BACK</Button>
+        )}
+        <Button size="lg" onClick={() => (last ? onDone() : setStep((v) => v + 1))}>
+          {last ? 'START TUNING' : 'NEXT'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm test -- tests/ui/screens.test.jsx`
+Expected: PASS, 11 tests.
+
+- [ ] **Step 6: Wire them into EcuLab.jsx**
+
+Delete the `TutorialScreen` function (`EcuLab.jsx:488-517`) and the `StartScreen`
+function (`:519-539`). Keep `TUTORIAL_STEPS` and `DialMark` where they are. Add to the
+imports at the top of the file:
+
+```jsx
+import { StartScreen } from './screens/StartScreen.jsx';
+import { TutorialScreen } from './screens/TutorialScreen.jsx';
+```
+
+Then replace the two dispatch lines (`:1164-1165`) with:
+
+```jsx
+  if (appView === 'start') {
+    return (
+      <StartScreen
+        onStart={() => { setAppView('app'); setTab('build'); }}
+        onTutorial={() => setAppView('tutorial')}
+        version={BUILD_VERSION}
+        dial={<DialMark size={92} pct={0.62} />}
+      />
+    );
+  }
+  if (appView === 'tutorial') {
+    return (
+      <TutorialScreen
+        steps={TUTORIAL_STEPS}
+        onDone={() => { setAppView('app'); setTab('build'); setJourneyStep(0); }}
+      />
+    );
+  }
+```
+
+- [ ] **Step 7: Put the screens directory under the typechecker**
+
+In `tsconfig.json`, add `"src/ui/screens"` to `include`, directly after
+`"src/ui/primitives"`.
+
+- [ ] **Step 8: Run the full suite and the whole gate**
+
+```bash
+npm test
+npm run lint
+npm run typecheck
+npm run build
+```
+
+Expected: all four clean. `npm run lint` will flag `useState` as unused in
+`EcuLab.jsx` only if no other code uses it — it does, so no change is needed there.
+
+- [ ] **Step 9: Look at both screens**
+
+Run: `npm run dev`.
+Expected: the start screen shows two azure actions **side by side above 560px wide** and
+stacked below it — the first responsive behaviour in the app. The tutorial reads at a
+comfortable measure instead of spanning the window.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/ui/screens/ src/ui/EcuLab.jsx tsconfig.json tests/ui/screens.test.jsx
+git commit -m "Rebuild the start and tutorial screens on the primitives
+
+First screens off the design system, and the app's first responsive layout: the
+entry actions sit side by side above 560px and stack below it.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd"
+```
+
+---
+
+### Task 10: Re-sync, verify, and open the PR
+
+**Files:**
+- Modify: `README.md` if it names the old palette (check; do not assume)
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: an open pull request awaiting human review.
+
+- [ ] **Step 1: Check the docs for stale colour claims**
+
+```bash
+grep -rn "amber\|orange\|#ff6a2c" README.md CONTRIBUTING.md docs/ --include="*.md" | grep -v "docs/superpowers"
+```
+
+If the README describes the palette, update the wording to match. If nothing matches,
+move on — do not invent documentation changes.
+
+- [ ] **Step 2: Re-sync with the base branch**
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+If anything conflicts, resolve it deliberately. If `tests/fixtures/` conflicts,
+regenerate rather than picking a side — but nothing in this plan touches fixtures, so a
+conflict there means something is wrong.
+
+- [ ] **Step 3: Re-run the entire gate after the rebase**
+
+A rebase produces a new tree; the pre-rebase green says nothing about it.
+
+```bash
+node --version    # must print v20.x or v22.x
+npm test
+npm run lint
+npm run typecheck
+npm run build
+```
+
+Expected: all clean, `fingerprint.test.js` included and unmodified.
+
+- [ ] **Step 4: Confirm the fingerprint baseline was never touched**
+
+```bash
+git diff origin/main --stat -- tests/fixtures/
+```
+
+Expected: **no output.** Any change here means the physics moved and the PR must not
+be opened until it is understood.
+
+- [ ] **Step 5: Confirm no production dependency changed**
+
+```bash
+git diff origin/main -- package.json | grep -A6 '"dependencies"'
+```
+
+Expected: no changes inside the `dependencies` block.
+
+- [ ] **Step 6: Push and open the PR**
+
+```bash
+git push -u origin feat/6-ui-design-system
+gh pr create --title "UI overhaul PR 1: design system and azure palette" --body "$(cat <<'EOF'
+First of seven PRs against #6. Establishes the token layer and primitives
+library the rest of the overhaul is built on — and recolours the app on the way
+past.
+
+## What changed
+
+- **`src/ui/tokens.js` + `tokens.css`** — the palette, defined once. A contract
+  test proves the two files cannot drift, and pins the rule the system rests on:
+  the accent is never a status colour.
+- **`theme.js` re-pointed at the tokens** — recolours all 500+ existing `T.*`
+  call sites at once, from orange to azure.
+- **58 hex literals and 9 `rgba()` literals removed from `EcuLab.jsx`**. That
+  file had been bypassing `theme.js` entirely, despite `theme.js` always saying
+  not to. A guard test now enforces it.
+- **Primitives** — Button, Panel, Eyebrow, Note, StatTile, Bar, Seg, Select,
+  Toggle. Each with a co-located CSS Module and component tests.
+- **Start and tutorial screens rebuilt** on the primitives, including the app's
+  first responsive breakpoint.
+
+## Why the palette changed
+
+The old accent `#ff6a2c` appeared 84 times — wordmark, active nav, focus ring,
+primary buttons, selected cells, *and* genuine warnings. An app whose purpose is
+reporting engine distress had spent its distress colour on chrome, leaving a real
+warning nothing to escalate to. Azure sits far from every status hue, and its
+blue-black base makes the red alarm state read harder than a neutral grey ground
+would.
+
+Design doc: `docs/superpowers/specs/2026-08-19-ui-overhaul-design.md`
+
+## What did NOT change
+
+No physics. `src/sim/` is untouched and the behavioural fingerprint is
+byte-identical — which is the point: a UI refactor that moves the fingerprint has
+broken something, and the baseline was never regenerated.
+
+No production dependencies. `@testing-library/react` and `jsdom` are devDependencies.
+
+## Verification
+
+`npm test`, `npm run lint`, `npm run typecheck` and `npm run build` all clean on
+Node 22, run again after rebasing onto current `main`.
+
+Part of #6.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd
+EOF
+)"
+```
+
+- [ ] **Step 7: Check no auto-merge is queued**
+
+```bash
+gh pr view --json autoMergeRequest
+```
+
+Expected: `{"autoMergeRequest":null}`. If it is non-null, run
+`gh pr merge <N> --disable-auto`. **Do not merge this PR.** It ends open, awaiting
+human review.
+
+---
+
+## Notes for the implementer
+
+**The fingerprint is the whole safety net.** Nothing in this plan touches `src/sim/`,
+so `tests/fingerprint.test.js` must stay green from the first commit to the last. If it
+ever fails, stop and find out why — the documented cure for a failing fingerprint is
+regenerating the baseline, and doing that here would replace the project's regression
+gate with a broken refactor's answer.
+
+**Check your Node version before believing a failure.** `node --version` must be 20 or
+22. On Node 26 the fingerprint fails on an untouched checkout, which looks exactly like
+a physics break and is not one.
+
+**Task 3 is the one to slow down on.** It is the only task that edits `EcuLab.jsx`
+broadly, and its `sed` renames are order-sensitive: `T.amberInk` and `T.amberBg` must be
+rewritten before `T.amber`, or the shorter pattern consumes the longer ones and produces
+`T.accInk` → `T.accInkInk`-style damage. Run the guard test and read the diff.
+
+**Do not add a barrel file** (`primitives/index.js`). Direct imports keep the dependency
+graph obvious and stop the whole library being pulled in for one Button.

--- a/docs/superpowers/specs/2026-08-19-ui-overhaul-design.md
+++ b/docs/superpowers/specs/2026-08-19-ui-overhaul-design.md
@@ -1,0 +1,179 @@
+# UI Overhaul — design
+
+Issue: [#6](https://github.com/DNiev/ecu-lab/issues/6)
+Date: 2026-08-19
+Status: approved
+
+## Problem
+
+ECU Lab's interface has three defects that reinforce each other.
+
+**It has no styling layer.** The entire UI is one 2365-line component, `src/ui/EcuLab.jsx`,
+carrying 439 inline style objects. Inline styles cannot express a media query, a `:hover`,
+or a `:focus-visible`. This is not a stylistic complaint — it is why the app has **zero
+breakpoints**. Every layout decision that depends on viewport width is currently
+inexpressible, so none were made.
+
+**It is a phone layout served to desktop.** The shell is a `100dvh` flex column with a
+bottom tab bar. On a monitor, panels and buttons stretch to the full window width because
+nothing constrains them. The eight `minWidth`/`maxWidth` hits in the file are all either
+`minWidth: '100%'` on a scroll container or `maxWidth: 300` on the start screen.
+
+**Its accent colour is its alarm colour.** `T.amber` (`#ff6a2c`) appears 84 times and
+`T.red` 22 times. The wordmark, the active nav tab, the focus ring, primary buttons,
+selected table cells and genuine warnings are all the same hot orange-red. An app whose
+purpose is reporting engine distress has spent its distress colour on chrome, leaving
+nothing to escalate to.
+
+Compounding all three: four tabs carry roughly 300 lines of JSX each, with collapsing
+accordions stacked inside them.
+
+### What the issue got right and wrong
+
+Issue #6 lists three bullets. Verified against the code:
+
+| Bullet | Verdict |
+|---|---|
+| "Make engine selection a dropdown" | **Already done.** `GroupedSelect` at `EcuLab.jsx:125`, used at `:1477` with optgroups. |
+| "Allow users to select multiple cells on tuning tables" | **Valid.** `TuningGrid` (`:317`) holds one `{type:'cell'\|'row'\|'col'}`. No range selection. |
+| "General modernization of look" | **Valid, underspecified.** Expanded by this document. |
+
+## Goals
+
+- Desktop-first and genuinely responsive, degrading to phone.
+- A colour system where the accent has one job and status colours are reserved.
+- More pages, each doing less.
+- A code structure where the next UI change is cheap.
+- Twelve selected features (see Roadmap).
+
+## Non-goals
+
+- **No physics changes.** `src/sim/` behaviour is frozen for this work. See Verification.
+- No light theme. This is an instrument; it is dark.
+- No new runtime dependencies. The only addition is `@testing-library/react` as a devDependency.
+
+## Visual direction
+
+**Accent: Azure `#4C9EFF`** on a blue-black base. Chosen over cyan (the first preference)
+because a blue-black ground makes the red alarm state pop harder than a neutral grey ground
+does — which matters in an app whose job is telling you when something is wrong.
+
+```
+--bg      #0a0d14     --ink     #e9eef8     --acc     #4c9eff
+--panel   #131824     --ink2    #8792a8     --accInk  #8fc2ff
+--panel2  #1a2130     --ink3    #5c6880     --accOn   #04162e
+--panel3  #212a3c     --line    #262f42     --lineHi  #33405a
+
+--ok #35e08a    --warn #ffb020    --danger #ff4d4d
+```
+
+**The rule that makes it work: the accent is never a status, and a status is never
+decoration.** Azure means "this is the action" or "this is the live value". Green, amber
+and red mean engine state and nothing else. The table heat-map gets its own cool ramp so a
+hot cell never competes visually with a real warning.
+
+That discipline is most of the fix. The specific hue is the smaller half.
+
+## Layout
+
+A blend of three directions, each answering a different question:
+
+- **Shell** — icon sidebar for the five sections, plus a slim always-visible status strip
+  (engine, boost, octane, health, last pull). Engine state never leaves the screen.
+- **Decomposition** — five sections split into roughly fourteen small pages. TUNE becomes
+  Airflow / Spark / Fuel / Injectors / Sensors; BUILD becomes Engine / Induction / Fuel
+  System / Exhaust. Content is width-capped so nothing spans a 27-inch monitor.
+- **Contextual panel, TUNE screens only** — a right-hand panel that reacts to the cells you
+  just edited and states what the change implies.
+
+The contextual panel must **report the gap, never close it** — `CONTRIBUTING.md` treats
+that as non-negotiable, and it applies here as much as to the advisors. It describes; it
+does not predict a result. Only a dyno pull measures anything.
+
+## Architecture
+
+| Layer | Location | Responsibility |
+|---|---|---|
+| Tokens | `src/ui/tokens.css` | Palette, spacing, type, radii, breakpoints as CSS custom properties |
+| Primitives | `src/ui/primitives/` | Button, Panel, StatTile, Bar, Select, Toggle, Field, Note — each with a co-located `.module.css` |
+| Screens | `src/ui/screens/` | One file per page |
+| Shell | `src/ui/AppShell.jsx` | Sidebar, status strip, content outlet, responsive behaviour |
+| State | `src/ui/state/` | `BuildContext`, `TuneContext`, `SessionContext` |
+| Table ops | `src/sim/tables.js` | Pure grid transforms: interpolate, smooth, scale, delta |
+
+### Decisions
+
+**CSS Modules over a styling library.** Vite supports `.module.css` natively. No new
+dependency, real media queries, real pseudo-classes. Tokens live once, as custom
+properties.
+
+**Hand-rolled hash routing (~40 lines) over react-router.** Fourteen pages need real URLs.
+`#/tune/spark` deep-links work on GitHub Pages with no server configuration. A router
+dependency is not worth it in an app with four production dependencies.
+
+**Three reducer-backed contexts over 40 `useState` calls.** Undo/redo needs an edit log;
+a reducer provides one structurally rather than as a bolt-on.
+
+**Bulk table ops live in `src/sim/tables.js`.** `CONTRIBUTING.md` forbids engineering maths
+in `src/ui/`. Interpolating a spark table is not physics, but it is maths over calibration
+data, and `tables.js` already owns that data, its axes and its clamps. Placing the ops
+there also makes them unit-testable without a DOM.
+
+## Verification
+
+**The behavioural fingerprint is the safety net for the whole refactor.** This is a
+UI-only change, so `tests/fingerprint.test.js` must stay byte-identical throughout. If it
+moves, the change broke physics and the fix is to the change — **not** to rebaseline the
+fingerprint. Run on Node 22 (keg-only install); the default Node 26 shifts float results
+and invalidates the hash on its own.
+
+Full gate per `CONTRIBUTING.md`, on every PR: `npm test`, `npm run lint`, `npm run
+typecheck`, `npm run build`.
+
+**Test strategy.** `tests/` currently holds no UI tests at all. Rather than pretend a
+redesign can be snapshot-tested, everything that can be pure will be pure and tested as
+such: table ops, the undo reducer, route parsing, share-link encode/decode. A thin layer of
+component tests over the primitives uses `@testing-library/react`, added as a
+devDependency.
+
+## Roadmap
+
+Seven pull requests. PRs 1–3 are the overhaul; 4–7 are the selected features.
+
+| # | PR | Contents |
+|---|---|---|
+| 1 | Design system | Tokens, CSS Modules setup, primitives library. No screen changes. |
+| 2 | State extraction | Three contexts. Behaviour-preserving; render stays monolithic. |
+| 3 | Shell + IA | Sidebar, status strip, routing, `EcuLab.jsx` split into ~14 screens. |
+| 4 | Table editing | Multi-cell selection, bulk ops, undo/redo, keyboard navigation, diff-vs-stock overlay |
+| 5 | Progress | Run-history timeline, ghost-curve fix, events plotted on the dyno curve, post-pull scrubber |
+| 6 | Garage | Multiple saved builds, shareable build links |
+| 7 | Extras | Command palette, challenges/scenarios |
+
+Splitting PR 2 from PR 3 is deliberate: moving state and moving markup in one diff produces
+a review nobody can perform.
+
+### Feature notes
+
+**Ghost curve already exists** — `EcuLab.jsx:2105` draws `prevHp`/`prevTorque` as dashed
+lines in `#3a4149`, a grey dark enough to be nearly invisible, and it remembers only one
+pull back. PR 5 makes it legible and lets any run from history be pinned as the comparison.
+
+**There is no undo anywhere in the app.** PR 4 introduces it.
+
+**`storage.js` persists only `{best, total, pulls}`.** Saved builds in PR 6 are new
+plumbing, not an extension of existing persistence.
+
+### Process
+
+Issue #6 should become an epic with one sub-issue per PR, so each lands against something
+specific. Its first bullet is already implemented and should be noted as such on the issue.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| The refactor silently changes physics | Fingerprint must not move; it is checked on every PR |
+| PR 3 is too large to review | State (PR 2) and markup (PR 3) are separated; screens land as one file per page |
+| Contextual panel becomes noise | Copy is held to the same `msg`/`cause`/`fix` standard as pull-log events |
+| Seven PRs stall midway | Each PR is independently shippable; the app stays working after every one |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -26,6 +26,7 @@ export default [
         clearTimeout: 'readonly',
         Float32Array: 'readonly',
         process: 'readonly',
+        URL: 'readonly',
       },
     },
     plugins: { react, 'react-hooks': reactHooks },

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
     <meta name="color-scheme" content="dark" />
-    <meta name="theme-color" content="#0a0d11" />
+    <meta name="theme-color" content="#0a0d14" />
     <meta
       name="description"
       content="An engine management and tuning simulator. Design an engine, edit the calibration tables a real tuner edits, run a dyno pull, and read a log explaining what went right or wrong."
@@ -13,13 +13,13 @@
     <style>
       /* The app renders dark-on-dark and is laid out for mobile first. Set the page
          background here so there is no white flash before React mounts. */
-      html, body { margin: 0; padding: 0; background: #0a0d11; }
+      html, body { margin: 0; padding: 0; background: #0a0d14; }
       body { -webkit-font-smoothing: antialiased; overscroll-behavior: none; }
       /* Every control in the app is a <button>; normalise them once, globally, rather
          than repeating a reset in each inline style object. */
       button { font: inherit; cursor: pointer; color: inherit; }
       button:focus-visible, [role="gridcell"]:focus-visible {
-        outline: 2px solid #ff6a2c;
+        outline: 2px solid #4c9eff;
         outline-offset: 2px;
       }
       @media (prefers-reduced-motion: reduce) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^22.20.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -23,13 +24,35 @@
         "eslint": "^9.15.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.0.0",
+        "jsdom": "^25.0.1",
         "typescript": "^5.6.3",
         "vite": "^5.4.11",
         "vitest": "^2.1.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=20 <23"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -320,6 +343,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -981,9 +1119,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1092,9 +1227,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1109,9 +1241,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1126,9 +1255,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1143,9 +1269,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1160,9 +1283,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1177,9 +1297,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1194,9 +1311,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1211,9 +1325,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1228,9 +1339,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1245,9 +1353,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1262,9 +1367,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1279,9 +1381,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1296,9 +1395,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1388,6 +1484,63 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1706,6 +1859,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -1721,6 +1884,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -1745,6 +1919,17 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -1903,6 +2088,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -2149,6 +2341,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2177,6 +2382,27 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -2305,6 +2531,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -2377,6 +2617,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -2436,6 +2683,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -2448,6 +2716,14 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -2480,6 +2756,19 @@
       "integrity": "sha512-lEcqhErbHjXRvd41rnWLpzbyU/IXfIYo7QwaFWmxGeLiLyY2TBCdHnWY88vB+p3ubnihRypDm66panXl7TylLA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -3072,6 +3361,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3356,6 +3662,60 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -3672,6 +4032,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -3878,6 +4245,47 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -4032,6 +4440,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4050,6 +4469,29 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -4126,6 +4568,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -4316,6 +4765,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4415,6 +4877,44 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -4672,6 +5172,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
@@ -4725,6 +5232,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -5077,6 +5604,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -5125,6 +5659,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/type-check": {
@@ -5470,6 +6050,67 @@
         }
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5601,6 +6242,45 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^22.20.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
@@ -47,6 +48,7 @@
     "eslint": "^9.15.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.0.0",
+    "jsdom": "^25.0.1",
     "typescript": "^5.6.3",
     "vite": "^5.4.11",
     "vitest": "^2.1.5"

--- a/src/css-modules.d.ts
+++ b/src/css-modules.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Vite resolves `*.module.css` to an object of generated class names at build time.
+ * `tsc` knows nothing about that, so without this declaration every stylesheet
+ * import is a "cannot find module" error under `npm run typecheck`.
+ */
+
+declare module '*.module.css' {
+  const classes: Record<string, string>;
+  export default classes;
+}
+
+declare module '*.css';

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,6 +7,8 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 
+import './ui/tokens.css';
+
 import EcuLab from './ui/EcuLab.jsx';
 import { ErrorBoundary } from './ui/ErrorBoundary.jsx';
 

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -32,15 +32,15 @@ import {
   deriveEngine, idealExhaustDiameter, interp2, liveStep, makeLiveState, presetById,
   simulateSweep, turbineWithCount, veRecommendations
 } from '../sim/index.js';
-import { T, heat, statusColor } from './theme.js';
+import { T, accAlpha, heat, shadowAlpha, statusColor } from './theme.js';
 import { BUILD_VERSION } from '../version.js';
 import { loadCareer, saveCareer } from '../storage.js';
 
 const Eyebrow = ({ children, icon: Icon }) => (
   <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
-    <div style={{ width: 3, height: 13, background: T.amber, borderRadius: 2 }} />
-    {Icon && <Icon size={13} color={T.amberInk} />}
-    <span style={{ fontSize: 10.5, letterSpacing: 1.6, color: T.amberInk, textTransform: 'uppercase', fontWeight: 800 }}>{children}</span>
+    <div style={{ width: 3, height: 13, background: T.acc, borderRadius: 2 }} />
+    {Icon && <Icon size={13} color={T.accInk} />}
+    <span style={{ fontSize: 10.5, letterSpacing: 1.6, color: T.accInk, textTransform: 'uppercase', fontWeight: 800 }}>{children}</span>
   </div>
 );
 
@@ -51,10 +51,10 @@ const Panel = ({ children, style, tight }) => (
 );
 
 const Note = ({ children, tone = 'info' }) => {
-  const colors = { info: [T.ink2, T.line, T.panel2], warn: [T.yellow, '#3a2f16', T.yellowBg] };
+  const colors = { info: [T.ink2, T.line, T.panel2], warn: [T.warn, T.warnBg, T.warnBg] };
   const [fg, bd, bgc] = colors[tone] || colors.info;
   return (
-    <div style={{ display: 'flex', gap: 9, background: bgc, border: `1px solid ${bd}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12.5, color: fg === T.ink2 ? '#b7c0c9' : fg, lineHeight: 1.55 }}>
+    <div style={{ display: 'flex', gap: 9, background: bgc, border: `1px solid ${bd}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12.5, color: fg === T.ink2 ? T.inkSoft : fg, lineHeight: 1.55 }}>
       <Info size={15} style={{ flexShrink: 0, marginTop: 1, color: fg }} />
       <div>{children}</div>
     </div>
@@ -67,12 +67,12 @@ function ExpandableInfo({ title, children }) {
     <div style={{ margin: '10px 0', border: `1px solid ${T.line}`, borderRadius: 10, overflow: 'hidden', background: T.panel }}>
       <button onClick={() => setOpen((o) => !o)} style={{ width: '100%', display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '11px 13px', background: 'none', border: 'none' }}>
         <span style={{ display: 'flex', alignItems: 'center', gap: 9, color: T.ink, fontSize: 12.5, fontWeight: 700, textAlign: 'left' }}>
-          <Info size={14} style={{ color: T.amber, flexShrink: 0 }} />{title}
+          <Info size={14} style={{ color: T.acc, flexShrink: 0 }} />{title}
         </span>
         <ChevronDown size={15} style={{ color: T.ink3, flexShrink: 0, marginLeft: 8, transform: open ? 'rotate(180deg)' : 'none', transition: 'transform .2s' }} />
       </button>
       <div style={{ maxHeight: open ? 900 : 0, opacity: open ? 1 : 0, overflow: 'hidden', transition: 'max-height .3s ease, opacity .2s ease' }}>
-        <div style={{ padding: '0 13px 13px', fontSize: 12.5, color: '#a5aebb', lineHeight: 1.65 }}>{children}</div>
+        <div style={{ padding: '0 13px 13px', fontSize: 12.5, color: T.ink2, lineHeight: 1.65 }}>{children}</div>
       </div>
     </div>
   );
@@ -88,8 +88,8 @@ function Seg({ options, value, onChange, wrap }) {
         return (
           <button key={o.value} onClick={() => onChange(o.value)} style={{
             flex: wrap ? '1 1 30%' : 1, padding: '11px 4px', borderRadius: 9, fontWeight: 700, fontSize: 12.5,
-            border: `1px solid ${active ? T.amber : T.line}`, background: active ? T.amberBg : T.panel2,
-            color: active ? T.amberInk : T.ink2, transition: 'all .15s',
+            border: `1px solid ${active ? T.acc : T.line}`, background: active ? T.accBg : T.panel2,
+            color: active ? T.accInk : T.ink2, transition: 'all .15s',
           }}>{o.label}</button>
         );
       })}
@@ -106,8 +106,8 @@ function PickList({ options, value, onChange }) {
         return (
           <button key={o.value} onClick={() => onChange(o.value)} style={{
             textAlign: 'left', padding: '11px 13px', borderRadius: 9, fontWeight: 600, fontSize: 13,
-            border: `1px solid ${active ? T.amber : T.line}`, background: active ? T.amberBg : T.panel2,
-            color: active ? T.amberInk : '#c3cad2',
+            border: `1px solid ${active ? T.acc : T.line}`, background: active ? T.accBg : T.panel2,
+            color: active ? T.accInk : T.inkSoft,
           }}>{o.label}{o.sub && <div style={{ fontSize: 11, color: T.ink2, marginTop: 2, fontWeight: 400 }}>{o.sub}</div>}</button>
         );
       })}
@@ -157,15 +157,15 @@ function GroupedSelect({ groups, extra = [], value, onChange }) {
   );
 }
 
-function ToggleRow({ label, sub, checked, onChange, color = T.amber }) {
+function ToggleRow({ label, sub, checked, onChange, color = T.acc }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 10, padding: 13 }}>
       <div style={{ marginRight: 10 }}>
         <div style={{ fontWeight: 700, fontSize: 13.5, color: T.ink }}>{label}</div>
         {sub && <div style={{ fontSize: 11.5, color: T.ink2, marginTop: 1 }}>{sub}</div>}
       </div>
-      <button onClick={() => onChange(!checked)} style={{ width: 48, height: 27, borderRadius: 14, border: 'none', position: 'relative', flexShrink: 0, background: checked ? color : '#2a323a', transition: 'background .2s' }}>
-        <div style={{ position: 'absolute', top: 3, left: checked ? 24 : 3, width: 21, height: 21, borderRadius: 11, background: '#fff', transition: 'left .2s', boxShadow: '0 1px 3px rgba(0,0,0,.4)' }} />
+      <button onClick={() => onChange(!checked)} style={{ width: 48, height: 27, borderRadius: 14, border: 'none', position: 'relative', flexShrink: 0, background: checked ? color : T.panel3, transition: 'background .2s' }}>
+        <div style={{ position: 'absolute', top: 3, left: checked ? 24 : 3, width: 21, height: 21, borderRadius: 11, background: T.ink, transition: 'left .2s', boxShadow: `0 1px 3px ${shadowAlpha(0.4)}` }} />
       </button>
     </div>
   );
@@ -216,18 +216,18 @@ function JourneyBanner({ step, onAdvance, onDismiss }) {
   const j = JOURNEY[step];
   if (!j) return null;
   return (
-    <div style={{ background: T.amberBg, border: `1px solid ${T.amber}`, borderRadius: 12, padding: '13px 14px', margin: '0 0 14px' }}>
+    <div style={{ background: T.accBg, border: `1px solid ${T.acc}`, borderRadius: 12, padding: '13px 14px', margin: '0 0 14px' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 10 }}>
-        <div style={{ fontSize: 11, letterSpacing: 1, color: T.amberInk, fontWeight: 800 }}>{j.title.toUpperCase()}</div>
+        <div style={{ fontSize: 11, letterSpacing: 1, color: T.accInk, fontWeight: 800 }}>{j.title.toUpperCase()}</div>
         <button onClick={onDismiss} style={{ background: 'none', border: 'none', color: T.ink3, fontSize: 10.5, fontWeight: 700, flexShrink: 0 }}>SKIP GUIDE</button>
       </div>
-      <div style={{ fontSize: 12.5, color: '#c3cad2', lineHeight: 1.55, marginTop: 7 }}>{j.body}</div>
+      <div style={{ fontSize: 12.5, color: T.inkSoft, lineHeight: 1.55, marginTop: 7 }}>{j.body}</div>
       <div style={{ display: 'flex', gap: 5, marginTop: 11, marginBottom: 10 }}>
         {JOURNEY.map((_, i) => (
-          <div key={i} style={{ flex: 1, height: 3, borderRadius: 2, background: i <= step ? T.amber : T.line }} />
+          <div key={i} style={{ flex: 1, height: 3, borderRadius: 2, background: i <= step ? T.acc : T.line }} />
         ))}
       </div>
-      <button onClick={onAdvance} style={{ width: '100%', padding: '11px 0', borderRadius: 9, border: 'none', background: T.amber, color: '#1a0f08', fontWeight: 800, fontSize: 12.5 }}>
+      <button onClick={onAdvance} style={{ width: '100%', padding: '11px 0', borderRadius: 9, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 12.5 }}>
         {j.cta}
       </button>
     </div>
@@ -239,18 +239,18 @@ function BuildSection({ active, onClick, icon: Icon, label, sub, children }) {
     <div style={{ marginBottom: 9 }}>
       <button onClick={onClick} style={{
         width: '100%', display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '13px 14px',
-        borderRadius: 11, border: `1px solid ${active ? T.amber : T.line}`, background: active ? T.amberBg : T.panel2,
+        borderRadius: 11, border: `1px solid ${active ? T.acc : T.line}`, background: active ? T.accBg : T.panel2,
       }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 11, textAlign: 'left' }}>
-          <div style={{ width: 32, height: 32, borderRadius: 9, background: active ? 'rgba(255,106,44,0.18)' : T.panel, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-            <Icon size={16} color={active ? T.amberInk : T.ink2} />
+          <div style={{ width: 32, height: 32, borderRadius: 9, background: active ? accAlpha(0.18) : T.panel, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+            <Icon size={16} color={active ? T.accInk : T.ink2} />
           </div>
           <div>
-            <div style={{ fontWeight: 800, fontSize: 13.5, color: active ? T.amberInk : T.ink }}>{label}</div>
+            <div style={{ fontWeight: 800, fontSize: 13.5, color: active ? T.accInk : T.ink }}>{label}</div>
             {sub && <div style={{ fontSize: 10.5, color: T.ink2, marginTop: 1 }}>{sub}</div>}
           </div>
         </div>
-        <ChevronDown size={16} style={{ color: active ? T.amberInk : T.ink3, flexShrink: 0, marginLeft: 8, transform: active ? 'rotate(180deg)' : 'none', transition: 'transform .2s' }} />
+        <ChevronDown size={16} style={{ color: active ? T.accInk : T.ink3, flexShrink: 0, marginLeft: 8, transform: active ? 'rotate(180deg)' : 'none', transition: 'transform .2s' }} />
       </button>
       <div style={{ maxHeight: active ? 3000 : 0, opacity: active ? 1 : 0, overflow: 'hidden', transition: 'max-height .35s ease, opacity .25s ease' }}>
         <div style={{ padding: '13px 2px 2px' }}>{children}</div>
@@ -273,13 +273,13 @@ function DialMark({ size = 64, pct = 0.62, live = false }) {
           <line key={i}
             x1={50 + inner * Math.sin(a)} y1={50 - inner * Math.cos(a)}
             x2={50 + outer * Math.sin(a)} y2={50 - outer * Math.cos(a)}
-            stroke={i > 9 ? T.red : T.line === T.line ? '#3a4149' : T.line} strokeWidth={i % 3 === 0 ? 1.6 : 1} />
+            stroke={i > 9 ? T.danger : T.line === T.line ? T.ink3 : T.line} strokeWidth={i % 3 === 0 ? 1.6 : 1} />
         );
       })}
       <g style={{ transition: live ? 'none' : 'transform .6s cubic-bezier(.34,1.4,.64,1)' }} transform={`rotate(${angle} 50 50)`}>
-        <line x1="50" y1="50" x2="50" y2="20" stroke={T.amber} strokeWidth="3" strokeLinecap="round" />
+        <line x1="50" y1="50" x2="50" y2="20" stroke={T.acc} strokeWidth="3" strokeLinecap="round" />
       </g>
-      <circle cx="50" cy="50" r="5" fill={T.amber} />
+      <circle cx="50" cy="50" r="5" fill={T.acc} />
     </svg>
   );
 }
@@ -289,7 +289,7 @@ function Tach({ rpm, cylinders, running, fullScaleRpm }) {
   // fullScaleRpm is redline * 1.1 (see tachFullScaleRpm), so redline itself always
   // sits at pct ≈ 0.909 regardless of engine — the red zone has to start at or just
   // below that, not above it, or the needle never shows red at the engine's own redline.
-  const zoneColor = pct > 0.9 ? T.red : pct > 0.75 ? T.yellow : T.green;
+  const zoneColor = pct > 0.9 ? T.danger : pct > 0.75 ? T.warn : T.ok;
   return (
     <Panel style={{ textAlign: 'center', background: T.panel }}>
       <style>{`@keyframes cylpulse{0%,100%{opacity:.25;transform:scaleY(.6)}50%{opacity:1;transform:scaleY(1)}}`}</style>
@@ -338,8 +338,8 @@ function TuningGrid({ data, min, max, decimals, selection, setSelection }) {
           {RPM.map((r, ci) => (
             <button key={r} onClick={() => selectCol(ci)} style={{
               width: 51, height: 30, flexShrink: 0, border: 'none', borderBottom: `1px solid ${T.line}`, borderLeft: `1px solid ${T.line}`,
-              background: selection?.type === 'col' && selection.col === ci ? T.amber : T.panel,
-              color: selection?.type === 'col' && selection.col === ci ? '#1a0f08' : T.ink2,
+              background: selection?.type === 'col' && selection.col === ci ? T.acc : T.panel,
+              color: selection?.type === 'col' && selection.col === ci ? T.accOn : T.ink2,
               fontFamily: T.mono, fontSize: 10, fontWeight: 700,
             }}>{r}</button>
           ))}
@@ -348,15 +348,15 @@ function TuningGrid({ data, min, max, decimals, selection, setSelection }) {
           <div key={load} style={{ display: 'flex' }}>
             <button onClick={() => selectRow(ri)} style={{
               width: 44, height: 37, flexShrink: 0, border: 'none', borderRight: `1px solid ${T.line}`, borderTop: `1px solid ${T.line}`,
-              background: selection?.type === 'row' && selection.row === ri ? T.amber : T.panel,
-              color: selection?.type === 'row' && selection.row === ri ? '#1a0f08' : T.ink2,
+              background: selection?.type === 'row' && selection.row === ri ? T.acc : T.panel,
+              color: selection?.type === 'row' && selection.row === ri ? T.accOn : T.ink2,
               fontFamily: T.mono, fontSize: 10, fontWeight: 700,
             }}>{load}</button>
             {data[ri].map((val, ci) => (
               <button key={ci} onClick={() => selectCell(ri, ci)} style={{
                 width: 51, height: 37, flexShrink: 0,
-                border: isSelected(ri, ci) ? `2px solid ${T.ink}` : `1px solid rgba(0,0,0,0.35)`,
-                background: heat(val, min, max), color: '#f2f5f7',
+                border: isSelected(ri, ci) ? `2px solid ${T.ink}` : `1px solid ${shadowAlpha(0.35)}`,
+                background: heat(val, min, max), color: T.ink,
                 fontFamily: T.mono, fontSize: 12, fontWeight: 700,
               }}>{fmt(val)}</button>
             ))}
@@ -431,7 +431,7 @@ function SelectionDock({ data, setData, selection, min, max, decimals, unit, onC
   else sel = `${RPM[selection.col]} RPM · ${LOAD[selection.row]} kPa MAP`;
 
   return (
-    <div style={{ position: 'sticky', bottom: 0, background: T.panel, borderTop: `1px solid ${T.line}`, padding: '11px 14px 13px', boxShadow: '0 -8px 20px rgba(0,0,0,0.45)' }}>
+    <div style={{ position: 'sticky', bottom: 0, background: T.panel, borderTop: `1px solid ${T.line}`, padding: '11px 14px 13px', boxShadow: `0 -8px 20px ${shadowAlpha(0.45)}` }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 7 }}>
         <div>
           <div style={{ fontSize: 10, letterSpacing: 1, color: T.ink2, textTransform: 'uppercase', fontWeight: 700 }}>{sel}</div>
@@ -444,21 +444,21 @@ function SelectionDock({ data, setData, selection, min, max, decimals, unit, onC
       {selection.type === 'cell' && kind && (() => {
         const ref = cellReference(kind, selection.row, selection.col, current);
         return (
-          <div style={{ background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 9, padding: '9px 11px', marginBottom: 9, fontSize: 11.5, lineHeight: 1.55, color: '#a5aebb' }}>
+          <div style={{ background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 9, padding: '9px 11px', marginBottom: 9, fontSize: 11.5, lineHeight: 1.55, color: T.ink2 }}>
             <div style={{ fontSize: 9.5, letterSpacing: 1, color: T.cyan, fontWeight: 800, marginBottom: 5 }}>REFERENCE · {RPM[selection.col]} RPM / {LOAD[selection.row]} kPa</div>
             <div>{ref.what}</div>
             <div style={{ marginTop: 4, color: T.ink }}>{ref.typical}</div>
-            <div style={{ marginTop: 4 }}><b style={{ color: '#c3cad2' }}>Affects: </b>{ref.affects}</div>
-            {ref.note && <div style={{ marginTop: 4, color: T.yellow }}>{ref.note}</div>}
+            <div style={{ marginTop: 4 }}><b style={{ color: T.inkSoft }}>Affects: </b>{ref.affects}</div>
+            {ref.note && <div style={{ marginTop: 4, color: T.warn }}>{ref.note}</div>}
           </div>
         );
       })()}
-      <input type="range" min={min} max={max} step={smallStep} value={current} onChange={(e) => setAbs(Number(e.target.value))} style={{ width: '100%', accentColor: T.amber }} />
+      <input type="range" min={min} max={max} step={smallStep} value={current} onChange={(e) => setAbs(Number(e.target.value))} style={{ width: '100%', accentColor: T.acc }} />
       <div style={{ display: 'flex', gap: 7, marginTop: 9 }}>
         {[-bigStep, -smallStep, smallStep, bigStep].map((d, i) => (
           <button key={i} onClick={() => apply(d)} style={{
             flex: 1, padding: '11px 0', borderRadius: 8, border: `1px solid ${T.line}`, background: T.panel2,
-            color: d < 0 ? '#ff9d7a' : T.green, fontWeight: 800, fontFamily: T.mono, fontSize: 13,
+            color: d < 0 ? T.accInk : T.ok, fontWeight: 800, fontFamily: T.mono, fontSize: 13,
           }}>{d > 0 ? '+' : ''}{d}</button>
         ))}
       </div>
@@ -492,23 +492,23 @@ function TutorialScreen({ onDone }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100dvh', background: T.bg, color: T.ink, fontFamily: T.sans }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '14px 16px' }}>
-        <div style={{ fontSize: 10.5, letterSpacing: 1.5, color: T.amberInk, fontWeight: 800 }}>TUTORIAL · {step + 1}/{TUTORIAL_STEPS.length}</div>
+        <div style={{ fontSize: 10.5, letterSpacing: 1.5, color: T.accInk, fontWeight: 800 }}>TUTORIAL · {step + 1}/{TUTORIAL_STEPS.length}</div>
         <button onClick={onDone} style={{ background: 'none', border: 'none', color: T.ink3, fontSize: 12, fontWeight: 700 }}>SKIP</button>
       </div>
       <div style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center', padding: '0 24px' }}>
         <div style={{ fontSize: 21, fontWeight: 800, marginBottom: 13, letterSpacing: -0.3 }}>{s.title}</div>
-        <div style={{ fontSize: 14.5, color: '#c3cad2', lineHeight: 1.7 }}>{s.body}</div>
+        <div style={{ fontSize: 14.5, color: T.inkSoft, lineHeight: 1.7 }}>{s.body}</div>
       </div>
       <div style={{ display: 'flex', gap: 6, justifyContent: 'center', padding: '0 0 18px' }}>
         {TUTORIAL_STEPS.map((_, i) => (
-          <div key={i} style={{ width: i === step ? 20 : 6, height: 6, borderRadius: 3, background: i === step ? T.amber : T.line, transition: 'width .2s' }} />
+          <div key={i} style={{ width: i === step ? 20 : 6, height: 6, borderRadius: 3, background: i === step ? T.acc : T.line, transition: 'width .2s' }} />
         ))}
       </div>
       <div style={{ display: 'flex', gap: 10, padding: '0 16px', paddingBottom: 'calc(16px + env(safe-area-inset-bottom))' }}>
         {step > 0 && (
-          <button onClick={() => setStep((v) => v - 1)} style={{ flex: 1, padding: '15px 0', borderRadius: 12, border: `1px solid ${T.line}`, background: T.panel2, color: '#c3cad2', fontWeight: 700, fontSize: 14 }}>BACK</button>
+          <button onClick={() => setStep((v) => v - 1)} style={{ flex: 1, padding: '15px 0', borderRadius: 12, border: `1px solid ${T.line}`, background: T.panel2, color: T.inkSoft, fontWeight: 700, fontSize: 14 }}>BACK</button>
         )}
-        <button onClick={() => (last ? onDone() : setStep((v) => v + 1))} style={{ flex: 2, padding: '15px 0', borderRadius: 12, border: 'none', background: T.amber, color: '#1a0f08', fontWeight: 800, fontSize: 14.5 }}>
+        <button onClick={() => (last ? onDone() : setStep((v) => v + 1))} style={{ flex: 2, padding: '15px 0', borderRadius: 12, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 14.5 }}>
           {last ? 'START TUNING' : 'NEXT'}
         </button>
       </div>
@@ -519,17 +519,17 @@ function TutorialScreen({ onDone }) {
 function StartScreen({ onStart, onTutorial }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100dvh', background: T.bg, color: T.ink, fontFamily: T.sans, justifyContent: 'center', alignItems: 'center', padding: 24, textAlign: 'center', position: 'relative', overflow: 'hidden' }}>
-      <div style={{ position: 'absolute', top: '-15%', left: '50%', transform: 'translateX(-50%)', width: 420, height: 420, borderRadius: '50%', background: 'radial-gradient(circle, rgba(255,106,44,0.10) 0%, transparent 70%)' }} />
+      <div style={{ position: 'absolute', top: '-15%', left: '50%', transform: 'translateX(-50%)', width: 420, height: 420, borderRadius: '50%', background: `radial-gradient(circle, ${accAlpha(0.10)} 0%, transparent 70%)` }} />
       <div style={{ marginBottom: 22, position: 'relative' }}><DialMark size={92} pct={0.62} /></div>
-      <div style={{ fontSize: 11, letterSpacing: 3, color: T.amberInk, fontWeight: 800, marginBottom: 7 }}>CARIBOU TUNING</div>
+      <div style={{ fontSize: 11, letterSpacing: 3, color: T.accInk, fontWeight: 800, marginBottom: 7 }}>CARIBOU TUNING</div>
       <div style={{ fontSize: 25, fontWeight: 800, textTransform: 'uppercase', letterSpacing: 0.3, marginBottom: 15, maxWidth: 320 }}>Engine Management Sandbox</div>
       <div style={{ fontSize: 13.5, color: T.ink2, lineHeight: 1.65, maxWidth: 300, marginBottom: 34 }}>
         Design an engine. Tune it. Log it. Improve it. A free-tune sandbox built to teach real engine management, not just move sliders.
       </div>
-      <button onClick={onStart} style={{ width: '100%', maxWidth: 300, padding: '16px 0', borderRadius: 12, border: 'none', background: T.amber, color: '#1a0f08', fontWeight: 800, fontSize: 15, letterSpacing: 0.4, marginBottom: 12, boxShadow: '0 8px 24px rgba(255,106,44,0.25)' }}>
+      <button onClick={onStart} style={{ width: '100%', maxWidth: 300, padding: '16px 0', borderRadius: 12, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 15, letterSpacing: 0.4, marginBottom: 12, boxShadow: `0 8px 24px ${accAlpha(0.25)}` }}>
         START
       </button>
-      <button onClick={onTutorial} style={{ width: '100%', maxWidth: 300, padding: '15px 0', borderRadius: 12, border: `1px solid ${T.line}`, background: 'none', color: '#c3cad2', fontWeight: 700, fontSize: 13.5 }}>
+      <button onClick={onTutorial} style={{ width: '100%', maxWidth: 300, padding: '15px 0', borderRadius: 12, border: `1px solid ${T.line}`, background: 'none', color: T.inkSoft, fontWeight: 700, fontSize: 13.5 }}>
         TUTORIAL
       </button>
       <div style={{ fontSize: 10.5, color: T.ink3, marginTop: 18, fontFamily: T.mono }}>{BUILD_VERSION}</div>
@@ -539,9 +539,9 @@ function StartScreen({ onStart, onTutorial }) {
 
 function LiveGauge({ label, value, unit, color = T.ink, warn }) {
   return (
-    <div style={{ flex: 1, minWidth: 68, background: T.panel, border: `1px solid ${warn ? T.red : T.line}`, borderRadius: 9, padding: '8px 9px' }}>
+    <div style={{ flex: 1, minWidth: 68, background: T.panel, border: `1px solid ${warn ? T.danger : T.line}`, borderRadius: 9, padding: '8px 9px' }}>
       <div style={{ fontSize: 8.5, color: T.ink2, letterSpacing: 0.8, fontWeight: 700 }}>{label}</div>
-      <div style={{ fontSize: 15, fontWeight: 800, fontFamily: T.mono, color: warn ? T.red : color }}>
+      <div style={{ fontSize: 15, fontWeight: 800, fontFamily: T.mono, color: warn ? T.danger : color }}>
         {value}<span style={{ fontSize: 9, color: T.ink3, marginLeft: 2 }}>{unit}</span>
       </div>
     </div>
@@ -550,7 +550,7 @@ function LiveGauge({ label, value, unit, color = T.ink, warn }) {
 
 function TrimBar({ label, value }) {
   const pct = clamp((value + 25) / 50, 0, 1) * 100;
-  const c = Math.abs(value) > 15 ? T.red : Math.abs(value) > 8 ? T.yellow : T.green;
+  const c = Math.abs(value) > 15 ? T.danger : Math.abs(value) > 8 ? T.warn : T.ok;
   return (
     <div style={{ marginBottom: 7 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 9.5, color: T.ink2, fontWeight: 700, marginBottom: 3 }}>
@@ -1170,7 +1170,7 @@ export default function EngineManagementSandbox() {
       <div style={{ padding: '13px 16px 12px', borderBottom: `1px solid ${T.line}`, background: T.panel }}>
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
           <div>
-            <div style={{ fontSize: 10, letterSpacing: 2, color: T.amberInk, fontWeight: 800 }}>CARIBOU TUNING</div>
+            <div style={{ fontSize: 10, letterSpacing: 2, color: T.accInk, fontWeight: 800 }}>CARIBOU TUNING</div>
             <div style={{ fontSize: 16.5, fontWeight: 800, letterSpacing: 0.2 }}>ECU Lab</div>
             <div style={{ fontSize: 11, color: T.ink2, marginTop: 3, fontFamily: T.mono }}>
               {engineName} · {turboOn ? 'Turbo' : 'N/A'} · {OCTANE_OPTS[octaneIdx].label} oct · {INJECTOR_OPTS[injIdx].label} · {BUILD_VERSION}
@@ -1190,7 +1190,7 @@ export default function EngineManagementSandbox() {
             <div style={{ width: `${overallHealth}%`, height: '100%', background: overallColor, transition: 'width .4s' }} />
           </div>
           <span style={{ fontSize: 10, color: overallColor, fontWeight: 800, fontFamily: T.mono }}>{Math.round(overallHealth)}%</span>
-          {live.running && <span style={{ fontSize: 9.5, color: T.green, fontWeight: 800, letterSpacing: 0.5 }}>● RUNNING</span>}
+          {live.running && <span style={{ fontSize: 9.5, color: T.ok, fontWeight: 800, letterSpacing: 0.5 }}>● RUNNING</span>}
         </div>
       </div>
 
@@ -1210,7 +1210,7 @@ export default function EngineManagementSandbox() {
                   <div style={{ position: 'relative', flexShrink: 0 }}>
                     <DialMark size={104} pct={clamp(live.sensedRpm / tachFullScaleRpm, 0, 1)} live />
                     <div style={{ position: 'absolute', top: '58%', left: '50%', transform: 'translate(-50%,-50%)', textAlign: 'center' }}>
-                      <div style={{ fontSize: 17, fontWeight: 800, fontFamily: T.mono, color: live.fuelCut ? T.red : T.ink }}>{Math.round(live.sensedRpm)}</div>
+                      <div style={{ fontSize: 17, fontWeight: 800, fontFamily: T.mono, color: live.fuelCut ? T.danger : T.ink }}>{Math.round(live.sensedRpm)}</div>
                       <div style={{ fontSize: 7, color: T.ink3, letterSpacing: 1, fontWeight: 700 }}>RPM</div>
                     </div>
                   </div>
@@ -1227,13 +1227,13 @@ export default function EngineManagementSandbox() {
                     <div style={{ display: 'flex', gap: 7 }}>
                       <button onClick={live.running || live.cranking ? stopEngine : startEngine} style={{
                         flex: 1, padding: '11px 0', borderRadius: 9, border: 'none', fontWeight: 800, fontSize: 12.5,
-                        background: live.running || live.cranking ? T.panel2 : T.green, color: live.running || live.cranking ? T.ink : '#06210f',
-                        borderWidth: 1, borderStyle: 'solid', borderColor: live.running || live.cranking ? T.line : T.green,
+                        background: live.running || live.cranking ? T.panel2 : T.ok, color: live.running || live.cranking ? T.ink : T.okBg,
+                        borderWidth: 1, borderStyle: 'solid', borderColor: live.running || live.cranking ? T.line : T.ok,
                       }}>{live.running || live.cranking ? 'STOP' : 'START ENGINE'}</button>
                       <button onClick={() => { if (!soundOn) ensureAudio()?.ctx.resume(); setSoundOn((v) => !v); }} title="Engine sound" style={{
                         width: 46, padding: '11px 0', borderRadius: 9, fontWeight: 800, fontSize: 13,
-                        border: `1px solid ${soundOn ? T.amber : T.line}`, background: soundOn ? T.amberBg : T.panel2,
-                        color: soundOn ? T.amberInk : T.ink3,
+                        border: `1px solid ${soundOn ? T.acc : T.line}`, background: soundOn ? T.accBg : T.panel2,
+                        color: soundOn ? T.accInk : T.ink3,
                       }}>{soundOn ? '♪' : '✕'}</button>
                     </div>
                   </div>
@@ -1247,9 +1247,9 @@ export default function EngineManagementSandbox() {
                     position: 'relative', overflow: 'hidden',
                     marginTop: 12, padding: '18px 0', borderRadius: 12, textAlign: 'center', userSelect: 'none',
                     WebkitUserSelect: 'none', WebkitTouchCallout: 'none',
-                    border: `1px solid ${throttleInput > 0 ? T.amber : T.line}`,
-                    background: throttleInput > 0 ? T.amberBg : T.panel2,
-                    color: throttleInput > 0 ? T.amberInk : T.ink2, fontWeight: 800, fontSize: 13.5, letterSpacing: 0.5,
+                    border: `1px solid ${throttleInput > 0 ? T.acc : T.line}`,
+                    background: throttleInput > 0 ? T.accBg : T.panel2,
+                    color: throttleInput > 0 ? T.accInk : T.ink2, fontWeight: 800, fontSize: 13.5, letterSpacing: 0.5,
                     touchAction: 'none', opacity: live.running ? 1 : 0.4,
                     transition: 'background .1s, border-color .1s',
                   }}
@@ -1257,7 +1257,7 @@ export default function EngineManagementSandbox() {
                   <div style={{
                     position: 'absolute', left: 0, top: 0, bottom: 0,
                     width: `${clamp(live.effThrottle ?? 0, 0, 100)}%`,
-                    background: 'rgba(255,106,44,0.16)', transition: 'width .12s',
+                    background: accAlpha(0.16), transition: 'width .12s',
                   }} />
                   <span style={{ position: 'relative' }}>
                     {!live.running ? 'START THE ENGINE FIRST' : throttleInput > 0 ? 'WIDE OPEN THROTTLE' : 'PRESS AND HOLD TO REV'}
@@ -1272,13 +1272,13 @@ export default function EngineManagementSandbox() {
                 <div style={{ display: 'flex', gap: 6, marginTop: 6, flexWrap: 'wrap' }}>
                   <LiveGauge label="LAMBDA" value={live.sensedLambda.toFixed(2)} unit="λ" color={T.violet} />
                   <LiveGauge label="COOLANT" value={Math.round(live.sensedCoolant)} unit="°C" warn={live.sensedCoolant > 105} />
-                  <LiveGauge label="TIMING" value={live.live ? live.live.timing : '—'} unit="°" color={T.yellow} warn={!!(live.live && live.live.knock)} />
+                  <LiveGauge label="TIMING" value={live.live ? live.live.timing : '—'} unit="°" color={T.warn} warn={!!(live.live && live.live.knock)} />
                 </div>
                 <div style={{ display: 'flex', gap: 6, marginTop: 6, flexWrap: 'wrap' }}>
                   <LiveGauge label="INJ PW" value={live.live ? live.live.pw : '—'} unit="ms" />
                   <LiveGauge label="DUTY" value={live.live ? live.live.duty : '—'} unit="%" warn={!!(live.live && live.live.duty > 90)} />
                   <LiveGauge label="IDLE AIR" value={Math.round(live.idleTrim)} unit="%" />
-                  <LiveGauge label="FUEL" value={live.fuelCut ? 'CUT' : 'ON'} unit="" color={live.fuelCut ? T.yellow : T.green} />
+                  <LiveGauge label="FUEL" value={live.fuelCut ? 'CUT' : 'ON'} unit="" color={live.fuelCut ? T.warn : T.ok} />
                 </div>
 
                 <div style={{ marginTop: 12 }}>
@@ -1297,18 +1297,18 @@ export default function EngineManagementSandbox() {
               sub={result ? `Best ${bestScore} · ${pullCount} pulls logged` : `${pullCount} pulls logged`}
             >
               <div style={{ display: 'flex', gap: 10, marginBottom: 12 }}>
-                <StatTile label="BEST PULL" value={bestScore} color={T.amberInk} />
+                <StatTile label="BEST PULL" value={bestScore} color={T.accInk} />
                 <StatTile label="CAREER TOTAL" value={totalScore} color={T.cyan} />
                 <StatTile label="PULLS" value={pullCount} color={T.ink} />
               </div>
               {result && scores ? (
                 <>
                   <div style={{ display: 'flex', gap: 10, marginBottom: 10 }}>
-                    <StatTile label="PEAK POWER" value={result.peakHp} unit="whp" color={T.amberInk} />
+                    <StatTile label="PEAK POWER" value={result.peakHp} unit="whp" color={T.accInk} />
                     <StatTile label="PEAK TORQUE" value={result.peakTq} unit="lb-ft" color={T.cyan} />
                   </div>
                   <div style={{ display: 'flex', gap: 10 }}>
-                    <StatTile label="PULL SCORE" value={scores.pull} color={T.amberInk} />
+                    <StatTile label="PULL SCORE" value={scores.pull} color={T.accInk} />
                     <StatTile label="TUNING" value={scores.tuning.score} color={statusColor(scores.tuning.score)} />
                     <StatTile label="ENGINEER" value={scores.engineer.score} color={statusColor(scores.engineer.score)} />
                   </div>
@@ -1336,7 +1336,7 @@ export default function EngineManagementSandbox() {
             >
               <div style={{ fontSize: 12, color: T.ink3, marginBottom: 10, lineHeight: 1.5 }}>Read in order. Each explains a piece of what the live engine is doing right now.</div>
 
-              <div style={{ fontSize: 11, letterSpacing: 1, color: T.amberInk, fontWeight: 800, margin: '4px 0 8px' }}>PART 1 · FUNDAMENTALS</div>
+              <div style={{ fontSize: 11, letterSpacing: 1, color: T.accInk, fontWeight: 800, margin: '4px 0 8px' }}>PART 1 · FUNDAMENTALS</div>
 
               <ExpandableInfo title="1. The whole thing in one paragraph">
                 An engine is an air pump. However much air it swallows decides how much fuel can be burned, and burning fuel is what makes power. The ECU's entire job is to measure the air, add the right amount of fuel, and light it at the right moment. Tuning is adjusting those last two decisions.
@@ -1368,7 +1368,7 @@ export default function EngineManagementSandbox() {
                 <br /><br /><b style={{ color: T.ink }}>How much is too much?</b> Tuners treat anything sustained above about 2° of retard as damaging, not as an operating point. Zero is the target.
               </ExpandableInfo>
 
-              <div style={{ fontSize: 11, letterSpacing: 1, color: T.amberInk, fontWeight: 800, margin: '14px 0 8px' }}>PART 2 · WHAT THE ECU CALCULATES</div>
+              <div style={{ fontSize: 11, letterSpacing: 1, color: T.accInk, fontWeight: 800, margin: '14px 0 8px' }}>PART 2 · WHAT THE ECU CALCULATES</div>
 
               <ExpandableInfo title="6. The control loop, in order">
                 Thousands of times a minute, the ECU runs the same sequence:
@@ -1418,7 +1418,7 @@ export default function EngineManagementSandbox() {
                 <br /><br /><b style={{ color: T.ink }}>Pumping loss</b> is the one people forget: at part throttle the engine is working hard to breathe against a closed throttle, and that shows up as wasted work. Under boost it flips — if the turbine is not choking the exhaust harder than the compressor is filling the intake, the gas-exchange loop can actually hand work back.
               </ExpandableInfo>
 
-              <div style={{ fontSize: 11, letterSpacing: 1, color: T.amberInk, fontWeight: 800, margin: '14px 0 8px' }}>PART 3 · THE TUNING PROCESS</div>
+              <div style={{ fontSize: 11, letterSpacing: 1, color: T.accInk, fontWeight: 800, margin: '14px 0 8px' }}>PART 3 · THE TUNING PROCESS</div>
 
               <ExpandableInfo title="12. The loop: change → pull → read → adjust">
                 This is the whole method, and it is not a simplification:
@@ -1508,7 +1508,7 @@ export default function EngineManagementSandbox() {
                   </div>
                   <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, color: T.ink2, fontWeight: 600 }}>
                     <span>YOUR LAST PULL</span>
-                    <span style={{ color: result ? T.amberInk : T.ink3, fontWeight: 800, fontFamily: T.mono }}>
+                    <span style={{ color: result ? T.accInk : T.ink3, fontWeight: 800, fontFamily: T.mono }}>
                       {result ? `${result.peakHp} whp · ${result.peakTq} lb-ft` : 'no pull logged'}
                     </span>
                   </div>
@@ -1521,12 +1521,12 @@ export default function EngineManagementSandbox() {
                 <Note>Custom build — every value below is yours to set. Pick a real engine above to start from a known-good factory configuration instead.</Note>
               )}
               {presetPrompt && (
-                <div style={{ background: T.panel2, border: `1px solid ${T.amber}`, borderRadius: 10, padding: '11px 13px', margin: '4px 0 10px' }}>
-                  <div style={{ fontSize: 12, color: '#a5aebb', lineHeight: 1.5, marginBottom: 9 }}>
-                    <b style={{ color: T.amberInk }}>This replaces your current tune.</b> Loading {presetPrompt.name} overwrites your VE, spark and fuel tables with its factory calibration. Your career stats are kept.
+                <div style={{ background: T.panel2, border: `1px solid ${T.acc}`, borderRadius: 10, padding: '11px 13px', margin: '4px 0 10px' }}>
+                  <div style={{ fontSize: 12, color: T.ink2, lineHeight: 1.5, marginBottom: 9 }}>
+                    <b style={{ color: T.accInk }}>This replaces your current tune.</b> Loading {presetPrompt.name} overwrites your VE, spark and fuel tables with its factory calibration. Your career stats are kept.
                   </div>
                   <div style={{ display: 'flex', gap: 7 }}>
-                    <button onClick={() => applyEnginePreset(presetPrompt)} style={{ flex: 1, padding: '10px 0', borderRadius: 8, border: 'none', background: T.amber, color: '#2a1206', fontWeight: 800, fontSize: 12 }}>
+                    <button onClick={() => applyEnginePreset(presetPrompt)} style={{ flex: 1, padding: '10px 0', borderRadius: 8, border: 'none', background: T.acc, color: T.accBg, fontWeight: 800, fontSize: 12 }}>
                       LOAD {presetPrompt.name.toUpperCase()}
                     </button>
                     <button onClick={() => setPresetPrompt(null)} style={{ flex: 1, padding: '10px 0', borderRadius: 8, border: `1px solid ${T.line}`, background: T.panel, color: T.ink2, fontWeight: 700, fontSize: 12 }}>
@@ -1538,12 +1538,12 @@ export default function EngineManagementSandbox() {
               <Panel tight style={{ marginBottom: 13 }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, color: T.ink2, marginBottom: 5, fontWeight: 600 }}><span>DISPLACEMENT</span><span style={{ color: T.ink, fontWeight: 800, fontFamily: T.mono }}>{engineDerived.displacementL.toFixed(2)} L</span></div>
                 <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, color: T.ink2, marginBottom: 5, fontWeight: 600 }}><span>BORE : STROKE</span><span style={{ color: T.ink, fontWeight: 800, fontFamily: T.mono }}>{engineDerived.ratio.toFixed(3)}</span></div>
-                <div style={{ fontSize: 11.5, color: T.amberInk, fontWeight: 600 }}>{engineDerived.character}</div>
+                <div style={{ fontSize: 11.5, color: T.accInk, fontWeight: 600 }}>{engineDerived.character}</div>
               </Panel>
 
               {!veAdvice.inSync && (
-                <div style={{ background: T.panel2, border: `1px solid ${T.amber}`, borderRadius: 10, padding: '11px 13px', margin: '4px 0 10px', fontSize: 12, color: '#a5aebb', lineHeight: 1.5 }}>
-                  <b style={{ color: T.amberInk }}>Your VE table is now stale.</b> This hardware breathes differently than what you last logged — up to {veAdvice.maxAbs.toFixed(0)}% off. Head to <b style={{ color: T.ink }}>TUNE &rsaquo; AIR</b> to see which cells changed and why, then accept it there.
+                <div style={{ background: T.panel2, border: `1px solid ${T.acc}`, borderRadius: 10, padding: '11px 13px', margin: '4px 0 10px', fontSize: 12, color: T.ink2, lineHeight: 1.5 }}>
+                  <b style={{ color: T.accInk }}>Your VE table is now stale.</b> This hardware breathes differently than what you last logged — up to {veAdvice.maxAbs.toFixed(0)}% off. Head to <b style={{ color: T.ink }}>TUNE &rsaquo; AIR</b> to see which cells changed and why, then accept it there.
                 </div>
               )}
               <ExpandableInfo title="Why changing hardware does not update your VE table">
@@ -1560,15 +1560,15 @@ export default function EngineManagementSandbox() {
               </ExpandableInfo>
 
               <div style={{ fontSize: 12, color: T.ink2, margin: '10px 0 6px', fontWeight: 600 }}>Bore: {engineConfig.bore.toFixed(1)} mm</div>
-              <input type="range" min={75} max={105} step={0.5} value={engineConfig.bore} onChange={(e) => setCfg({ bore: Number(e.target.value) })} style={{ width: '100%', accentColor: T.amber }} />
+              <input type="range" min={75} max={105} step={0.5} value={engineConfig.bore} onChange={(e) => setCfg({ bore: Number(e.target.value) })} style={{ width: '100%', accentColor: T.acc }} />
               <div style={{ fontSize: 12, color: T.ink2, margin: '10px 0 6px', fontWeight: 600 }}>Stroke: {engineConfig.stroke.toFixed(1)} mm</div>
-              <input type="range" min={65} max={100} step={0.5} value={engineConfig.stroke} onChange={(e) => setCfg({ stroke: Number(e.target.value) })} style={{ width: '100%', accentColor: T.amber }} />
+              <input type="range" min={65} max={100} step={0.5} value={engineConfig.stroke} onChange={(e) => setCfg({ stroke: Number(e.target.value) })} style={{ width: '100%', accentColor: T.acc }} />
               <ExpandableInfo title="Bore, stroke, and engine character">
                 Bore is cylinder diameter, stroke is how far the piston travels; together with cylinder count they set displacement. But the ratio between them shapes character independent of displacement: big-bore/short-stroke ("oversquare") tends to breathe and rev higher; small-bore/long-stroke ("undersquare") tends toward stronger low-end torque. This sandbox shifts your VE curve's effective bias toward high or low RPM based on what you set here.
               </ExpandableInfo>
 
               <div style={{ fontSize: 12, color: T.ink2, margin: '10px 0 6px', fontWeight: 600 }}>Compression Ratio: {engineConfig.compression.toFixed(1)}:1</div>
-              <input type="range" min={8.5} max={13.0} step={0.1} value={engineConfig.compression} onChange={(e) => setCfg({ compression: Number(e.target.value) })} style={{ width: '100%', accentColor: T.amber }} />
+              <input type="range" min={8.5} max={13.0} step={0.1} value={engineConfig.compression} onChange={(e) => setCfg({ compression: Number(e.target.value) })} style={{ width: '100%', accentColor: T.acc }} />
               <ExpandableInfo title="Compression ratio's trade-off">
                 Higher compression squeezes the mixture tighter before ignition, extracting more work from the same fuel — genuinely more efficient and torquey. The same squeeze also raises end-gas temperature and pressure, which is what causes knock. That is exactly why turbocharged engines usually run lower static compression than naturally aspirated ones: boost already adds cylinder pressure on its own.
               </ExpandableInfo>
@@ -1576,7 +1576,7 @@ export default function EngineManagementSandbox() {
               <div style={{ fontSize: 12, color: T.ink2, margin: '10px 0 6px', fontWeight: 600 }}>
                 Camshaft Duration: {engineConfig.camDuration}° <span style={{ color: T.ink3, fontWeight: 400 }}>· overlap {Math.round(engineDerived.overlapDeg)}°</span>
               </div>
-              <input type="range" min={180} max={300} step={2} value={engineConfig.camDuration} onChange={(e) => setCfg({ camDuration: Number(e.target.value) })} style={{ width: '100%', accentColor: T.amber }} />
+              <input type="range" min={180} max={300} step={2} value={engineConfig.camDuration} onChange={(e) => setCfg({ camDuration: Number(e.target.value) })} style={{ width: '100%', accentColor: T.acc }} />
               <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 9.5, color: T.ink3, marginTop: 2 }}>
                 <span>mild · low-end torque</span><span>wild · top-end power</span>
               </div>
@@ -1587,11 +1587,11 @@ export default function EngineManagementSandbox() {
               </ExpandableInfo>
 
               <div style={{ fontSize: 12, color: T.ink2, margin: '10px 0 6px', fontWeight: 600 }}>
-                Valve Spring Rate: {engineConfig.springRate} <span style={{ color: engineDerived.floatRpm < engineDerived.redline ? T.red : T.ink3, fontWeight: 400 }}>· float at {Math.round(engineDerived.floatRpm)} RPM</span>
+                Valve Spring Rate: {engineConfig.springRate} <span style={{ color: engineDerived.floatRpm < engineDerived.redline ? T.danger : T.ink3, fontWeight: 400 }}>· float at {Math.round(engineDerived.floatRpm)} RPM</span>
               </div>
-              <input type="range" min={20} max={100} step={1} value={engineConfig.springRate} onChange={(e) => setCfg({ springRate: Number(e.target.value) })} style={{ width: '100%', accentColor: engineDerived.floatRpm < engineDerived.redline ? T.red : T.cyan }} />
+              <input type="range" min={20} max={100} step={1} value={engineConfig.springRate} onChange={(e) => setCfg({ springRate: Number(e.target.value) })} style={{ width: '100%', accentColor: engineDerived.floatRpm < engineDerived.redline ? T.danger : T.cyan }} />
               {engineDerived.floatRpm < engineDerived.redline && (
-                <div style={{ fontSize: 11.5, color: T.red, marginTop: 5 }}>
+                <div style={{ fontSize: 11.5, color: T.danger, marginTop: 5 }}>
                   Springs float below redline — cylinder filling collapses above {Math.round(engineDerived.floatRpm)} RPM. Stiffen them or fit a milder cam.
                 </div>
               )}
@@ -1625,12 +1625,12 @@ export default function EngineManagementSandbox() {
                 {Object.keys(MOD_INFO).map((key) => (
                   <button key={key} onClick={() => installMod(key)} disabled={mods[key]} style={{
                     textAlign: 'left', padding: '11px 13px', borderRadius: 10,
-                    border: `1px solid ${mods[key] ? '#1f4a30' : T.line}`,
-                    background: mods[key] ? T.greenBg : T.panel2,
+                    border: `1px solid ${mods[key] ? T.okBg : T.line}`,
+                    background: mods[key] ? T.okBg : T.panel2,
                   }}>
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                      <span style={{ fontWeight: 700, fontSize: 13, color: mods[key] ? T.green : T.ink }}>{MOD_INFO[key].label}</span>
-                      <span style={{ fontSize: 10.5, fontWeight: 800, color: mods[key] ? T.green : T.amberInk }}>{mods[key] ? 'INSTALLED' : 'INSTALL'}</span>
+                      <span style={{ fontWeight: 700, fontSize: 13, color: mods[key] ? T.ok : T.ink }}>{MOD_INFO[key].label}</span>
+                      <span style={{ fontSize: 10.5, fontWeight: 800, color: mods[key] ? T.ok : T.accInk }}>{mods[key] ? 'INSTALLED' : 'INSTALL'}</span>
                     </div>
                     <div style={{ fontSize: 11.5, color: T.ink2, marginTop: 3 }}>{MOD_INFO[key].blurb}</div>
                   </button>
@@ -1675,19 +1675,19 @@ export default function EngineManagementSandbox() {
                         return (
                           <button key={r} onClick={() => setBoostSel(i)} style={{
                             flex: 1, height: '100%', padding: 0, borderRadius: 7,
-                            border: `1px solid ${on ? T.amber : T.line}`,
-                            background: on ? T.amberBg : T.panel,
+                            border: `1px solid ${on ? T.acc : T.line}`,
+                            background: on ? T.accBg : T.panel,
                             display: 'flex', flexDirection: 'column', justifyContent: 'flex-end', overflow: 'hidden',
                           }}>
-                            <div style={{ fontSize: 10, fontFamily: T.mono, fontWeight: 800, color: over ? T.red : on ? T.amberInk : T.ink2, paddingBottom: 2 }}>
+                            <div style={{ fontSize: 10, fontFamily: T.mono, fontWeight: 800, color: over ? T.danger : on ? T.accInk : T.ink2, paddingBottom: 2 }}>
                               {boostCurve[i]}
                             </div>
                             <div style={{
                               height: `${(boostCurve[i] / 25) * 72}%`, minHeight: boostCurve[i] > 0 ? 3 : 0,
-                              background: over ? T.red : on ? T.amber : '#7a4526',
+                              background: over ? T.danger : on ? T.acc : T.lineHi,
                               borderRadius: '3px 3px 0 0', transition: 'height .12s',
                             }} />
-                            <div style={{ fontSize: 8, color: on ? T.amberInk : T.ink3, fontFamily: T.mono, padding: '3px 0' }}>
+                            <div style={{ fontSize: 8, color: on ? T.accInk : T.ink3, fontFamily: T.mono, padding: '3px 0' }}>
                               {r >= 1000 ? (r / 1000).toFixed(1) + 'k' : r}
                             </div>
                           </button>
@@ -1699,18 +1699,18 @@ export default function EngineManagementSandbox() {
                   <Panel tight style={{ marginBottom: 10 }}>
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 8 }}>
                       <span style={{ fontSize: 10.5, letterSpacing: 1, color: T.ink2, fontWeight: 700 }}>{RPM[boostSel]} RPM</span>
-                      <span style={{ fontFamily: T.mono, fontSize: 24, fontWeight: 800, color: boostCurve[boostSel] > COMPRESSOR_OPTS[compressorIdx].boostCeiling ? T.red : T.amberInk }}>
+                      <span style={{ fontFamily: T.mono, fontSize: 24, fontWeight: 800, color: boostCurve[boostSel] > COMPRESSOR_OPTS[compressorIdx].boostCeiling ? T.danger : T.accInk }}>
                         {boostCurve[boostSel]}<span style={{ fontSize: 12, color: T.ink2, marginLeft: 3 }}>psi</span>
                       </span>
                     </div>
                     <input type="range" min={0} max={25} step={1} value={boostCurve[boostSel]}
                       onChange={(e) => setBoostAt(boostSel, Number(e.target.value))}
-                      style={{ width: '100%', accentColor: T.amber }} />
+                      style={{ width: '100%', accentColor: T.acc }} />
                     <div style={{ display: 'flex', gap: 6, marginTop: 8 }}>
                       {[-5, -1, 1, 5].map((d) => (
                         <button key={d} onClick={() => setBoostAt(boostSel, (boostCurve[boostSel] ?? 0) + d)}
                           style={{ flex: 1, padding: '11px 0', borderRadius: 8, border: `1px solid ${T.line}`, background: T.panel,
-                            color: d < 0 ? '#ff9d7a' : T.green, fontWeight: 800, fontFamily: T.mono, fontSize: 14 }}>
+                            color: d < 0 ? T.accInk : T.ok, fontWeight: 800, fontFamily: T.mono, fontSize: 14 }}>
                           {d > 0 ? '+' : ''}{d}
                         </button>
                       ))}
@@ -1733,7 +1733,7 @@ export default function EngineManagementSandbox() {
                         ZERO
                       </button>
                     </div>
-                    <div style={{ fontSize: 10.5, color: Math.max(...boostCurve) > COMPRESSOR_OPTS[compressorIdx].boostCeiling ? T.red : T.ink3, marginTop: 8 }}>
+                    <div style={{ fontSize: 10.5, color: Math.max(...boostCurve) > COMPRESSOR_OPTS[compressorIdx].boostCeiling ? T.danger : T.ink3, marginTop: 8 }}>
                       Compressor efficient to ~{COMPRESSOR_OPTS[compressorIdx].boostCeiling} psi{Math.max(...boostCurve) > COMPRESSOR_OPTS[compressorIdx].boostCeiling ? ' — you are past it, expect hot inefficient air' : ''}
                     </div>
                   </Panel>
@@ -1756,7 +1756,7 @@ export default function EngineManagementSandbox() {
               <Seg options={EXHAUST_DIA_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={EXHAUST_DIA_OPTS[exhaustDiaIdx].label} onChange={(v) => setExhaustDiaIdxInvalidating(EXHAUST_DIA_OPTS.findIndex((o) => o.label === v))} />
               <div style={{ fontSize: 11, color: T.ink3, marginBottom: 4 }}>
                 Estimated ideal for this build: ~{idealExhaustDia.toFixed(2)} in
-                {turboOn && Math.max(...boostCurve) > 0 && <span style={{ color: T.amberInk }}> (raised by boost)</span>}
+                {turboOn && Math.max(...boostCurve) > 0 && <span style={{ color: T.accInk }}> (raised by boost)</span>}
               </div>
               <ExpandableInfo title="Why exhaust diameter isn't just 'bigger is better'">
                 Undersized piping restricts flow at high RPM, choking VE right when the engine wants air moving fastest. Oversized piping does the opposite at low RPM — exhaust velocity drops, scavenging gets lazy, and low-end response suffers.
@@ -1776,8 +1776,8 @@ export default function EngineManagementSandbox() {
                 <button key={v.id} onClick={() => { setTuneView(v.id); setSelection(null); }} style={{
                   flex: 1, padding: '10px 0 9px', borderRadius: 10, display: 'flex', flexDirection: 'column',
                   alignItems: 'center', gap: 4, fontWeight: 800, fontSize: 10, letterSpacing: 0.4,
-                  border: `1px solid ${on ? T.amber : T.line}`, background: on ? T.amberBg : T.panel2,
-                  color: on ? T.amberInk : T.ink2,
+                  border: `1px solid ${on ? T.acc : T.line}`, background: on ? T.accBg : T.panel2,
+                  color: on ? T.accInk : T.ink2,
                 }}>
                   <Icon size={15} />{v.label}
                 </button>
@@ -1801,27 +1801,27 @@ export default function EngineManagementSandbox() {
 
               {veAdvice && (
                 veAdvice.inSync ? (
-                  <div style={{ display: 'flex', gap: 8, background: T.greenBg, border: '1px solid #1f4a30', borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12.5, color: T.green, lineHeight: 1.5 }}>
+                  <div style={{ display: 'flex', gap: 8, background: T.okBg, border: `1px solid ${T.okBg}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12.5, color: T.ok, lineHeight: 1.5 }}>
                     <Info size={15} style={{ flexShrink: 0, marginTop: 1 }} />
                     <div>VE table matches your current hardware. Nothing to correct.</div>
                   </div>
                 ) : (
-                  <div style={{ background: T.panel2, border: `1px solid ${T.amber}`, borderRadius: 10, padding: '12px 13px', margin: '10px 0' }}>
+                  <div style={{ background: T.panel2, border: `1px solid ${T.acc}`, borderRadius: 10, padding: '12px 13px', margin: '10px 0' }}>
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
-                      <div style={{ fontSize: 10, letterSpacing: 1, color: T.amberInk, fontWeight: 800 }}>VE OUT OF SYNC WITH HARDWARE</div>
-                      <div style={{ fontSize: 11, fontFamily: T.mono, color: T.amberInk, fontWeight: 700 }}>{veAdvice.maxAbs.toFixed(0)}% max gap</div>
+                      <div style={{ fontSize: 10, letterSpacing: 1, color: T.accInk, fontWeight: 800 }}>VE OUT OF SYNC WITH HARDWARE</div>
+                      <div style={{ fontSize: 11, fontFamily: T.mono, color: T.accInk, fontWeight: 700 }}>{veAdvice.maxAbs.toFixed(0)}% max gap</div>
                     </div>
-                    <div style={{ fontSize: 12, color: '#a5aebb', lineHeight: 1.55, marginBottom: 9 }}>
+                    <div style={{ fontSize: 12, color: T.ink2, lineHeight: 1.55, marginBottom: 9 }}>
                       Your hardware changed but this table is still the old log. Here is what re-logging airflow on the dyno would actually show:
                     </div>
                     {veAdvice.recs.map((r, i) => (
                       <div key={i} style={{ marginBottom: 9 }}>
                         <div style={{ fontSize: 12, color: T.ink, fontWeight: 700 }}>{r.rpmText}</div>
-                        <div style={{ fontSize: 11.5, color: '#a5aebb', lineHeight: 1.5, marginTop: 2 }}>{r.text}</div>
+                        <div style={{ fontSize: 11.5, color: T.ink2, lineHeight: 1.5, marginTop: 2 }}>{r.text}</div>
                         <div style={{ fontSize: 10.5, color: T.cyan, fontFamily: T.mono, marginTop: 3 }}>{r.cells.join('   ')}</div>
                       </div>
                     ))}
-                    <button onClick={recalcVE} style={{ width: '100%', marginTop: 4, padding: '11px 0', borderRadius: 9, border: 'none', background: T.amber, color: '#1a0f08', fontWeight: 800, fontSize: 12.5 }}>
+                    <button onClick={recalcVE} style={{ width: '100%', marginTop: 4, padding: '11px 0', borderRadius: 9, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 12.5 }}>
                       ACCEPT RE-LOGGED VALUES
                     </button>
                     <div style={{ fontSize: 10.5, color: T.ink3, textAlign: 'center', marginTop: 6 }}>Or type them in yourself — these are the measured targets, not a suggestion.</div>
@@ -1846,11 +1846,11 @@ export default function EngineManagementSandbox() {
               <div style={{ fontSize: 12.5, color: T.ink2, marginBottom: 12 }}>Degrees of spark advance before top dead center (° BTDC).</div>
               <TuningGrid data={timing} min={SPARK_MIN_DEG} max={SPARK_MAX_DEG} decimals={0} {...gridProps} />
               {calAdvice.overAdvanced.length > 0 ? (
-                <div style={{ background: T.redBg, border: `1px solid #3a2020`, borderRadius: 10, padding: '12px 13px', margin: '10px 0' }}>
-                  <div style={{ fontSize: 10, letterSpacing: 1, color: '#ff9d9d', fontWeight: 800, marginBottom: 7 }}>
+                <div style={{ background: T.dangerBg, border: `1px solid ${T.dangerBg}`, borderRadius: 10, padding: '12px 13px', margin: '10px 0' }}>
+                  <div style={{ fontSize: 10, letterSpacing: 1, color: T.dangerInk, fontWeight: 800, marginBottom: 7 }}>
                     {calAdvice.overAdvanced.length} CELLS BEYOND THE KNOCK LIMIT
                   </div>
-                  <div style={{ fontSize: 12, color: '#a5aebb', lineHeight: 1.55, marginBottom: 8 }}>
+                  <div style={{ fontSize: 12, color: T.ink2, lineHeight: 1.55, marginBottom: 8 }}>
                     Your current hardware will not tolerate this much advance here. These cells are asking for more timing than the charge, octane and compression allow:
                   </div>
                   {calAdvice.overAdvanced.slice(0, 5).map((c, i) => (
@@ -1862,15 +1862,15 @@ export default function EngineManagementSandbox() {
                   <div style={{ fontSize: 11, color: T.ink3, marginTop: 8 }}>Edit them yourself — a calibration is yours to make, not something the app should silently rewrite.</div>
                 </div>
               ) : calAdvice.underAdvanced.length > 4 ? (
-                <div style={{ background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12, color: '#a5aebb', lineHeight: 1.5 }}>
-                  <b style={{ color: T.amberInk }}>Timing left on the table.</b> {calAdvice.underAdvanced.length} cells are more than 3° below what this build would tolerate. Safe, but you are giving away torque — advance them a little at a time and pull between each change.
+                <div style={{ background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12, color: T.ink2, lineHeight: 1.5 }}>
+                  <b style={{ color: T.accInk }}>Timing left on the table.</b> {calAdvice.underAdvanced.length} cells are more than 3° below what this build would tolerate. Safe, but you are giving away torque — advance them a little at a time and pull between each change.
                 </div>
               ) : calAdvice.pastMbt.length > 0 ? (
-                <div style={{ background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12, color: '#a5aebb', lineHeight: 1.5 }}>
-                  <b style={{ color: T.amberInk }}>Past peak torque.</b> {calAdvice.pastMbt.length} cells command more advance than the burn can use — the charge is already finishing where it should, so the extra degrees are working against the piston on its way up rather than adding torque. Not dangerous here — these cells are inside the knock limit — but pulling them back gains a little power and buys margin.
+                <div style={{ background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12, color: T.ink2, lineHeight: 1.5 }}>
+                  <b style={{ color: T.accInk }}>Past peak torque.</b> {calAdvice.pastMbt.length} cells command more advance than the burn can use — the charge is already finishing where it should, so the extra degrees are working against the piston on its way up rather than adding torque. Not dangerous here — these cells are inside the knock limit — but pulling them back gains a little power and buys margin.
                 </div>
               ) : (
-                <div style={{ background: T.greenBg, border: '1px solid #1f4a30', borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12.5, color: T.green }}>
+                <div style={{ background: T.okBg, border: `1px solid ${T.okBg}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12.5, color: T.ok }}>
                   Spark table sits within the knock limit for this hardware.
                 </div>
               )}
@@ -1898,15 +1898,15 @@ export default function EngineManagementSandbox() {
               <div style={{ fontSize: 12.5, color: T.ink2, marginBottom: 12, lineHeight: 1.5 }}>Target air:fuel ratio the ECU aims for. Divide by 14.7 to read it as lambda.</div>
               <TuningGrid data={afr} min={10} max={18} decimals={1} {...gridProps} />
               {calAdvice.wrongMix.length > 0 && (
-                <div style={{ background: T.panel2, border: `1px solid ${T.amber}`, borderRadius: 10, padding: '12px 13px', margin: '10px 0' }}>
-                  <div style={{ fontSize: 10, letterSpacing: 1, color: T.amberInk, fontWeight: 800, marginBottom: 7 }}>
+                <div style={{ background: T.panel2, border: `1px solid ${T.acc}`, borderRadius: 10, padding: '12px 13px', margin: '10px 0' }}>
+                  <div style={{ fontSize: 10, letterSpacing: 1, color: T.accInk, fontWeight: 800, marginBottom: 7 }}>
                     {calAdvice.wrongMix.length} HIGH-LOAD CELLS OFF BEST POWER
                   </div>
-                  <div style={{ fontSize: 12, color: '#a5aebb', lineHeight: 1.55, marginBottom: 8 }}>
+                  <div style={{ fontSize: 12, color: T.ink2, lineHeight: 1.55, marginBottom: 8 }}>
                     Best-power mixture shifts with boost — richer as cylinder pressure rises. These cells are judged on what the engine actually <b style={{ color: T.ink }}>delivered</b>, not on what the table commanded: if your MAF or injector scaling is off, the two are not the same number, and the delivered one is the one the pistons feel. The suggestion is the value to type into the cell to land on target.
                   </div>
                   {calAdvice.wrongMix.slice(0, 5).map((c, i) => (
-                    <div key={i} style={{ fontSize: 11, fontFamily: T.mono, color: c.delta < 0 ? '#ff9d9d' : T.cyan, marginBottom: 2 }}>
+                    <div key={i} style={{ fontSize: 11, fontFamily: T.mono, color: c.delta < 0 ? T.dangerInk : T.cyan, marginBottom: 2 }}>
                       {c.map} kPa / {c.rpm} RPM: {c.current}:1 → {c.suggested}:1 {c.delta < 0 ? '(richen)' : '(lean out)'} · delivered {c.delivered}, wants {c.target}
                     </div>
                   ))}
@@ -1936,7 +1936,7 @@ export default function EngineManagementSandbox() {
             <Seg options={OCTANE_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={OCTANE_OPTS[octaneIdx].label} onChange={(v) => setOctaneIdxInvalidating(OCTANE_OPTS.findIndex((o) => o.label === v))} />
             <ExpandableInfo title="What octane actually does — and what E85 costs you">
               Octane measures a fuel's resistance to auto-igniting under heat and pressure before the spark fires it — not energy content or "power." Higher octane tolerates more cylinder pressure and temperature before knock, letting a tuner run more advance or more boost safely. It does not add power on its own; it raises the ceiling for how much timing/boost you can use before knock becomes the limit.
-              <br /><br /><b style={{ color: T.ink }}>E85 is not a free upgrade.</b> Its stoichiometric point is about 9.8:1, not gasoline's 14.7:1 — so hitting the same lambda takes roughly <b style={{ color: T.amberInk }}>1.43× the fuel volume</b>. Switch to E85 without upsizing injectors and you will run out of duty cycle long before you cash in that knock margin. Watch the duty preview below change the moment you select it.
+              <br /><br /><b style={{ color: T.ink }}>E85 is not a free upgrade.</b> Its stoichiometric point is about 9.8:1, not gasoline's 14.7:1 — so hitting the same lambda takes roughly <b style={{ color: T.accInk }}>1.43× the fuel volume</b>. Switch to E85 without upsizing injectors and you will run out of duty cycle long before you cash in that knock margin. Watch the duty preview below change the moment you select it.
               <br /><br />That trade — huge knock resistance, huge fuel demand — is exactly why serious E85 builds pair it with bigger injectors and a bigger pump, and why "just run E85" is not a shortcut around a fuel system.
             </ExpandableInfo>
 
@@ -1947,14 +1947,14 @@ export default function EngineManagementSandbox() {
             </div>
             <Seg options={INJECTOR_OPTS.map((o) => ({ label: `${o.cc}`, value: o.cc }))} value={ecuInjectorCc} onChange={setEcuInjectorCcInvalidating} wrap />
             {ecuInjectorCc !== injectorCc ? (
-              <div style={{ background: T.redBg, border: `1px solid #3a2020`, borderRadius: 10, padding: '11px 13px', margin: '8px 0', fontSize: 12, color: '#ff9d9d', lineHeight: 1.5 }}>
+              <div style={{ background: T.dangerBg, border: `1px solid ${T.dangerBg}`, borderRadius: 10, padding: '11px 13px', margin: '8px 0', fontSize: 12, color: T.dangerInk, lineHeight: 1.5 }}>
                 <b>Scaling mismatch.</b> Hardware is {injectorCc}cc but the ECU is calibrated for {ecuInjectorCc}cc — every pulse delivers about {((injectorCc / ecuInjectorCc) * 100).toFixed(0)}% of the intended fuel, so the engine runs {injectorCc > ecuInjectorCc ? 'far too rich' : 'dangerously lean'} everywhere.
-                <button onClick={() => setEcuInjectorCcInvalidating(injectorCc)} style={{ display: 'block', width: '100%', marginTop: 9, padding: '10px 0', borderRadius: 8, border: 'none', background: T.amber, color: '#1a0f08', fontWeight: 800, fontSize: 12.5 }}>
+                <button onClick={() => setEcuInjectorCcInvalidating(injectorCc)} style={{ display: 'block', width: '100%', marginTop: 9, padding: '10px 0', borderRadius: 8, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 12.5 }}>
                   RESCALE ECU TO {injectorCc}cc
                 </button>
               </div>
             ) : (
-              <div style={{ fontSize: 11, color: T.green, margin: '6px 0 4px' }}>ECU scaling matches the fitted injectors.</div>
+              <div style={{ fontSize: 11, color: T.ok, margin: '6px 0 4px' }}>ECU scaling matches the fitted injectors.</div>
             )}
             <ExpandableInfo title="Injector scaling — the step everyone forgets">
               The ECU never commands "fuel" — it commands a pulse width, calculated for the injector size it has been <i>told</i> is fitted. Bolt in bigger injectors without updating that number and every pulse delivers proportionally more fuel than intended, so the engine runs rich everywhere regardless of what your AFR table says.
@@ -1968,12 +1968,12 @@ export default function EngineManagementSandbox() {
             <Panel tight style={{ marginTop: 6, marginBottom: 16 }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                 <div style={{ fontSize: 10, color: T.ink2, letterSpacing: 1, fontWeight: 700 }}>INJECTOR DUTY PREVIEW · WOT @ 6500 RPM</div>
-                {fuel.stoich < 14 && <div style={{ fontSize: 10, color: T.amberInk, fontFamily: T.mono, fontWeight: 700 }}>{fuel.label} stoich {fuel.stoich}:1</div>}
+                {fuel.stoich < 14 && <div style={{ fontSize: 10, color: T.accInk, fontFamily: T.mono, fontWeight: 700 }}>{fuel.label} stoich {fuel.stoich}:1</div>}
               </div>
               <div style={{ height: 8, background: T.panel, borderRadius: 4, marginTop: 8, overflow: 'hidden', border: `1px solid ${T.line}` }}>
-                <div style={{ width: `${Math.min(100, dutyPreview)}%`, height: '100%', background: dutyPreview > 90 ? T.red : dutyPreview > 75 ? T.yellow : T.green }} />
+                <div style={{ width: `${Math.min(100, dutyPreview)}%`, height: '100%', background: dutyPreview > 90 ? T.danger : dutyPreview > 75 ? T.warn : T.ok }} />
               </div>
-              <div style={{ fontSize: 12, marginTop: 7, color: dutyPreview > 90 ? '#ff9d9d' : '#c3cad2' }}>
+              <div style={{ fontSize: 12, marginTop: 7, color: dutyPreview > 90 ? T.dangerInk : T.inkSoft }}>
                 {dutyPreview.toFixed(0)}% duty {dutyPreview > 90 ? '— undersized for this build, expect forced lean-out' : ''}
               </div>
             </Panel>
@@ -1982,7 +1982,7 @@ export default function EngineManagementSandbox() {
             <Panel style={{ marginBottom: 13 }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 11, color: T.ink2, fontWeight: 700 }}>
                 <span>MAF RECAL STATUS</span>
-                <span style={{ color: needsMafRecal ? T.yellow : T.green, fontWeight: 800 }}>{needsMafRecal ? 'HARDWARE CHANGED' : 'STOCK — OK'}</span>
+                <span style={{ color: needsMafRecal ? T.warn : T.ok, fontWeight: 800 }}>{needsMafRecal ? 'HARDWARE CHANGED' : 'STOCK — OK'}</span>
               </div>
               {needsMafRecal && (
                 <div style={{ fontSize: 11.5, color: T.ink2, marginTop: 7 }}>
@@ -1992,7 +1992,7 @@ export default function EngineManagementSandbox() {
             </Panel>
             <div style={{ fontSize: 12, color: T.ink2, marginBottom: 7, fontWeight: 600 }}>MAF Scalar</div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 11, marginBottom: 6 }}>
-              <input type="range" min={0.75} max={1.25} step={0.01} value={mafScalar} onChange={(e) => setMafScalarInvalidating(Number(e.target.value))} style={{ flex: 1, accentColor: T.amber }} />
+              <input type="range" min={0.75} max={1.25} step={0.01} value={mafScalar} onChange={(e) => setMafScalarInvalidating(Number(e.target.value))} style={{ flex: 1, accentColor: T.acc }} />
               <div style={{ fontFamily: T.mono, fontWeight: 800, fontSize: 15, width: 52, textAlign: 'right', color: T.ink }}>{mafScalar.toFixed(2)}</div>
             </div>
             <ExpandableInfo title="VE tuning vs. MAF tuning — platforms differ">
@@ -2038,9 +2038,9 @@ export default function EngineManagementSandbox() {
 
             <button onClick={doRun} disabled={running} style={{
               width: '100%', padding: '15px 0', borderRadius: 12, border: 'none', marginBottom: 16,
-              background: running ? '#3a2c1c' : T.amber, color: '#1a0f08', fontWeight: 800, fontSize: 14.5,
+              background: running ? T.warnBg : T.acc, color: T.accOn, fontWeight: 800, fontSize: 14.5,
               display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, letterSpacing: 0.3,
-              boxShadow: running ? 'none' : '0 6px 18px rgba(255,106,44,0.22)',
+              boxShadow: running ? 'none' : `0 6px 18px ${accAlpha(0.22)}`,
             }}>
               <Play size={16} />
               {running ? 'SWEEPING…' : 'RUN DYNO PULL'}
@@ -2049,7 +2049,7 @@ export default function EngineManagementSandbox() {
             {result && (
               <>
                 <div style={{ display: 'flex', gap: 10, marginBottom: 14 }}>
-                  <StatTile label="PEAK WHP" value={result.peakHp} color={T.amberInk} />
+                  <StatTile label="PEAK WHP" value={result.peakHp} color={T.accInk} />
                   <StatTile label="PEAK TQ" value={result.peakTq} unit="lb-ft" color={T.cyan} />
                 </div>
 
@@ -2064,9 +2064,9 @@ export default function EngineManagementSandbox() {
                     <Panel tight style={{ marginBottom: 16, display: 'flex', alignItems: 'center', gap: 8 }}>
                       <TrendingUp size={15} color={T.ink2} style={{ flexShrink: 0 }} />
                       <div style={{ display: 'flex', gap: 14, fontSize: 12.5, flexWrap: 'wrap' }}>
-                        <span style={{ color: dHp === 0 ? T.ink2 : dHp > 0 ? T.green : '#ff8f8f', fontFamily: T.mono, fontWeight: 800 }}>{fmtDelta(dHp, ' whp')}</span>
-                        <span style={{ color: dTq === 0 ? T.ink2 : dTq > 0 ? T.green : '#ff8f8f', fontFamily: T.mono, fontWeight: 800 }}>{fmtDelta(dTq, ' lb-ft')}</span>
-                        <span style={{ color: dKnock === 0 ? T.ink2 : dKnock < 0 ? T.green : '#ff9d9d', fontFamily: T.mono, fontWeight: 800 }}>{knockNow} knock{knockNow === 1 ? '' : 's'} {dKnock !== 0 ? `(${fmtDelta(dKnock, '')})` : ''}</span>
+                        <span style={{ color: dHp === 0 ? T.ink2 : dHp > 0 ? T.ok : T.dangerInk, fontFamily: T.mono, fontWeight: 800 }}>{fmtDelta(dHp, ' whp')}</span>
+                        <span style={{ color: dTq === 0 ? T.ink2 : dTq > 0 ? T.ok : T.dangerInk, fontFamily: T.mono, fontWeight: 800 }}>{fmtDelta(dTq, ' lb-ft')}</span>
+                        <span style={{ color: dKnock === 0 ? T.ink2 : dKnock < 0 ? T.ok : T.dangerInk, fontFamily: T.mono, fontWeight: 800 }}>{knockNow} knock{knockNow === 1 ? '' : 's'} {dKnock !== 0 ? `(${fmtDelta(dKnock, '')})` : ''}</span>
                       </div>
                     </Panel>
                   );
@@ -2080,11 +2080,11 @@ export default function EngineManagementSandbox() {
                       return (
                         <button key={id} onClick={() => setDynoView(id)} style={{
                           flex: 1, padding: '9px 0', borderRadius: 9, fontWeight: 800, fontSize: 10, letterSpacing: 0.3,
-                          border: `1px solid ${on ? T.amber : T.line}`, background: on ? T.amberBg : T.panel2,
-                          color: on ? T.amberInk : T.ink2, position: 'relative',
+                          border: `1px solid ${on ? T.acc : T.line}`, background: on ? T.accBg : T.panel2,
+                          color: on ? T.accInk : T.ink2, position: 'relative',
                         }}>
                           {label}
-                          {flag && <span style={{ position: 'absolute', top: 5, right: 7, width: 5, height: 5, borderRadius: 3, background: T.red }} />}
+                          {flag && <span style={{ position: 'absolute', top: 5, right: 7, width: 5, height: 5, borderRadius: 3, background: T.danger }} />}
                         </button>
                       );
                     })}
@@ -2102,9 +2102,9 @@ export default function EngineManagementSandbox() {
                       <YAxis stroke={T.ink3} fontSize={10} />
                       <Tooltip contentStyle={{ background: T.panel2, border: `1px solid ${T.line}`, fontSize: 11 }} />
                       <Legend wrapperStyle={{ fontSize: 11 }} />
-                      {prevResult && <Line dataKey="prevHp" name="Prev WHP" stroke="#3a4149" strokeDasharray="4 3" dot={false} isAnimationActive={false} />}
-                      {prevResult && <Line dataKey="prevTorque" name="Prev TQ" stroke="#3a4149" strokeDasharray="4 3" dot={false} isAnimationActive={false} />}
-                      <Line dataKey="hp" name="WHP" stroke={T.amber} strokeWidth={2} dot={false} isAnimationActive={false} />
+                      {prevResult && <Line dataKey="prevHp" name="Prev WHP" stroke={T.ink3} strokeDasharray="4 3" dot={false} isAnimationActive={false} />}
+                      {prevResult && <Line dataKey="prevTorque" name="Prev TQ" stroke={T.ink3} strokeDasharray="4 3" dot={false} isAnimationActive={false} />}
+                      <Line dataKey="hp" name="WHP" stroke={T.acc} strokeWidth={2} dot={false} isAnimationActive={false} />
                       <Line dataKey="torque" name="Torque" stroke={T.cyan} strokeWidth={2} dot={false} isAnimationActive={false} />
                     </LineChart>
                   </ResponsiveContainer>
@@ -2119,9 +2119,9 @@ export default function EngineManagementSandbox() {
                       <YAxis stroke={T.ink3} fontSize={10} />
                       <Tooltip contentStyle={{ background: T.panel2, border: `1px solid ${T.line}`, fontSize: 11 }} />
                       <Legend wrapperStyle={{ fontSize: 11 }} />
-                      <Line dataKey="afrCommanded" name="AFR commanded" stroke="#5c6672" strokeDasharray="3 3" dot={false} isAnimationActive={false} />
-                      <Line dataKey="afr" name="AFR actual" stroke={T.green} strokeWidth={2} dot={false} isAnimationActive={false} />
-                      <Line dataKey="timing" name="Timing used" stroke={T.yellow} strokeWidth={2} dot={false} isAnimationActive={false} />
+                      <Line dataKey="afrCommanded" name="AFR commanded" stroke={T.ink3} strokeDasharray="3 3" dot={false} isAnimationActive={false} />
+                      <Line dataKey="afr" name="AFR actual" stroke={T.ok} strokeWidth={2} dot={false} isAnimationActive={false} />
+                      <Line dataKey="timing" name="Timing used" stroke={T.warn} strokeWidth={2} dot={false} isAnimationActive={false} />
                     </LineChart>
                   </ResponsiveContainer>
                 </Panel>
@@ -2141,7 +2141,7 @@ export default function EngineManagementSandbox() {
                         if (!p) return null;
                         const bad = p.knock || p.fuelLimited || p.leanRisk || p.richRisk || p.pressureRisk;
                         const warn = !bad && (p.duty > 85 || p.egtRisk);
-                        const edge = bad ? T.red : warn ? T.yellow : T.line;
+                        const edge = bad ? T.danger : warn ? T.warn : T.line;
 
                         // Each row: label, what was asked, what happened, and a verdict.
                         const rows = [
@@ -2173,9 +2173,9 @@ export default function EngineManagementSandbox() {
 
                         return (
                           <div key={r} style={{ border: `1px solid ${edge}`, borderRadius: 10, background: T.panel2, overflow: 'hidden' }}>
-                            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '9px 12px', background: bad ? T.redBg : warn ? T.yellowBg : T.panel }}>
+                            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '9px 12px', background: bad ? T.dangerBg : warn ? T.warnBg : T.panel }}>
                               <span style={{ fontFamily: T.mono, fontWeight: 800, fontSize: 14, color: T.ink }}>{r} RPM</span>
-                              <span style={{ fontFamily: T.mono, fontSize: 12, fontWeight: 700, color: bad ? T.red : warn ? T.yellow : T.green }}>
+                              <span style={{ fontFamily: T.mono, fontSize: 12, fontWeight: 700, color: bad ? T.danger : warn ? T.warn : T.ok }}>
                                 {p.hp} whp · {p.torque} lb-ft{bad ? '  ⚠' : warn ? '  !' : '  ✓'}
                               </span>
                             </div>
@@ -2184,12 +2184,12 @@ export default function EngineManagementSandbox() {
                                 <div key={i} style={{ paddingTop: 7 }}>
                                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', gap: 8 }}>
                                     <span style={{ fontSize: 11.5, color: T.ink2, fontWeight: 600, minWidth: 62 }}>{row.k}</span>
-                                    <span style={{ fontFamily: T.mono, fontSize: 12, color: row.ok ? T.ink : T.red, fontWeight: 700, textAlign: 'right' }}>
+                                    <span style={{ fontFamily: T.mono, fontSize: 12, color: row.ok ? T.ink : T.danger, fontWeight: 700, textAlign: 'right' }}>
                                       {row.asked != null && <span style={{ color: T.ink3, fontWeight: 400 }}>{row.asked} → </span>}
                                       {row.got}
                                     </span>
                                   </div>
-                                  <div style={{ fontSize: 10.5, color: row.ok ? T.ink3 : '#ff9d9d', lineHeight: 1.4, marginTop: 1 }}>{row.note}</div>
+                                  <div style={{ fontSize: 10.5, color: row.ok ? T.ink3 : T.dangerInk, lineHeight: 1.4, marginTop: 1 }}>{row.note}</div>
                                 </div>
                               ))}
                             </div>
@@ -2235,7 +2235,7 @@ export default function EngineManagementSandbox() {
                                   const mag = e == null ? 0 : Math.min(1, Math.abs(e) / 12);
                                   const bg = e == null ? T.panel2 : `hsl(${e > 0 ? 8 : 200}, 60%, ${14 + mag * 22}%)`;
                                   return (
-                                    <div key={ci} style={{ width: 51, height: 32, flexShrink: 0, background: bg, color: e == null ? T.ink3 : '#fff', fontFamily: T.mono, fontSize: 11, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid rgba(0,0,0,0.35)' }}>
+                                    <div key={ci} style={{ width: 51, height: 32, flexShrink: 0, background: bg, color: e == null ? T.ink3 : T.ink, fontFamily: T.mono, fontSize: 11, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center', border: `1px solid ${shadowAlpha(0.35)}` }}>
                                       {e == null ? '—' : `${e > 0 ? '+' : ''}${e.toFixed(1)}`}
                                     </div>
                                   );
@@ -2246,7 +2246,7 @@ export default function EngineManagementSandbox() {
                         </div>
                         <div style={{ fontSize: 10.5, color: T.ink3, marginBottom: 8 }}>Cells show % airflow error (blank = not visited during this pull). Rows are MAP kPa, columns RPM.</div>
                         <div style={{ display: 'flex', gap: 8 }}>
-                          <button onClick={applyHistogram} style={{ flex: 2, padding: '12px 0', borderRadius: 10, border: 'none', background: T.amber, color: '#1a0f08', fontWeight: 800, fontSize: 12.5 }}>
+                          <button onClick={applyHistogram} style={{ flex: 2, padding: '12px 0', borderRadius: 10, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 12.5 }}>
                             APPLY CORRECTIONS TO VE
                           </button>
                           <button onClick={() => setHistogram(null)} style={{ flex: 1, padding: '12px 0', borderRadius: 10, border: `1px solid ${T.line}`, background: T.panel2, color: T.ink2, fontWeight: 700, fontSize: 12.5 }}>
@@ -2263,7 +2263,7 @@ export default function EngineManagementSandbox() {
                   <>
                     <Eyebrow icon={AlertTriangle}>Pull Log</Eyebrow>
                     {result.events.length === 0 ? (
-                      <div style={{ fontSize: 12.5, color: T.green, background: T.greenBg, border: '1px solid #1f4a30', borderRadius: 10, padding: 12 }}>
+                      <div style={{ fontSize: 12.5, color: T.ok, background: T.okBg, border: `1px solid ${T.okBg}`, borderRadius: 10, padding: 12 }}>
                         Clean pull — no knock, fueling, or trim issues across the sweep.
                       </div>
                     ) : (
@@ -2272,9 +2272,9 @@ export default function EngineManagementSandbox() {
                           const isDanger = e.type === 'knock' || e.type === 'valve' || e.type === 'rich' || e.type === 'injscale' || e.type === 'float' || e.type === 'pressure';
                           const isWarn = e.type === 'lean' || e.type === 'fuel' || e.type === 'compressor' || e.type === 'cam';
                           const isViolet = e.type === 'maf';
-                          const bg = isDanger ? T.redBg : isWarn ? T.yellowBg : isViolet ? T.violetBg : T.panel2;
-                          const bd = isDanger ? '#3a2020' : isWarn ? '#3a2f16' : isViolet ? '#382a4a' : T.line;
-                          const fg = isDanger ? '#ff9d9d' : isWarn ? '#ffcf8a' : isViolet ? T.violet : T.cyan;
+                          const bg = isDanger ? T.dangerBg : isWarn ? T.warnBg : isViolet ? T.violetBg : T.panel2;
+                          const bd = isDanger ? T.dangerBg : isWarn ? T.warnBg : isViolet ? T.violetBg : T.line;
+                          const fg = isDanger ? T.dangerInk : isWarn ? T.warnInk : isViolet ? T.violet : T.cyan;
                           return (
                             <div key={i} style={{ padding: '11px 12px', borderRadius: 10, background: bg, border: `1px solid ${bd}` }}>
                               <div style={{ display: 'flex', justifyContent: 'space-between', gap: 8 }}>
@@ -2284,8 +2284,8 @@ export default function EngineManagementSandbox() {
                                 </div>
                                 {e.impact != null && <span style={{ fontSize: 11, fontFamily: T.mono, fontWeight: 800, color: fg, flexShrink: 0 }}>-{e.impact}</span>}
                               </div>
-                              {e.cause && <div style={{ fontSize: 11.5, color: '#9aa4b0', marginTop: 6, paddingLeft: 22 }}><b style={{ color: '#c3cad2' }}>Why: </b>{e.cause}</div>}
-                              {e.fix && <div style={{ fontSize: 11.5, color: '#9aa4b0', marginTop: 4, paddingLeft: 22 }}><b style={{ color: '#c3cad2' }}>Try: </b>{e.fix}</div>}
+                              {e.cause && <div style={{ fontSize: 11.5, color: T.ink2, marginTop: 6, paddingLeft: 22 }}><b style={{ color: T.inkSoft }}>Why: </b>{e.cause}</div>}
+                              {e.fix && <div style={{ fontSize: 11.5, color: T.ink2, marginTop: 4, paddingLeft: 22 }}><b style={{ color: T.inkSoft }}>Try: </b>{e.fix}</div>}
                             </div>
                           );
                         })}
@@ -2298,10 +2298,10 @@ export default function EngineManagementSandbox() {
                 {!running && dynoView === 'score' && scores && (
                       <>
                         <Eyebrow icon={Trophy}>Scorecard</Eyebrow>
-                        <Panel style={{ marginBottom: 10, background: T.amberBg, border: `1px solid ${T.amber}`, textAlign: 'center' }}>
-                          <div style={{ fontSize: 10, color: T.amberInk, letterSpacing: 1.5, fontWeight: 800 }}>PULL SCORE</div>
-                          <div style={{ fontSize: 40, fontWeight: 800, fontFamily: T.mono, color: T.amberInk, lineHeight: 1.1 }}>{scores.pull}</div>
-                          <div style={{ fontSize: 11.5, color: scores.pull >= bestScore ? T.green : T.ink2, fontWeight: 700, marginTop: 2 }}>
+                        <Panel style={{ marginBottom: 10, background: T.accBg, border: `1px solid ${T.acc}`, textAlign: 'center' }}>
+                          <div style={{ fontSize: 10, color: T.accInk, letterSpacing: 1.5, fontWeight: 800 }}>PULL SCORE</div>
+                          <div style={{ fontSize: 40, fontWeight: 800, fontFamily: T.mono, color: T.accInk, lineHeight: 1.1 }}>{scores.pull}</div>
+                          <div style={{ fontSize: 11.5, color: scores.pull >= bestScore ? T.ok : T.ink2, fontWeight: 700, marginTop: 2 }}>
                             {scores.pull >= bestScore ? 'NEW BEST' : `Best: ${bestScore}`}
                           </div>
                         </Panel>
@@ -2319,7 +2319,7 @@ export default function EngineManagementSandbox() {
                         </div>
                         <Note>Pull Score rewards actual output (peak whp + torque), scaled by how clean (Tuning) and how sound (Engineer) the build is — a big, slightly imperfect pull can still out-score a small, spotless one. It has no ceiling; every pull is a chance to beat your best.</Note>
                         {(scores.tuning.deductions.length > 0 || scores.engineer.deductions.length > 0) && (
-                          <Panel tight style={{ marginBottom: 16, fontSize: 11.5, color: '#9aa4b0', fontFamily: T.mono, lineHeight: 1.8 }}>
+                          <Panel tight style={{ marginBottom: 16, fontSize: 11.5, color: T.ink2, fontFamily: T.mono, lineHeight: 1.8 }}>
                             {scores.tuning.deductions.map((d, i) => <div key={'t' + i}>{d}</div>)}
                             {scores.engineer.deductions.map((d, i) => <div key={'e' + i}>{d}</div>)}
                           </Panel>
@@ -2351,9 +2351,9 @@ export default function EngineManagementSandbox() {
             <button key={t.id} onClick={() => changeTab(t.id)} style={{
               flex: 1, padding: '10px 0 9px', background: 'none', border: 'none', position: 'relative',
               display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4,
-              color: active ? T.amberInk : T.ink3,
+              color: active ? T.accInk : T.ink3,
             }}>
-              {active && <div style={{ position: 'absolute', top: 0, left: '30%', right: '30%', height: 2, background: T.amber, borderRadius: '0 0 2px 2px' }} />}
+              {active && <div style={{ position: 'absolute', top: 0, left: '30%', right: '30%', height: 2, background: T.acc, borderRadius: '0 0 2px 2px' }} />}
               <Icon size={17} />
               <span style={{ fontSize: 9, fontWeight: 800, letterSpacing: 0.3 }}>{t.label}</span>
             </button>

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -2004,7 +2004,7 @@ export default function EngineManagementSandbox() {
 
             <button onClick={doRun} disabled={running} style={{
               width: '100%', padding: '15px 0', borderRadius: 12, border: 'none', marginBottom: 16,
-              background: running ? T.warnBg : T.acc, color: T.accOn, fontWeight: 800, fontSize: 14.5,
+              background: running ? T.panel3 : T.acc, color: running ? T.ink2 : T.accOn, fontWeight: 800, fontSize: 14.5,
               display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, letterSpacing: 0.3,
               boxShadow: running ? 'none' : `0 6px 18px ${accAlpha(0.22)}`,
             }}>

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -32,7 +32,7 @@ import {
   deriveEngine, idealExhaustDiameter, interp2, liveStep, makeLiveState, presetById,
   simulateSweep, turbineWithCount, veRecommendations
 } from '../sim/index.js';
-import { T, accAlpha, heat, shadowAlpha, statusColor } from './theme.js';
+import { T, accAlpha, deltaHeat, heat, shadowAlpha, statusColor } from './theme.js';
 import { BUILD_VERSION } from '../version.js';
 import { loadCareer, saveCareer } from '../storage.js';
 
@@ -51,7 +51,7 @@ const Panel = ({ children, style, tight }) => (
 );
 
 const Note = ({ children, tone = 'info' }) => {
-  const colors = { info: [T.ink2, T.line, T.panel2], warn: [T.warn, T.warnBg, T.warnBg] };
+  const colors = { info: [T.ink2, T.line, T.panel2], warn: [T.warn, T.warnLine, T.warnBg] };
   const [fg, bd, bgc] = colors[tone] || colors.info;
   return (
     <div style={{ display: 'flex', gap: 9, background: bgc, border: `1px solid ${bd}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12.5, color: fg === T.ink2 ? T.inkSoft : fg, lineHeight: 1.55 }}>
@@ -1526,7 +1526,7 @@ export default function EngineManagementSandbox() {
                     <b style={{ color: T.accInk }}>This replaces your current tune.</b> Loading {presetPrompt.name} overwrites your VE, spark and fuel tables with its factory calibration. Your career stats are kept.
                   </div>
                   <div style={{ display: 'flex', gap: 7 }}>
-                    <button onClick={() => applyEnginePreset(presetPrompt)} style={{ flex: 1, padding: '10px 0', borderRadius: 8, border: 'none', background: T.acc, color: T.accBg, fontWeight: 800, fontSize: 12 }}>
+                    <button onClick={() => applyEnginePreset(presetPrompt)} style={{ flex: 1, padding: '10px 0', borderRadius: 8, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 12 }}>
                       LOAD {presetPrompt.name.toUpperCase()}
                     </button>
                     <button onClick={() => setPresetPrompt(null)} style={{ flex: 1, padding: '10px 0', borderRadius: 8, border: `1px solid ${T.line}`, background: T.panel, color: T.ink2, fontWeight: 700, fontSize: 12 }}>
@@ -1625,7 +1625,7 @@ export default function EngineManagementSandbox() {
                 {Object.keys(MOD_INFO).map((key) => (
                   <button key={key} onClick={() => installMod(key)} disabled={mods[key]} style={{
                     textAlign: 'left', padding: '11px 13px', borderRadius: 10,
-                    border: `1px solid ${mods[key] ? T.okBg : T.line}`,
+                    border: `1px solid ${mods[key] ? T.okLine : T.line}`,
                     background: mods[key] ? T.okBg : T.panel2,
                   }}>
                     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
@@ -1801,7 +1801,7 @@ export default function EngineManagementSandbox() {
 
               {veAdvice && (
                 veAdvice.inSync ? (
-                  <div style={{ display: 'flex', gap: 8, background: T.okBg, border: `1px solid ${T.okBg}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12.5, color: T.ok, lineHeight: 1.5 }}>
+                  <div style={{ display: 'flex', gap: 8, background: T.okBg, border: `1px solid ${T.okLine}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12.5, color: T.ok, lineHeight: 1.5 }}>
                     <Info size={15} style={{ flexShrink: 0, marginTop: 1 }} />
                     <div>VE table matches your current hardware. Nothing to correct.</div>
                   </div>
@@ -1846,7 +1846,7 @@ export default function EngineManagementSandbox() {
               <div style={{ fontSize: 12.5, color: T.ink2, marginBottom: 12 }}>Degrees of spark advance before top dead center (° BTDC).</div>
               <TuningGrid data={timing} min={SPARK_MIN_DEG} max={SPARK_MAX_DEG} decimals={0} {...gridProps} />
               {calAdvice.overAdvanced.length > 0 ? (
-                <div style={{ background: T.dangerBg, border: `1px solid ${T.dangerBg}`, borderRadius: 10, padding: '12px 13px', margin: '10px 0' }}>
+                <div style={{ background: T.dangerBg, border: `1px solid ${T.dangerLine}`, borderRadius: 10, padding: '12px 13px', margin: '10px 0' }}>
                   <div style={{ fontSize: 10, letterSpacing: 1, color: T.dangerInk, fontWeight: 800, marginBottom: 7 }}>
                     {calAdvice.overAdvanced.length} CELLS BEYOND THE KNOCK LIMIT
                   </div>
@@ -1870,7 +1870,7 @@ export default function EngineManagementSandbox() {
                   <b style={{ color: T.accInk }}>Past peak torque.</b> {calAdvice.pastMbt.length} cells command more advance than the burn can use — the charge is already finishing where it should, so the extra degrees are working against the piston on its way up rather than adding torque. Not dangerous here — these cells are inside the knock limit — but pulling them back gains a little power and buys margin.
                 </div>
               ) : (
-                <div style={{ background: T.okBg, border: `1px solid ${T.okBg}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12.5, color: T.ok }}>
+                <div style={{ background: T.okBg, border: `1px solid ${T.okLine}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12.5, color: T.ok }}>
                   Spark table sits within the knock limit for this hardware.
                 </div>
               )}
@@ -1947,7 +1947,7 @@ export default function EngineManagementSandbox() {
             </div>
             <Seg options={INJECTOR_OPTS.map((o) => ({ label: `${o.cc}`, value: o.cc }))} value={ecuInjectorCc} onChange={setEcuInjectorCcInvalidating} wrap />
             {ecuInjectorCc !== injectorCc ? (
-              <div style={{ background: T.dangerBg, border: `1px solid ${T.dangerBg}`, borderRadius: 10, padding: '11px 13px', margin: '8px 0', fontSize: 12, color: T.dangerInk, lineHeight: 1.5 }}>
+              <div style={{ background: T.dangerBg, border: `1px solid ${T.dangerLine}`, borderRadius: 10, padding: '11px 13px', margin: '8px 0', fontSize: 12, color: T.dangerInk, lineHeight: 1.5 }}>
                 <b>Scaling mismatch.</b> Hardware is {injectorCc}cc but the ECU is calibrated for {ecuInjectorCc}cc — every pulse delivers about {((injectorCc / ecuInjectorCc) * 100).toFixed(0)}% of the intended fuel, so the engine runs {injectorCc > ecuInjectorCc ? 'far too rich' : 'dangerously lean'} everywhere.
                 <button onClick={() => setEcuInjectorCcInvalidating(injectorCc)} style={{ display: 'block', width: '100%', marginTop: 9, padding: '10px 0', borderRadius: 8, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 12.5 }}>
                   RESCALE ECU TO {injectorCc}cc
@@ -2232,8 +2232,7 @@ export default function EngineManagementSandbox() {
                                 <div style={{ width: 44, height: 32, flexShrink: 0, background: T.panel, color: T.ink2, fontFamily: T.mono, fontSize: 9.5, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center', borderTop: `1px solid ${T.line}` }}>{m}</div>
                                 {RPM.map((_, ci) => {
                                   const e = histogram[ri][ci];
-                                  const mag = e == null ? 0 : Math.min(1, Math.abs(e) / 12);
-                                  const bg = e == null ? T.panel2 : `hsl(${e > 0 ? 8 : 200}, 60%, ${14 + mag * 22}%)`;
+                                  const bg = e == null ? T.panel2 : deltaHeat(e);
                                   return (
                                     <div key={ci} style={{ width: 51, height: 32, flexShrink: 0, background: bg, color: e == null ? T.ink3 : T.ink, fontFamily: T.mono, fontSize: 11, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center', border: `1px solid ${shadowAlpha(0.35)}` }}>
                                       {e == null ? '—' : `${e > 0 ? '+' : ''}${e.toFixed(1)}`}
@@ -2263,7 +2262,7 @@ export default function EngineManagementSandbox() {
                   <>
                     <Eyebrow icon={AlertTriangle}>Pull Log</Eyebrow>
                     {result.events.length === 0 ? (
-                      <div style={{ fontSize: 12.5, color: T.ok, background: T.okBg, border: `1px solid ${T.okBg}`, borderRadius: 10, padding: 12 }}>
+                      <div style={{ fontSize: 12.5, color: T.ok, background: T.okBg, border: `1px solid ${T.okLine}`, borderRadius: 10, padding: 12 }}>
                         Clean pull — no knock, fueling, or trim issues across the sweep.
                       </div>
                     ) : (
@@ -2273,7 +2272,7 @@ export default function EngineManagementSandbox() {
                           const isWarn = e.type === 'lean' || e.type === 'fuel' || e.type === 'compressor' || e.type === 'cam';
                           const isViolet = e.type === 'maf';
                           const bg = isDanger ? T.dangerBg : isWarn ? T.warnBg : isViolet ? T.violetBg : T.panel2;
-                          const bd = isDanger ? T.dangerBg : isWarn ? T.warnBg : isViolet ? T.violetBg : T.line;
+                          const bd = isDanger ? T.dangerLine : isWarn ? T.warnLine : isViolet ? T.violetLine : T.line;
                           const fg = isDanger ? T.dangerInk : isWarn ? T.warnInk : isViolet ? T.violet : T.cyan;
                           return (
                             <div key={i} style={{ padding: '11px 12px', borderRadius: 10, background: bg, border: `1px solid ${bd}` }}>

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -35,6 +35,8 @@ import {
 import { T, accAlpha, deltaHeat, heat, shadowAlpha, statusColor } from './theme.js';
 import { BUILD_VERSION } from '../version.js';
 import { loadCareer, saveCareer } from '../storage.js';
+import { StartScreen } from './screens/StartScreen.jsx';
+import { TutorialScreen } from './screens/TutorialScreen.jsx';
 
 const Eyebrow = ({ children, icon: Icon }) => (
   <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
@@ -484,58 +486,6 @@ const TUTORIAL_STEPS = [
   { title: 'Chase the score',
     body: 'Every pull grades Tuning (how clean the calibration is) and Engineer (how sound the hardware choices are), then combines them with actual output into an uncapped Pull Score. A big, slightly dirty pull can beat a small spotless one — the same tension a real tuner balances.' },
 ];
-
-function TutorialScreen({ onDone }) {
-  const [step, setStep] = useState(0);
-  const s = TUTORIAL_STEPS[step];
-  const last = step === TUTORIAL_STEPS.length - 1;
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100dvh', background: T.bg, color: T.ink, fontFamily: T.sans }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '14px 16px' }}>
-        <div style={{ fontSize: 10.5, letterSpacing: 1.5, color: T.accInk, fontWeight: 800 }}>TUTORIAL · {step + 1}/{TUTORIAL_STEPS.length}</div>
-        <button onClick={onDone} style={{ background: 'none', border: 'none', color: T.ink3, fontSize: 12, fontWeight: 700 }}>SKIP</button>
-      </div>
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'center', padding: '0 24px' }}>
-        <div style={{ fontSize: 21, fontWeight: 800, marginBottom: 13, letterSpacing: -0.3 }}>{s.title}</div>
-        <div style={{ fontSize: 14.5, color: T.inkSoft, lineHeight: 1.7 }}>{s.body}</div>
-      </div>
-      <div style={{ display: 'flex', gap: 6, justifyContent: 'center', padding: '0 0 18px' }}>
-        {TUTORIAL_STEPS.map((_, i) => (
-          <div key={i} style={{ width: i === step ? 20 : 6, height: 6, borderRadius: 3, background: i === step ? T.acc : T.line, transition: 'width .2s' }} />
-        ))}
-      </div>
-      <div style={{ display: 'flex', gap: 10, padding: '0 16px', paddingBottom: 'calc(16px + env(safe-area-inset-bottom))' }}>
-        {step > 0 && (
-          <button onClick={() => setStep((v) => v - 1)} style={{ flex: 1, padding: '15px 0', borderRadius: 12, border: `1px solid ${T.line}`, background: T.panel2, color: T.inkSoft, fontWeight: 700, fontSize: 14 }}>BACK</button>
-        )}
-        <button onClick={() => (last ? onDone() : setStep((v) => v + 1))} style={{ flex: 2, padding: '15px 0', borderRadius: 12, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 14.5 }}>
-          {last ? 'START TUNING' : 'NEXT'}
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function StartScreen({ onStart, onTutorial }) {
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', height: '100dvh', background: T.bg, color: T.ink, fontFamily: T.sans, justifyContent: 'center', alignItems: 'center', padding: 24, textAlign: 'center', position: 'relative', overflow: 'hidden' }}>
-      <div style={{ position: 'absolute', top: '-15%', left: '50%', transform: 'translateX(-50%)', width: 420, height: 420, borderRadius: '50%', background: `radial-gradient(circle, ${accAlpha(0.10)} 0%, transparent 70%)` }} />
-      <div style={{ marginBottom: 22, position: 'relative' }}><DialMark size={92} pct={0.62} /></div>
-      <div style={{ fontSize: 11, letterSpacing: 3, color: T.accInk, fontWeight: 800, marginBottom: 7 }}>CARIBOU TUNING</div>
-      <div style={{ fontSize: 25, fontWeight: 800, textTransform: 'uppercase', letterSpacing: 0.3, marginBottom: 15, maxWidth: 320 }}>Engine Management Sandbox</div>
-      <div style={{ fontSize: 13.5, color: T.ink2, lineHeight: 1.65, maxWidth: 300, marginBottom: 34 }}>
-        Design an engine. Tune it. Log it. Improve it. A free-tune sandbox built to teach real engine management, not just move sliders.
-      </div>
-      <button onClick={onStart} style={{ width: '100%', maxWidth: 300, padding: '16px 0', borderRadius: 12, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 15, letterSpacing: 0.4, marginBottom: 12, boxShadow: `0 8px 24px ${accAlpha(0.25)}` }}>
-        START
-      </button>
-      <button onClick={onTutorial} style={{ width: '100%', maxWidth: 300, padding: '15px 0', borderRadius: 12, border: `1px solid ${T.line}`, background: 'none', color: T.inkSoft, fontWeight: 700, fontSize: 13.5 }}>
-        TUTORIAL
-      </button>
-      <div style={{ fontSize: 10.5, color: T.ink3, marginTop: 18, fontFamily: T.mono }}>{BUILD_VERSION}</div>
-    </div>
-  );
-}
 
 function LiveGauge({ label, value, unit, color = T.ink, warn }) {
   return (
@@ -1161,8 +1111,24 @@ export default function EngineManagementSandbox() {
   ];
   const gridProps = { selection, setSelection };
 
-  if (appView === 'start') return <StartScreen onStart={() => { setAppView('app'); setTab('build'); }} onTutorial={() => setAppView('tutorial')} />;
-  if (appView === 'tutorial') return <TutorialScreen onDone={() => { setAppView('app'); setTab('build'); setJourneyStep(0); }} />;
+  if (appView === 'start') {
+    return (
+      <StartScreen
+        onStart={() => { setAppView('app'); setTab('build'); }}
+        onTutorial={() => setAppView('tutorial')}
+        version={BUILD_VERSION}
+        dial={<DialMark size={92} pct={0.62} />}
+      />
+    );
+  }
+  if (appView === 'tutorial') {
+    return (
+      <TutorialScreen
+        steps={TUTORIAL_STEPS}
+        onDone={() => { setAppView('app'); setTab('build'); setJourneyStep(0); }}
+      />
+    );
+  }
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100dvh', maxHeight: '100dvh', background: T.bg, color: T.ink, fontFamily: T.sans, overflow: 'hidden' }}>

--- a/src/ui/ErrorBoundary.jsx
+++ b/src/ui/ErrorBoundary.jsx
@@ -36,7 +36,7 @@ export class ErrorBoundary extends React.Component {
         display: 'flex', flexDirection: 'column', justifyContent: 'center',
         padding: 24, gap: 14,
       }}>
-        <div style={{ fontSize: 10.5, letterSpacing: 2, color: T.amberInk, fontWeight: 800 }}>
+        <div style={{ fontSize: 10.5, letterSpacing: 2, color: T.accInk, fontWeight: 800 }}>
           CARIBOU TUNING · ECU LAB
         </div>
         <div style={{ fontSize: 21, fontWeight: 800 }}>Something broke.</div>
@@ -47,7 +47,7 @@ export class ErrorBoundary extends React.Component {
         </div>
         <pre style={{
           background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 10,
-          padding: '12px 14px', fontSize: 11.5, fontFamily: T.mono, color: '#ff9d9d',
+          padding: '12px 14px', fontSize: 11.5, fontFamily: T.mono, color: T.dangerInk,
           overflowX: 'auto', whiteSpace: 'pre-wrap', wordBreak: 'break-word', margin: 0,
         }}>
           {String(error?.stack || error?.message || error)}
@@ -57,8 +57,8 @@ export class ErrorBoundary extends React.Component {
             type="button"
             onClick={() => this.setState({ error: null })}
             style={{
-              padding: '13px 22px', borderRadius: 11, border: 'none', background: T.amber,
-              color: '#1a0f08', fontWeight: 800, fontSize: 13.5,
+              padding: '13px 22px', borderRadius: 11, border: 'none', background: T.acc,
+              color: T.accOn, fontWeight: 800, fontSize: 13.5,
             }}
           >
             TRY AGAIN
@@ -68,7 +68,7 @@ export class ErrorBoundary extends React.Component {
             onClick={() => window.location.reload()}
             style={{
               padding: '13px 22px', borderRadius: 11, border: `1px solid ${T.line}`,
-              background: T.panel2, color: '#c3cad2', fontWeight: 700, fontSize: 13.5,
+              background: T.panel2, color: T.inkSoft, fontWeight: 700, fontSize: 13.5,
             }}
           >
             RELOAD

--- a/src/ui/primitives/Bar.jsx
+++ b/src/ui/primitives/Bar.jsx
@@ -3,16 +3,19 @@
  *
  * Those two use cases run in opposite directions: high component health is good,
  * but high injector duty is the dangerous end. `higherIsBetter` is how a caller
- * says which way this particular value reads.
+ * says which way this particular value reads. Each direction has its own colour
+ * scale rather than one mirrored around the other — `statusColor` for health,
+ * `utilisationColor` for how much of a capacity is spent — because they are
+ * different judgements about different quantities, not reflections of each other.
  *
- * The fill colour comes from `statusColor`, so it is a STATUS, never decoration.
- * Do not use this for a value that has no good/bad reading.
+ * The fill colour comes from one of those two scales, so it is a STATUS, never
+ * decoration. Do not use this for a value that has no good/bad reading.
  */
 
 import React from 'react';
 
 import { clamp } from '../../sim/index.js';
-import { statusColor } from '../theme.js';
+import { statusColor, utilisationColor } from '../theme.js';
 
 import styles from './Bar.module.css';
 
@@ -28,9 +31,7 @@ import styles from './Bar.module.css';
 export function Bar({ label, value, max = 100, higherIsBetter = true }) {
   const pct = clamp((value / max) * 100, 0, 100);
   const shown = clamp(value, 0, max);
-  // Mirror the percentage through the one status scale rather than adding a
-  // second set of thresholds that could drift from statusColor's.
-  const tone = higherIsBetter ? statusColor(pct) : statusColor(100 - pct);
+  const tone = higherIsBetter ? statusColor(pct) : utilisationColor(pct);
   return (
     <div className={styles.wrap}>
       <div className={styles.label}>

--- a/src/ui/primitives/Bar.jsx
+++ b/src/ui/primitives/Bar.jsx
@@ -1,0 +1,48 @@
+/**
+ * A horizontal meter for a 0-max quantity: component health, injector duty.
+ *
+ * The fill colour comes from `statusColor`, so it is a STATUS, never decoration.
+ * Do not use this for a value that has no good/bad reading.
+ */
+
+import React from 'react';
+
+import { clamp } from '../../sim/index.js';
+import { statusColor } from '../theme.js';
+
+import styles from './Bar.module.css';
+
+/**
+ * @param {object} props
+ * @param {string} props.label
+ * @param {number} props.value
+ * @param {number} [props.max]
+ * @returns {React.ReactElement}
+ */
+export function Bar({ label, value, max = 100 }) {
+  const pct = clamp((value / max) * 100, 0, 100);
+  return (
+    <div className={styles.wrap}>
+      <div className={styles.label}>
+        <span>{label}</span>
+        <span className={styles.pct} style={{ color: statusColor(pct) }}>
+          {Math.round(pct)}%
+        </span>
+      </div>
+      <div
+        className={styles.track}
+        role="meter"
+        aria-label={label}
+        aria-valuenow={value}
+        aria-valuemin={0}
+        aria-valuemax={max}
+      >
+        <div
+          data-fill=""
+          className={styles.fill}
+          style={{ width: `${pct}%`, background: statusColor(pct) }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/ui/primitives/Bar.jsx
+++ b/src/ui/primitives/Bar.jsx
@@ -1,6 +1,10 @@
 /**
  * A horizontal meter for a 0-max quantity: component health, injector duty.
  *
+ * Those two use cases run in opposite directions: high component health is good,
+ * but high injector duty is the dangerous end. `higherIsBetter` is how a caller
+ * says which way this particular value reads.
+ *
  * The fill colour comes from `statusColor`, so it is a STATUS, never decoration.
  * Do not use this for a value that has no good/bad reading.
  */
@@ -17,15 +21,21 @@ import styles from './Bar.module.css';
  * @param {string} props.label
  * @param {number} props.value
  * @param {number} [props.max]
+ * @param {boolean} [props.higherIsBetter] true when a high value is healthy
+ *   (component wear); false when a high value is the dangerous end (injector duty cycle)
  * @returns {React.ReactElement}
  */
-export function Bar({ label, value, max = 100 }) {
+export function Bar({ label, value, max = 100, higherIsBetter = true }) {
   const pct = clamp((value / max) * 100, 0, 100);
+  const shown = clamp(value, 0, max);
+  // Mirror the percentage through the one status scale rather than adding a
+  // second set of thresholds that could drift from statusColor's.
+  const tone = higherIsBetter ? statusColor(pct) : statusColor(100 - pct);
   return (
     <div className={styles.wrap}>
       <div className={styles.label}>
         <span>{label}</span>
-        <span className={styles.pct} style={{ color: statusColor(pct) }}>
+        <span className={styles.pct} style={{ color: tone }}>
           {Math.round(pct)}%
         </span>
       </div>
@@ -33,14 +43,14 @@ export function Bar({ label, value, max = 100 }) {
         className={styles.track}
         role="meter"
         aria-label={label}
-        aria-valuenow={value}
+        aria-valuenow={shown}
         aria-valuemin={0}
         aria-valuemax={max}
       >
         <div
           data-fill=""
           className={styles.fill}
-          style={{ width: `${pct}%`, background: statusColor(pct) }}
+          style={{ width: `${pct}%`, background: tone }}
         />
       </div>
     </div>

--- a/src/ui/primitives/Bar.module.css
+++ b/src/ui/primitives/Bar.module.css
@@ -3,7 +3,7 @@
 .label {
   display: flex;
   justify-content: space-between;
-  font-size: 9.5px;
+  font-size: var(--fs-micro);
   color: var(--ink2);
   margin-bottom: 4px;
 }
@@ -12,7 +12,7 @@
 
 .track {
   height: 5px;
-  border-radius: 3px;
+  border-radius: var(--r-xs);
   background: var(--panel3);
   overflow: hidden;
 }

--- a/src/ui/primitives/Bar.module.css
+++ b/src/ui/primitives/Bar.module.css
@@ -1,0 +1,20 @@
+.wrap { font-family: var(--sans); }
+
+.label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 9.5px;
+  color: var(--ink2);
+  margin-bottom: 4px;
+}
+
+.pct { font-family: var(--mono); font-weight: 700; }
+
+.track {
+  height: 5px;
+  border-radius: 3px;
+  background: var(--panel3);
+  overflow: hidden;
+}
+
+.fill { height: 100%; transition: width 0.4s ease; }

--- a/src/ui/primitives/Button.jsx
+++ b/src/ui/primitives/Button.jsx
@@ -8,6 +8,9 @@
  *
  * `danger` is for destructive actions only. It is not an emphasis variant; the
  * status colours mean engine state and must not be spent on decoration.
+ *
+ * `quiet` is for escape hatches — actions like SKIP that must be reachable but must
+ * not compete with the screen's primary action. Text-only, no fill or border.
  */
 
 import React from 'react';
@@ -17,7 +20,7 @@ import styles from './Button.module.css';
 /**
  * @typedef {Object} ButtonProps
  * @property {React.ReactNode} children
- * @property {'primary'|'ghost'|'danger'} [variant='primary']
+ * @property {'primary'|'ghost'|'danger'|'quiet'} [variant='primary']
  * @property {'sm'|'md'|'lg'} [size='md']
  * @property {boolean} [block=false] - stretch to the full width of the container
  * @property {'button'|'submit'|'reset'} [type='button']

--- a/src/ui/primitives/Button.jsx
+++ b/src/ui/primitives/Button.jsx
@@ -1,0 +1,47 @@
+/**
+ * The app's only button.
+ *
+ * Content-width by default. The pre-overhaul UI set `width: '100%'` on every
+ * call-to-action, which is why a primary action spanned the whole window on a
+ * desktop monitor — so full-width is opt-in via `block`, and worth justifying each
+ * time you reach for it.
+ *
+ * `danger` is for destructive actions only. It is not an emphasis variant; the
+ * status colours mean engine state and must not be spent on decoration.
+ */
+
+import React from 'react';
+
+import styles from './Button.module.css';
+
+/**
+ * @typedef {Object} ButtonProps
+ * @property {React.ReactNode} children
+ * @property {'primary'|'ghost'|'danger'} [variant='primary']
+ * @property {'sm'|'md'|'lg'} [size='md']
+ * @property {boolean} [block=false] - stretch to the full width of the container
+ * @property {'button'|'submit'|'reset'} [type='button']
+ */
+
+/**
+ * @param {ButtonProps & React.ButtonHTMLAttributes<HTMLButtonElement>} props
+ * @returns {React.ReactElement}
+ */
+export function Button({
+  children,
+  variant = 'primary',
+  size = 'md',
+  block = false,
+  type = 'button',
+  ...rest
+}) {
+  const className = [styles.button, styles[variant], styles[size], block && styles.block]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button type={type} className={className} {...rest}>
+      {children}
+    </button>
+  );
+}

--- a/src/ui/primitives/Button.module.css
+++ b/src/ui/primitives/Button.module.css
@@ -6,7 +6,7 @@
   justify-content: center;
   gap: 7px;
   border: 1px solid transparent;
-  border-radius: 8px;
+  border-radius: var(--r-md);
   font-family: var(--sans);
   font-weight: 800;
   letter-spacing: 0.05em;
@@ -63,9 +63,12 @@
 
 /* --- sizes --- */
 
-.sm { padding: 6px 11px; font-size: 10px; }
-.md { padding: 9px 16px; font-size: 11.5px; }
-.lg { padding: 13px 22px; font-size: 13.5px; }
+.sm { padding: var(--sp-sm) var(--sp-md); font-size: var(--fs-xs); }
+.md { padding: var(--sp-md) var(--sp-xl); font-size: var(--fs-sm); }
+/* 22px horizontal is not on the spacing scale: it is 2px from the nearest
+   step (--sp-xxl, 24px), further than the ~1px this pass snaps, and moving it
+   would visibly change the button's proportions. Left raw. */
+.lg { padding: var(--sp-lg) 22px; font-size: var(--fs-base); }
 
 /* --- full width, opt-in only --- */
 

--- a/src/ui/primitives/Button.module.css
+++ b/src/ui/primitives/Button.module.css
@@ -44,6 +44,8 @@
 }
 
 /* Reserved for genuinely destructive actions, never for emphasis. */
+/* Keeps the saturated hue rather than --danger-line: a destructive control is
+   deliberately louder than a status box, which only reports. */
 .danger {
   background: var(--danger-bg);
   border-color: var(--danger);

--- a/src/ui/primitives/Button.module.css
+++ b/src/ui/primitives/Button.module.css
@@ -1,0 +1,62 @@
+/* Content-width by default. `block` is opt-in — see Button.jsx. */
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  font-family: var(--sans);
+  font-weight: 800;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background-color 0.14s ease, border-color 0.14s ease, color 0.14s ease;
+}
+
+.button:focus-visible {
+  outline: 2px solid var(--acc);
+  outline-offset: 2px;
+}
+
+.button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+/* --- variants --- */
+
+.primary {
+  background: var(--acc);
+  color: var(--acc-on);
+}
+.primary:hover:not(:disabled) { background: var(--acc-ink); }
+
+.ghost {
+  background: transparent;
+  border-color: var(--line);
+  color: var(--ink2);
+}
+.ghost:hover:not(:disabled) {
+  border-color: var(--line-hi);
+  color: var(--ink);
+}
+
+/* Reserved for genuinely destructive actions, never for emphasis. */
+.danger {
+  background: var(--danger-bg);
+  border-color: var(--danger);
+  color: var(--danger-ink);
+}
+.danger:hover:not(:disabled) { background: var(--danger); color: var(--bg); }
+
+/* --- sizes --- */
+
+.sm { padding: 6px 11px; font-size: 10px; }
+.md { padding: 9px 16px; font-size: 11.5px; }
+.lg { padding: 13px 22px; font-size: 13.5px; }
+
+/* --- full width, opt-in only --- */
+
+.block { display: flex; width: 100%; }

--- a/src/ui/primitives/Button.module.css
+++ b/src/ui/primitives/Button.module.css
@@ -51,6 +51,14 @@
 }
 .danger:hover:not(:disabled) { background: var(--danger); color: var(--bg); }
 
+/* Text-only, for escape hatches that must not compete with the primary action. */
+.quiet {
+  background: transparent;
+  border-color: transparent;
+  color: var(--ink3);
+}
+.quiet:hover:not(:disabled) { color: var(--ink2); }
+
 /* --- sizes --- */
 
 .sm { padding: 6px 11px; font-size: 10px; }

--- a/src/ui/primitives/Eyebrow.jsx
+++ b/src/ui/primitives/Eyebrow.jsx
@@ -1,0 +1,21 @@
+/** Small uppercase section label with an accent rule. Labels a group; never a status. */
+
+import React from 'react';
+
+import styles from './Eyebrow.module.css';
+
+/**
+ * @param {object} props
+ * @param {React.ReactNode} props.children
+ * @param {React.ElementType} [props.icon] optional Lucide icon component
+ * @returns {React.ReactElement}
+ */
+export function Eyebrow({ children, icon: Icon }) {
+  return (
+    <div className={styles.eyebrow}>
+      <span className={styles.rule} />
+      {Icon && <Icon size={13} />}
+      <span>{children}</span>
+    </div>
+  );
+}

--- a/src/ui/primitives/Eyebrow.module.css
+++ b/src/ui/primitives/Eyebrow.module.css
@@ -1,0 +1,19 @@
+.eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+  font-family: var(--sans);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--acc-ink);
+}
+
+.rule {
+  width: 3px;
+  height: 13px;
+  border-radius: 2px;
+  background: var(--acc);
+}

--- a/src/ui/primitives/Eyebrow.module.css
+++ b/src/ui/primitives/Eyebrow.module.css
@@ -4,7 +4,7 @@
   gap: 6px;
   margin-bottom: 8px;
   font-family: var(--sans);
-  font-size: 10.5px;
+  font-size: var(--fs-xs);
   font-weight: 800;
   letter-spacing: 0.15em;
   text-transform: uppercase;
@@ -14,6 +14,6 @@
 .rule {
   width: 3px;
   height: 13px;
-  border-radius: 2px;
+  border-radius: var(--r-xs);
   background: var(--acc);
 }

--- a/src/ui/primitives/Note.jsx
+++ b/src/ui/primitives/Note.jsx
@@ -1,0 +1,27 @@
+/**
+ * An inline explanatory box.
+ *
+ * `warn` and `danger` carry engine meaning, so they are not emphasis levels — do not
+ * reach for `danger` to make a paragraph louder.
+ */
+
+import { Info } from 'lucide-react';
+import React from 'react';
+
+import styles from './Note.module.css';
+
+/**
+ * @param {object} props
+ * @param {React.ReactNode} props.children
+ * @param {'info'|'warn'|'danger'} [props.tone]
+ * @returns {React.ReactElement}
+ */
+export function Note({ children, tone = 'info' }) {
+  const className = [styles.note, styles[tone] ?? styles.info].join(' ');
+  return (
+    <div className={className} role={tone === 'danger' ? 'alert' : 'note'}>
+      <Info size={15} className={styles.icon} aria-hidden="true" />
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/src/ui/primitives/Note.module.css
+++ b/src/ui/primitives/Note.module.css
@@ -13,5 +13,5 @@
 .icon { flex-shrink: 0; margin-top: 1px; }
 
 .info { background: var(--panel2); border-color: var(--line); color: var(--ink-soft); }
-.warn { background: var(--warn-bg); border-color: var(--warn); color: var(--warn-ink); }
-.danger { background: var(--danger-bg); border-color: var(--danger); color: var(--danger-ink); }
+.warn { background: var(--warn-bg); border-color: var(--warn-line); color: var(--warn-ink); }
+.danger { background: var(--danger-bg); border-color: var(--danger-line); color: var(--danger-ink); }

--- a/src/ui/primitives/Note.module.css
+++ b/src/ui/primitives/Note.module.css
@@ -2,11 +2,11 @@
   display: flex;
   gap: 9px;
   margin: 10px 0;
-  padding: 11px 13px;
+  padding: var(--sp-md) var(--sp-lg);
   border: 1px solid;
-  border-radius: 10px;
+  border-radius: var(--r-md);
   font-family: var(--sans);
-  font-size: 12.5px;
+  font-size: var(--fs-sm);
   line-height: 1.55;
 }
 

--- a/src/ui/primitives/Note.module.css
+++ b/src/ui/primitives/Note.module.css
@@ -1,0 +1,17 @@
+.note {
+  display: flex;
+  gap: 9px;
+  margin: 10px 0;
+  padding: 11px 13px;
+  border: 1px solid;
+  border-radius: 10px;
+  font-family: var(--sans);
+  font-size: 12.5px;
+  line-height: 1.55;
+}
+
+.icon { flex-shrink: 0; margin-top: 1px; }
+
+.info { background: var(--panel2); border-color: var(--line); color: var(--ink-soft); }
+.warn { background: var(--warn-bg); border-color: var(--warn); color: var(--warn-ink); }
+.danger { background: var(--danger-bg); border-color: var(--danger); color: var(--danger-ink); }

--- a/src/ui/primitives/Panel.jsx
+++ b/src/ui/primitives/Panel.jsx
@@ -1,0 +1,17 @@
+/** A bordered surface. The app's default container for a group of related controls. */
+
+import React from 'react';
+
+import styles from './Panel.module.css';
+
+/**
+ * @param {object} props
+ * @param {React.ReactNode} props.children
+ * @param {boolean} [props.tight] reduce the padding
+ * @param {React.ElementType} [props.as] element to render, defaults to a div
+ * @returns {React.ReactElement}
+ */
+export function Panel({ children, tight = false, as: As = 'div', ...rest }) {
+  const className = [styles.panel, tight && styles.tight].filter(Boolean).join(' ');
+  return <As className={className} {...rest}>{children}</As>;
+}

--- a/src/ui/primitives/Panel.module.css
+++ b/src/ui/primitives/Panel.module.css
@@ -1,0 +1,8 @@
+.panel {
+  background: var(--panel2);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  padding: 14px;
+}
+
+.tight { padding: 10px 12px; }

--- a/src/ui/primitives/Panel.module.css
+++ b/src/ui/primitives/Panel.module.css
@@ -1,8 +1,8 @@
 .panel {
   background: var(--panel2);
   border: 1px solid var(--line);
-  border-radius: 12px;
-  padding: 14px;
+  border-radius: var(--r-lg);
+  padding: var(--sp-lg);
 }
 
-.tight { padding: 10px 12px; }
+.tight { padding: var(--sp-md) var(--sp-lg); }

--- a/src/ui/primitives/Seg.jsx
+++ b/src/ui/primitives/Seg.jsx
@@ -3,6 +3,12 @@
  *
  * Plain buttons carrying `aria-pressed` rather than a radio group, because these
  * switch a view rather than submit a value.
+ *
+ * `equal` exists because the legacy `Seg` in EcuLab.jsx laid every option out at
+ * flex:1 (equal width), and its busiest call site — the 6-option injector-size
+ * picker — leans on exactly that so a wide picker reads as one even row rather
+ * than a ragged content-width wrap. A few-option picker still looks better
+ * sitting inline at its content width, which is why `equal` defaults to off.
  */
 
 import React from 'react';
@@ -15,11 +21,18 @@ import styles from './Seg.module.css';
  * @param {Array<{id: string, label: string, icon?: React.ElementType}>} props.options
  * @param {string} props.value id of the selected option
  * @param {(id: string) => void} props.onChange
+ * @param {boolean} [props.equal] lay options out at equal width, wrapping as needed,
+ *   instead of the default content-width row. For pickers with enough options that
+ *   an inline row would crowd or wrap raggedly (e.g. injector sizes).
  * @returns {React.ReactElement}
  */
-export function Seg({ label, options, value, onChange }) {
+export function Seg({ label, options, value, onChange, equal = false }) {
   return (
-    <div className={styles.seg} role="group" aria-label={label}>
+    <div
+      className={equal ? `${styles.seg} ${styles.equal}` : styles.seg}
+      role="group"
+      aria-label={label}
+    >
       {options.map(({ id, label: text, icon: Icon }) => (
         <button
           key={id}

--- a/src/ui/primitives/Seg.jsx
+++ b/src/ui/primitives/Seg.jsx
@@ -1,0 +1,37 @@
+/**
+ * A segmented control: pick exactly one of a small set.
+ *
+ * Plain buttons carrying `aria-pressed` rather than a radio group, because these
+ * switch a view rather than submit a value.
+ */
+
+import React from 'react';
+
+import styles from './Seg.module.css';
+
+/**
+ * @param {object} props
+ * @param {string} props.label accessible name for the group
+ * @param {Array<{id: string, label: string, icon?: React.ElementType}>} props.options
+ * @param {string} props.value id of the selected option
+ * @param {(id: string) => void} props.onChange
+ * @returns {React.ReactElement}
+ */
+export function Seg({ label, options, value, onChange }) {
+  return (
+    <div className={styles.seg} role="group" aria-label={label}>
+      {options.map(({ id, label: text, icon: Icon }) => (
+        <button
+          key={id}
+          type="button"
+          className={styles.item}
+          aria-pressed={id === value}
+          onClick={() => onChange(id)}
+        >
+          {Icon && <Icon size={13} aria-hidden="true" />}
+          {text}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/ui/primitives/Seg.module.css
+++ b/src/ui/primitives/Seg.module.css
@@ -2,23 +2,23 @@
   display: inline-flex;
   flex-wrap: wrap;
   gap: 4px;
-  padding: 3px;
+  padding: var(--sp-xs);
   background: var(--panel);
   border: 1px solid var(--line);
-  border-radius: 9px;
+  border-radius: var(--r-md);
 }
 
 .item {
   display: inline-flex;
   align-items: center;
   gap: 5px;
-  padding: 7px 13px;
+  padding: var(--sp-sm) var(--sp-lg);
   border: none;
-  border-radius: 6px;
+  border-radius: var(--r-sm);
   background: transparent;
   color: var(--ink3);
   font-family: var(--sans);
-  font-size: 10.5px;
+  font-size: var(--fs-xs);
   font-weight: 800;
   letter-spacing: 0.06em;
   cursor: pointer;
@@ -32,4 +32,22 @@
   background: var(--acc-bg);
   color: var(--acc-ink);
   box-shadow: inset 0 0 0 1px var(--acc);
+}
+
+/* --- equal, opt-in --- */
+/* Declared after the base rules: CSS Modules classes carry equal specificity,
+   so source order decides, and .equal must win over .seg/.item here. Some
+   pickers have few enough options to sit inline at their content width (the
+   default); others — the injector-size picker chief among them — read better
+   as an even row that fills the available width. */
+
+.equal {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+}
+
+.equal .item {
+  flex: 1;
+  min-width: 64px;
 }

--- a/src/ui/primitives/Seg.module.css
+++ b/src/ui/primitives/Seg.module.css
@@ -1,0 +1,35 @@
+.seg {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 3px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+}
+
+.item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 7px 13px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--ink3);
+  font-family: var(--sans);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  cursor: pointer;
+  transition: background-color 0.14s ease, color 0.14s ease;
+}
+
+.item:hover { color: var(--ink2); }
+.item:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; }
+
+.item[aria-pressed='true'] {
+  background: var(--acc-bg);
+  color: var(--acc-ink);
+  box-shadow: inset 0 0 0 1px var(--acc);
+}

--- a/src/ui/primitives/Select.jsx
+++ b/src/ui/primitives/Select.jsx
@@ -1,0 +1,45 @@
+/**
+ * A grouped dropdown built on a real `<select>`.
+ *
+ * Deliberately native: keyboard navigation, type-ahead and screen-reader semantics
+ * come free, and on a phone it opens the platform picker. Only the chevron is ours.
+ */
+
+import { ChevronDown } from 'lucide-react';
+import React from 'react';
+
+import styles from './Select.module.css';
+
+/**
+ * @param {object} props
+ * @param {string} props.label accessible name
+ * @param {Array<{label: string, options: Array<{value: string, label: string}>}>} props.groups
+ * @param {Array<{value: string, label: string}>} [props.extra] ungrouped options, appended last
+ * @param {string} props.value
+ * @param {(value: string) => void} props.onChange
+ * @returns {React.ReactElement}
+ */
+export function Select({ label, groups, extra = [], value, onChange }) {
+  return (
+    <div className={styles.wrap}>
+      <select
+        className={styles.select}
+        aria-label={label}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        {groups.map((g) => (
+          <optgroup key={g.label} label={g.label}>
+            {g.options.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </optgroup>
+        ))}
+        {extra.map((o) => (
+          <option key={o.value} value={o.value}>{o.label}</option>
+        ))}
+      </select>
+      <ChevronDown size={16} className={styles.chevron} aria-hidden="true" />
+    </div>
+  );
+}

--- a/src/ui/primitives/Select.jsx
+++ b/src/ui/primitives/Select.jsx
@@ -3,6 +3,11 @@
  *
  * Deliberately native: keyboard navigation, type-ahead and screen-reader semantics
  * come free, and on a phone it opens the platform picker. Only the chevron is ours.
+ *
+ * Known migration gap: the legacy `GroupedSelect` this replaces is `width: 100%`
+ * with a bottom margin; this primitive's wrapper is `inline-block` with a
+ * `min-width`. A drop-in swap will change layout at every call site — callers
+ * will need to size and space it themselves.
  */
 
 import { ChevronDown } from 'lucide-react';

--- a/src/ui/primitives/Select.module.css
+++ b/src/ui/primitives/Select.module.css
@@ -2,15 +2,17 @@
 
 .select {
   width: 100%;
-  padding: 11px 34px 11px 13px;
+  /* Right padding is not on the spacing scale: it is a functional offset that
+     reserves room for the chevron icon, not a rhythm step. */
+  padding: var(--sp-md) 34px var(--sp-md) var(--sp-lg);
   appearance: none;
   -webkit-appearance: none;
   border: 1px solid var(--line);
-  border-radius: 9px;
+  border-radius: var(--r-md);
   background: var(--panel2);
   color: var(--ink);
   font-family: var(--sans);
-  font-size: 13px;
+  font-size: var(--fs-base);
   font-weight: 600;
   cursor: pointer;
 }

--- a/src/ui/primitives/Select.module.css
+++ b/src/ui/primitives/Select.module.css
@@ -1,0 +1,28 @@
+.wrap { position: relative; display: inline-block; min-width: 200px; }
+
+.select {
+  width: 100%;
+  padding: 11px 34px 11px 13px;
+  appearance: none;
+  -webkit-appearance: none;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--panel2);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.select:hover { border-color: var(--line-hi); }
+.select:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; }
+
+.chevron {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--ink2);
+  pointer-events: none;
+}

--- a/src/ui/primitives/StatTile.jsx
+++ b/src/ui/primitives/StatTile.jsx
@@ -1,0 +1,26 @@
+/** A single labelled number. The app's unit of measured output. */
+
+import React from 'react';
+
+import styles from './StatTile.module.css';
+
+/**
+ * @param {object} props
+ * @param {string} props.label
+ * @param {string|number} props.value
+ * @param {string} [props.unit]
+ * @param {'neutral'|'acc'|'ok'|'warn'|'danger'} [props.tone]
+ * @returns {React.ReactElement}
+ */
+export function StatTile({ label, value, unit, tone = 'neutral' }) {
+  const className = [styles.tile, styles[tone]].filter(Boolean).join(' ');
+  return (
+    <div className={className}>
+      <div className={styles.label}>{label}</div>
+      <div className={styles.value}>
+        {value}
+        {unit && <span className={styles.unit}>{unit}</span>}
+      </div>
+    </div>
+  );
+}

--- a/src/ui/primitives/StatTile.module.css
+++ b/src/ui/primitives/StatTile.module.css
@@ -1,0 +1,36 @@
+.tile {
+  flex: 1;
+  min-width: 74px;
+  padding: 9px 10px;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  font-family: var(--sans);
+}
+
+.label {
+  font-size: 8.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: var(--ink3);
+}
+
+.value {
+  margin-top: 3px;
+  font-family: var(--mono);
+  font-size: 18px;
+  font-weight: 800;
+  color: var(--ink);
+}
+
+.unit {
+  margin-left: 2px;
+  font-size: 9.5px;
+  font-weight: 600;
+  color: var(--ink2);
+}
+
+.acc .value { color: var(--acc); }
+.ok .value { color: var(--ok); }
+.warn .value { color: var(--warn); }
+.danger .value { color: var(--danger); }

--- a/src/ui/primitives/StatTile.module.css
+++ b/src/ui/primitives/StatTile.module.css
@@ -1,15 +1,15 @@
 .tile {
   flex: 1;
   min-width: 74px;
-  padding: 9px 10px;
+  padding: var(--sp-md) var(--sp-md);
   background: var(--panel);
   border: 1px solid var(--line);
-  border-radius: 9px;
+  border-radius: var(--r-md);
   font-family: var(--sans);
 }
 
 .label {
-  font-size: 8.5px;
+  font-size: var(--fs-micro);
   font-weight: 700;
   letter-spacing: 0.12em;
   color: var(--ink3);
@@ -18,14 +18,14 @@
 .value {
   margin-top: 3px;
   font-family: var(--mono);
-  font-size: 18px;
+  font-size: var(--fs-lg);
   font-weight: 800;
   color: var(--ink);
 }
 
 .unit {
   margin-left: 2px;
-  font-size: 9.5px;
+  font-size: var(--fs-micro);
   font-weight: 600;
   color: var(--ink2);
 }

--- a/src/ui/primitives/Toggle.jsx
+++ b/src/ui/primitives/Toggle.jsx
@@ -1,0 +1,33 @@
+/** An on/off row for a single hardware option. */
+
+import React from 'react';
+
+import styles from './Toggle.module.css';
+
+/**
+ * @param {object} props
+ * @param {string} props.label
+ * @param {string} [props.sub] one line on what the option physically does
+ * @param {boolean} props.checked
+ * @param {(next: boolean) => void} props.onChange
+ * @returns {React.ReactElement}
+ */
+export function Toggle({ label, sub, checked, onChange }) {
+  return (
+    <button
+      type="button"
+      className={styles.row}
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+    >
+      <span>
+        <span className={styles.label}>{label}</span>
+        {sub && <span className={styles.sub} style={{ display: 'block' }}>{sub}</span>}
+      </span>
+      <span className={styles.track}>
+        <span className={styles.knob} />
+      </span>
+    </button>
+  );
+}

--- a/src/ui/primitives/Toggle.jsx
+++ b/src/ui/primitives/Toggle.jsx
@@ -1,4 +1,11 @@
-/** An on/off row for a single hardware option. */
+/**
+ * An on/off row for a single hardware option.
+ *
+ * Known migration gap: the legacy `ToggleRow` this replaces has a `color` prop,
+ * used non-default at one call site (the intercooler toggle, `color={T.cyan}`).
+ * This primitive has no equivalent. Migrating that call site needs a decision:
+ * either add the prop here, or accept the default accent colour there.
+ */
 
 import React, { useId } from 'react';
 

--- a/src/ui/primitives/Toggle.jsx
+++ b/src/ui/primitives/Toggle.jsx
@@ -1,6 +1,6 @@
 /** An on/off row for a single hardware option. */
 
-import React from 'react';
+import React, { useId } from 'react';
 
 import styles from './Toggle.module.css';
 
@@ -13,17 +13,20 @@ import styles from './Toggle.module.css';
  * @returns {React.ReactElement}
  */
 export function Toggle({ label, sub, checked, onChange }) {
+  const subId = useId();
   return (
     <button
       type="button"
       className={styles.row}
       role="switch"
       aria-checked={checked}
+      aria-label={label}
+      aria-describedby={sub ? subId : undefined}
       onClick={() => onChange(!checked)}
     >
       <span>
         <span className={styles.label}>{label}</span>
-        {sub && <span className={styles.sub} style={{ display: 'block' }}>{sub}</span>}
+        {sub && <span id={subId} className={styles.sub}>{sub}</span>}
       </span>
       <span className={styles.track}>
         <span className={styles.knob} />

--- a/src/ui/primitives/Toggle.module.css
+++ b/src/ui/primitives/Toggle.module.css
@@ -1,0 +1,48 @@
+.row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  width: 100%;
+  padding: 11px 13px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--panel2);
+  color: inherit;
+  font-family: var(--sans);
+  text-align: left;
+  cursor: pointer;
+  transition: border-color 0.14s ease;
+}
+
+.row:hover { border-color: var(--line-hi); }
+.row:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; }
+.row[aria-checked='true'] { border-color: var(--acc); }
+
+.label { font-size: 13px; font-weight: 700; color: var(--ink); }
+.sub { margin-top: 2px; font-size: 11px; color: var(--ink2); }
+
+.track {
+  flex-shrink: 0;
+  width: 38px;
+  height: 22px;
+  padding: 2px;
+  border-radius: 11px;
+  background: var(--panel3);
+  transition: background-color 0.16s ease;
+}
+
+.row[aria-checked='true'] .track { background: var(--acc); }
+
+.knob {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--ink2);
+  transition: transform 0.16s ease, background-color 0.16s ease;
+}
+
+.row[aria-checked='true'] .knob {
+  transform: translateX(16px);
+  background: var(--acc-on);
+}

--- a/src/ui/primitives/Toggle.module.css
+++ b/src/ui/primitives/Toggle.module.css
@@ -4,9 +4,9 @@
   justify-content: space-between;
   gap: 12px;
   width: 100%;
-  padding: 11px 13px;
+  padding: var(--sp-md) var(--sp-lg);
   border: 1px solid var(--line);
-  border-radius: 10px;
+  border-radius: var(--r-md);
   background: var(--panel2);
   color: inherit;
   font-family: var(--sans);
@@ -19,14 +19,20 @@
 .row:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; }
 .row[aria-checked='true'] { border-color: var(--acc); }
 
-.label { font-size: 13px; font-weight: 700; color: var(--ink); }
-.sub { display: block; margin-top: 2px; font-size: 11px; color: var(--ink2); }
+.label { font-size: var(--fs-base); font-weight: 700; color: var(--ink); }
+.sub { display: block; margin-top: 2px; font-size: var(--fs-xs); color: var(--ink2); }
 
 .track {
   flex-shrink: 0;
   width: 38px;
   height: 22px;
+  /* 2px is not on the spacing scale: the knob is a fixed 18px and the track a
+     fixed 22px tall, so this inset must stay exactly (22 - 18) / 2 or the knob
+     overflows the track. Left raw. */
   padding: 2px;
+  /* 11px is not on the radius scale: it is exactly half the track's own 22px
+     height, which is what makes the track read as a pill. A scale step here
+     would either square off the ends or clip the knob. Left raw. */
   border-radius: 11px;
   background: var(--panel3);
   transition: background-color 0.16s ease;

--- a/src/ui/primitives/Toggle.module.css
+++ b/src/ui/primitives/Toggle.module.css
@@ -20,7 +20,7 @@
 .row[aria-checked='true'] { border-color: var(--acc); }
 
 .label { font-size: 13px; font-weight: 700; color: var(--ink); }
-.sub { margin-top: 2px; font-size: 11px; color: var(--ink2); }
+.sub { display: block; margin-top: 2px; font-size: 11px; color: var(--ink2); }
 
 .track {
   flex-shrink: 0;

--- a/src/ui/screens/StartScreen.jsx
+++ b/src/ui/screens/StartScreen.jsx
@@ -1,0 +1,37 @@
+/** The first screen: what this is, and the two ways in. */
+
+import React from 'react';
+
+import { Button } from '../primitives/Button.jsx';
+
+import styles from './StartScreen.module.css';
+
+/**
+ * @param {object} props
+ * @param {() => void} props.onStart
+ * @param {() => void} props.onTutorial
+ * @param {string} props.version
+ * @param {React.ReactNode} [props.dial] decorative dial mark
+ * @returns {React.ReactElement}
+ */
+export function StartScreen({ onStart, onTutorial, version, dial }) {
+  return (
+    <div className={styles.screen}>
+      <div className={styles.glow} aria-hidden="true" />
+      <div className={styles.inner}>
+        {dial && <div className={styles.dial}>{dial}</div>}
+        <div className={styles.eyebrow}>CARIBOU TUNING</div>
+        <h1 className={styles.title}>Engine Management Sandbox</h1>
+        <p className={styles.blurb}>
+          Design an engine. Tune it. Log it. Improve it. A free-tune sandbox built to
+          teach real engine management, not just move sliders.
+        </p>
+        <div className={styles.actions}>
+          <Button size="lg" onClick={onStart}>START</Button>
+          <Button size="lg" variant="ghost" onClick={onTutorial}>TUTORIAL</Button>
+        </div>
+        <div className={styles.version}>{version}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/screens/StartScreen.module.css
+++ b/src/ui/screens/StartScreen.module.css
@@ -4,7 +4,7 @@
   align-items: center;
   justify-content: center;
   min-height: 100dvh;
-  padding: 24px;
+  padding: var(--sp-xxl);
   position: relative;
   overflow: hidden;
   background: var(--bg);
@@ -31,12 +31,16 @@
 
 .eyebrow {
   margin-bottom: 7px;
-  font-size: 11px;
+  font-size: var(--fs-xs);
   font-weight: 800;
   letter-spacing: 0.28em;
   color: var(--acc-ink);
 }
 
+/* 25px/34px (below, at the breakpoint) are not on the font-size scale: this is
+   the app's one hero headline, sized as its own editorial choice rather than
+   a repeating text role. Forcing it onto the ramp would be renaming a
+   one-off, not systematising a repeated value. */
 .title {
   max-width: 22ch;
   margin-bottom: 15px;
@@ -49,17 +53,19 @@
 .blurb {
   max-width: 42ch;
   margin-bottom: 34px;
-  font-size: 13.5px;
+  font-size: var(--fs-base);
   line-height: 1.65;
   color: var(--ink2);
 }
 
 .actions { display: flex; flex-direction: column; gap: 12px; width: 100%; max-width: 300px; }
 
-.version { margin-top: 18px; font-family: var(--mono); font-size: 10.5px; color: var(--ink3); }
+.version { margin-top: 18px; font-family: var(--mono); font-size: var(--fs-xs); color: var(--ink3); }
 
 /* From the small-tablet breakpoint up there is room to sit the two actions side by
-   side, which is also where a full-width button starts looking wrong. */
+   side, which is also where a full-width button starts looking wrong.
+   560px is the project's one breakpoint — see the note beside the scale in
+   tokens.css. Kept in sync by hand with TutorialScreen.module.css. */
 @media (min-width: 560px) {
   .title { font-size: 34px; }
   .actions { flex-direction: row; max-width: none; justify-content: center; }

--- a/src/ui/screens/StartScreen.module.css
+++ b/src/ui/screens/StartScreen.module.css
@@ -1,0 +1,66 @@
+.screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100dvh;
+  padding: 24px;
+  position: relative;
+  overflow: hidden;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--sans);
+  text-align: center;
+}
+
+.glow {
+  position: absolute;
+  top: -15%;
+  left: 50%;
+  width: 420px;
+  height: 420px;
+  transform: translateX(-50%);
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(var(--acc-rgb), 0.10) 0%, transparent 70%);
+  pointer-events: none;
+}
+
+.inner { position: relative; display: flex; flex-direction: column; align-items: center; }
+
+.dial { margin-bottom: 22px; }
+
+.eyebrow {
+  margin-bottom: 7px;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.28em;
+  color: var(--acc-ink);
+}
+
+.title {
+  max-width: 22ch;
+  margin-bottom: 15px;
+  font-size: 25px;
+  font-weight: 800;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+}
+
+.blurb {
+  max-width: 42ch;
+  margin-bottom: 34px;
+  font-size: 13.5px;
+  line-height: 1.65;
+  color: var(--ink2);
+}
+
+.actions { display: flex; flex-direction: column; gap: 12px; width: 100%; max-width: 300px; }
+
+.version { margin-top: 18px; font-family: var(--mono); font-size: 10.5px; color: var(--ink3); }
+
+/* From the small-tablet breakpoint up there is room to sit the two actions side by
+   side, which is also where a full-width button starts looking wrong. */
+@media (min-width: 560px) {
+  .title { font-size: 34px; }
+  .actions { flex-direction: row; max-width: none; justify-content: center; }
+}

--- a/src/ui/screens/TutorialScreen.jsx
+++ b/src/ui/screens/TutorialScreen.jsx
@@ -21,7 +21,7 @@ export function TutorialScreen({ steps, onDone }) {
     <div className={styles.screen}>
       <div className={styles.bar}>
         <div className={styles.count}>TUTORIAL · {step + 1}/{steps.length}</div>
-        <button type="button" className={styles.skip} onClick={onDone}>SKIP</button>
+        <Button variant="quiet" size="sm" onClick={onDone}>SKIP</Button>
       </div>
 
       <div className={styles.body}>

--- a/src/ui/screens/TutorialScreen.jsx
+++ b/src/ui/screens/TutorialScreen.jsx
@@ -1,0 +1,53 @@
+/** The eight-card walkthrough, shown before the first run and from the header. */
+
+import React, { useState } from 'react';
+
+import { Button } from '../primitives/Button.jsx';
+
+import styles from './TutorialScreen.module.css';
+
+/**
+ * @param {object} props
+ * @param {Array<{title: string, body: string}>} props.steps
+ * @param {() => void} props.onDone
+ * @returns {React.ReactElement}
+ */
+export function TutorialScreen({ steps, onDone }) {
+  const [step, setStep] = useState(0);
+  const current = steps[step];
+  const last = step === steps.length - 1;
+
+  return (
+    <div className={styles.screen}>
+      <div className={styles.bar}>
+        <div className={styles.count}>TUTORIAL · {step + 1}/{steps.length}</div>
+        <button type="button" className={styles.skip} onClick={onDone}>SKIP</button>
+      </div>
+
+      <div className={styles.body}>
+        <div className={styles.inner}>
+          <h2 className={styles.title}>{current.title}</h2>
+          <p className={styles.text}>{current.body}</p>
+        </div>
+      </div>
+
+      <div className={styles.dots} aria-hidden="true">
+        {steps.map((s, i) => (
+          <span
+            key={s.title}
+            className={[styles.dot, i === step && styles.dotOn].filter(Boolean).join(' ')}
+          />
+        ))}
+      </div>
+
+      <div className={styles.actions}>
+        {step > 0 && (
+          <Button size="lg" variant="ghost" onClick={() => setStep((v) => v - 1)}>BACK</Button>
+        )}
+        <Button size="lg" onClick={() => (last ? onDone() : setStep((v) => v + 1))}>
+          {last ? 'START TUNING' : 'NEXT'}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/screens/TutorialScreen.jsx
+++ b/src/ui/screens/TutorialScreen.jsx
@@ -26,7 +26,7 @@ export function TutorialScreen({ steps, onDone }) {
 
       <div className={styles.body}>
         <div className={styles.inner}>
-          <h2 className={styles.title}>{current.title}</h2>
+          <h1 className={styles.title}>{current.title}</h1>
           <p className={styles.text}>{current.body}</p>
         </div>
       </div>

--- a/src/ui/screens/TutorialScreen.module.css
+++ b/src/ui/screens/TutorialScreen.module.css
@@ -43,10 +43,21 @@
 .actions {
   display: flex;
   gap: 10px;
-  justify-content: center;
   padding: 0 16px calc(16px + env(safe-area-inset-bottom));
 }
 
+.actions > * { flex: 1; }
+.actions > *:last-child { flex: 2; }
+
 @media (min-width: 560px) {
   .title { font-size: 27px; }
+
+  .actions {
+    justify-content: center;
+  }
+
+  .actions > *,
+  .actions > *:last-child {
+    flex: 0 0 auto;
+  }
 }

--- a/src/ui/screens/TutorialScreen.module.css
+++ b/src/ui/screens/TutorialScreen.module.css
@@ -1,0 +1,64 @@
+.screen {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--sans);
+}
+
+.bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+}
+
+.count {
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.15em;
+  color: var(--acc-ink);
+}
+
+.skip {
+  border: none;
+  background: none;
+  color: var(--ink3);
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+}
+.skip:hover { color: var(--ink2); }
+.skip:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; }
+
+.body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 0 24px;
+}
+
+.inner { width: 100%; max-width: 60ch; }
+
+.title { margin: 0 0 13px; font-size: 21px; font-weight: 800; letter-spacing: -0.01em; }
+.text { margin: 0; font-size: 14.5px; line-height: 1.7; color: var(--ink-soft); }
+
+.dots { display: flex; gap: 6px; justify-content: center; padding-bottom: 18px; }
+
+.dot { width: 6px; height: 6px; border-radius: 3px; background: var(--line); transition: width 0.2s ease; }
+.dotOn { width: 20px; background: var(--acc); }
+
+.actions {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  padding: 0 16px calc(16px + env(safe-area-inset-bottom));
+}
+
+@media (min-width: 560px) {
+  .title { font-size: 27px; }
+}

--- a/src/ui/screens/TutorialScreen.module.css
+++ b/src/ui/screens/TutorialScreen.module.css
@@ -21,18 +21,6 @@
   color: var(--acc-ink);
 }
 
-.skip {
-  border: none;
-  background: none;
-  color: var(--ink3);
-  font-family: var(--sans);
-  font-size: 12px;
-  font-weight: 700;
-  cursor: pointer;
-}
-.skip:hover { color: var(--ink2); }
-.skip:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; }
-
 .body {
   flex: 1;
   display: flex;

--- a/src/ui/screens/TutorialScreen.module.css
+++ b/src/ui/screens/TutorialScreen.module.css
@@ -11,11 +11,11 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 14px 16px;
+  padding: var(--sp-lg) var(--sp-xl);
 }
 
 .count {
-  font-size: 10.5px;
+  font-size: var(--fs-xs);
   font-weight: 800;
   letter-spacing: 0.15em;
   color: var(--acc-ink);
@@ -27,28 +27,37 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: 0 24px;
+  padding: 0 var(--sp-xxl);
 }
 
 .inner { width: 100%; max-width: 60ch; }
 
+/* 21px/27px (below, at the breakpoint) are not on the font-size scale: this is
+   this screen's one section headline, a deliberately different size from
+   StartScreen's hero title rather than a shared repeating role. See the note
+   there. */
 .title { margin: 0 0 13px; font-size: 21px; font-weight: 800; letter-spacing: -0.01em; }
-.text { margin: 0; font-size: 14.5px; line-height: 1.7; color: var(--ink-soft); }
+.text { margin: 0; font-size: var(--fs-md); line-height: 1.7; color: var(--ink-soft); }
 
+/* 18px is not on the spacing scale: a single-use bottom spacer ahead of the
+   safe-area inset, 2px from the nearest step (--sp-xl, 16px) — further than
+   the ~1px this pass snaps. Left raw. */
 .dots { display: flex; gap: 6px; justify-content: center; padding-bottom: 18px; }
 
-.dot { width: 6px; height: 6px; border-radius: 3px; background: var(--line); transition: width 0.2s ease; }
+.dot { width: 6px; height: 6px; border-radius: var(--r-xs); background: var(--line); transition: width 0.2s ease; }
 .dotOn { width: 20px; background: var(--acc); }
 
 .actions {
   display: flex;
   gap: 10px;
-  padding: 0 16px calc(16px + env(safe-area-inset-bottom));
+  padding: 0 var(--sp-xl) calc(var(--sp-xl) + env(safe-area-inset-bottom));
 }
 
 .actions > * { flex: 1; }
 .actions > *:last-child { flex: 2; }
 
+/* 560px is the project's one breakpoint — see the note beside the scale in
+   tokens.css. Kept in sync by hand with StartScreen.module.css. */
 @media (min-width: 560px) {
   .title { font-size: 27px; }
 

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -57,6 +57,30 @@ const T = {
 export const statusColor = (v) => (v >= 90 ? T.ok : v >= 55 ? T.warn : T.danger);
 
 /**
+ * Status colour for a value where HIGH is the dangerous end: injector duty cycle,
+ * or any "how much of the available capacity is spent" reading.
+ *
+ * Deliberately NOT the mirror image of `statusColor`. Health and utilisation are
+ * different judgements about different quantities: 55% health is already poor,
+ * while 55% duty is an ordinary cruise load. Mirroring the health bands would paint
+ * everything above 45% duty as an alarm and could not tell a comfortable 60% from a
+ * lean-out-imminent 90%.
+ *
+ * The bands come from the app's own long-standing duty readout — a real injector is
+ * sized so that sustained duty above ~90% has no headroom left for the next
+ * enrichment the ECU asks for.
+ *
+ * These bands are copied exactly — thresholds and comparison operators — from the
+ * inline duty preview in `EcuLab.jsx`. That copy is still there because this PR does
+ * not migrate screens. When that panel moves onto `Bar`, delete the inline version
+ * and call this instead; until then the two must be changed together.
+ *
+ * @param {number} v 0-100
+ * @returns {string} a status colour
+ */
+export const utilisationColor = (v) => (v > 90 ? T.danger : v > 75 ? T.warn : T.ok);
+
+/**
  * Heat-map colour for a table cell, cool (low) through warm (high).
  *
  * Deliberately its own ramp rather than the status scale: a hot VE cell is not a

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -39,6 +39,11 @@ const T = {
   dangerInk: tokens.dangerInk,
   dangerBg: tokens.dangerBg,
 
+  okLine: tokens.okLine,
+  warnLine: tokens.warnLine,
+  dangerLine: tokens.dangerLine,
+  violetLine: tokens.violetLine,
+
   cyan: tokens.cyan,
   cyanBg: tokens.cyanBg,
   violet: tokens.violet,
@@ -68,4 +73,21 @@ function heat(value, min, max) {
   return `hsl(${hue.toFixed(0)}, 68%, ${26 + t * 12}%)`;
 }
 
-export { T, accAlpha, heat, shadowAlpha };
+/**
+ * Diverging colour for a SIGNED delta: warm for positive, cool for negative, with
+ * intensity carrying magnitude.
+ *
+ * Distinct from `heat()`, which is a one-directional ramp for an absolute cell value.
+ * A delta has a sign that means something — richer vs leaner, advanced vs retarded —
+ * so it needs a scale that reads outward from a neutral middle rather than along a line.
+ *
+ * @param {number} delta signed difference
+ * @param {number} [fullScale] magnitude at which the colour saturates
+ * @returns {string} an hsl() colour
+ */
+function deltaHeat(delta, fullScale = 12) {
+  const mag = clamp(Math.abs(delta) / fullScale, 0, 1);
+  return `hsl(${delta > 0 ? 8 : 200}, 60%, ${14 + mag * 22}%)`;
+}
+
+export { T, accAlpha, deltaHeat, heat, shadowAlpha };

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -4,15 +4,11 @@
  * Every colour in the app resolves to `src/ui/tokens.js`. Screens must not hard-code
  * hex values — `tests/no-hardcoded-colours.test.js` enforces that, because the rule
  * was stated here for a long time and quietly broken 58 times.
- *
- * The `amber*`/`yellow`/`green`/`red` keys are ALIASES kept so the pre-overhaul
- * screens keep rendering while they are migrated. Write new code against
- * `acc`/`warn`/`ok`/`danger` and delete an alias the moment its last caller goes.
  */
 
 import { clamp } from '../sim/index.js';
 
-import { tokens } from './tokens.js';
+import { accAlpha, shadowAlpha, tokens } from './tokens.js';
 
 const T = {
   bg: tokens.bg,
@@ -48,17 +44,6 @@ const T = {
   violet: tokens.violet,
   violetBg: tokens.violetBg,
 
-  // --- aliases retired during the overhaul; see the file comment above ---
-  amber: tokens.acc,
-  amberInk: tokens.accInk,
-  amberBg: tokens.accBg,
-  green: tokens.ok,
-  greenBg: tokens.okBg,
-  yellow: tokens.warn,
-  yellowBg: tokens.warnBg,
-  red: tokens.danger,
-  redBg: tokens.dangerBg,
-
   mono: tokens.mono,
   sans: tokens.sans,
 };
@@ -83,4 +68,4 @@ function heat(value, min, max) {
   return `hsl(${hue.toFixed(0)}, 68%, ${26 + t * 12}%)`;
 }
 
-export { T, heat };
+export { T, accAlpha, heat, shadowAlpha };

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -1,33 +1,76 @@
 /**
- * Design tokens and the shared visual language.
+ * The shared visual language, assembled from the tokens.
  *
- * Every colour, font and status hue in the app comes from here. Screens and
- * primitives must not hard-code hex values — if you need a new colour, add it as a
- * named token so the UI keeps reading as one product rather than a stack of
- * separately-styled forms.
+ * Every colour in the app resolves to `src/ui/tokens.js`. Screens must not hard-code
+ * hex values — `tests/no-hardcoded-colours.test.js` enforces that, because the rule
+ * was stated here for a long time and quietly broken 58 times.
+ *
+ * The `amber*`/`yellow`/`green`/`red` keys are ALIASES kept so the pre-overhaul
+ * screens keep rendering while they are migrated. Write new code against
+ * `acc`/`warn`/`ok`/`danger` and delete an alias the moment its last caller goes.
  */
 
 import { clamp } from '../sim/index.js';
 
+import { tokens } from './tokens.js';
+
 const T = {
-  bg: '#0a0d11', panel: '#12161c', panel2: '#181d24', panelHi: '#1e242c',
-  line: '#242b34', lineHi: '#33404d',
-  ink: '#eef2f5', ink2: '#8b96a3', ink3: '#57616c',
-  amber: '#ff6a2c', amberInk: '#ffab7a', amberBg: '#2a1810',
-  cyan: '#3ec8ff', cyanBg: '#0f2530',
-  violet: '#b083ff', violetBg: '#211a30',
-  green: '#39d980', greenBg: '#0f2418',
-  yellow: '#ffc94d', yellowBg: '#2a2110',
-  red: '#ff5252', redBg: '#2a1414',
-  mono: "ui-monospace, 'SF Mono', Menlo, Consolas, monospace",
-  sans: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+  bg: tokens.bg,
+  panel: tokens.panel,
+  panel2: tokens.panel2,
+  panel3: tokens.panel3,
+  panelHi: tokens.panel3,
+  line: tokens.line,
+  lineHi: tokens.lineHi,
+
+  ink: tokens.ink,
+  inkSoft: tokens.inkSoft,
+  ink2: tokens.ink2,
+  ink3: tokens.ink3,
+
+  acc: tokens.acc,
+  accInk: tokens.accInk,
+  accBg: tokens.accBg,
+  accOn: tokens.accOn,
+
+  ok: tokens.ok,
+  okInk: tokens.okInk,
+  okBg: tokens.okBg,
+  warn: tokens.warn,
+  warnInk: tokens.warnInk,
+  warnBg: tokens.warnBg,
+  danger: tokens.danger,
+  dangerInk: tokens.dangerInk,
+  dangerBg: tokens.dangerBg,
+
+  cyan: tokens.cyan,
+  cyanBg: tokens.cyanBg,
+  violet: tokens.violet,
+  violetBg: tokens.violetBg,
+
+  // --- aliases retired during the overhaul; see the file comment above ---
+  amber: tokens.acc,
+  amberInk: tokens.accInk,
+  amberBg: tokens.accBg,
+  green: tokens.ok,
+  greenBg: tokens.okBg,
+  yellow: tokens.warn,
+  yellowBg: tokens.warnBg,
+  red: tokens.danger,
+  redBg: tokens.dangerBg,
+
+  mono: tokens.mono,
+  sans: tokens.sans,
 };
 
-/** Maps a 0-100 health/quality value onto the green/yellow/red status scale. */
-export const statusColor = (v) => (v >= 90 ? T.green : v >= 55 ? T.yellow : T.red);
+/** Maps a 0-100 health/quality value onto the green/amber/red status scale. */
+export const statusColor = (v) => (v >= 90 ? T.ok : v >= 55 ? T.warn : T.danger);
 
 /**
- * Heat-map colour for a table cell, blue (low) through red (high).
+ * Heat-map colour for a table cell, cool (low) through warm (high).
+ *
+ * Deliberately its own ramp rather than the status scale: a hot VE cell is not a
+ * fault, and it must never compete visually with a real warning.
  *
  * @param {number} value cell value
  * @param {number} min low end of the scale

--- a/src/ui/tokens.css
+++ b/src/ui/tokens.css
@@ -1,0 +1,43 @@
+/* Mirrors src/ui/tokens.js. Both are checked against each other by
+   tests/tokens.test.js — change one and you must change the other. */
+
+:root {
+  --bg: #0a0d14;
+  --panel: #131824;
+  --panel2: #1a2130;
+  --panel3: #212a3c;
+
+  --line: #262f42;
+  --line-hi: #33405a;
+
+  --ink: #e9eef8;
+  --ink-soft: #c8d2e2;
+  --ink2: #8792a8;
+  --ink3: #5c6880;
+
+  --acc: #4c9eff;
+  --acc-ink: #8fc2ff;
+  --acc-bg: #0f2033;
+  --acc-on: #04162e;
+
+  --ok: #35e08a;
+  --ok-ink: #7fe8b4;
+  --ok-bg: #0d2419;
+  --warn: #ffb020;
+  --warn-ink: #ffd07a;
+  --warn-bg: #2a2110;
+  --danger: #ff4d4d;
+  --danger-ink: #ff9d9d;
+  --danger-bg: #2a1414;
+
+  --cyan: #38d9f0;
+  --cyan-bg: #0b2630;
+  --violet: #a78bfa;
+  --violet-bg: #1d1a33;
+
+  --mono: ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+  --sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+
+  --acc-rgb: 76, 158, 255;
+  --shadow-rgb: 0, 0, 0;
+}

--- a/src/ui/tokens.css
+++ b/src/ui/tokens.css
@@ -30,6 +30,11 @@
   --danger-ink: #ff9d9d;
   --danger-bg: #2a1414;
 
+  --ok-line: #1e5238;
+  --warn-line: #5c4415;
+  --danger-line: #5c2626;
+  --violet-line: #3b3363;
+
   --cyan: #38d9f0;
   --cyan-bg: #0b2630;
   --violet: #a78bfa;

--- a/src/ui/tokens.css
+++ b/src/ui/tokens.css
@@ -45,4 +45,40 @@
 
   --acc-rgb: 76, 158, 255;
   --shadow-rgb: 0, 0, 0;
+
+  /* Font-size scale, small to large. See the matching comment in tokens.js for
+     why these six steps replace fifteen raw values rather than naming all of
+     them. One-off screen headlines (21/25/27/34px) are intentionally not on
+     this ramp — see the comments at their declarations. */
+  --fs-micro: 9px;
+  --fs-xs: 10.5px;
+  --fs-sm: 12px;
+  --fs-base: 13.5px;
+  --fs-md: 14.5px;
+  --fs-lg: 18px;
+
+  /* Border-radius scale, small to large. `50%` circles and one pill radius
+     pinned to half its own element's height are deliberately not on this
+     ramp — see the comment at that declaration (Toggle.module.css). */
+  --r-xs: 3px;
+  --r-sm: 6px;
+  --r-md: 9px;
+  --r-lg: 12px;
+
+  /* Spacing scale, for padding. A few raw padding values stay off this ramp
+     because they are pinned to something other than rhythm — a chevron's
+     clearance, a toggle knob's fit inside its track — each documented at its
+     declaration. */
+  --sp-xs: 3px;
+  --sp-sm: 7px;
+  --sp-md: 10px;
+  --sp-lg: 13px;
+  --sp-xl: 16px;
+  --sp-xxl: 24px;
+
+  /* Breakpoint. `@media` cannot read a custom property, so this cannot be a
+     token — it is recorded here instead. 560px is the project's one
+     breakpoint (small-tablet-and-up); it must be kept in sync by hand across
+     every file that uses it: src/ui/screens/StartScreen.module.css and
+     src/ui/screens/TutorialScreen.module.css. */
 }

--- a/src/ui/tokens.js
+++ b/src/ui/tokens.js
@@ -51,6 +51,14 @@ export const tokens = Object.freeze({
   dangerInk: '#ff9d9d',
   dangerBg: '#2a1414',
 
+  // Status borders. One step brighter than the matching *Bg so a status box reads as
+  // a bounded object rather than a wash — without reaching the full status hue, which
+  // belongs to text and indicators.
+  okLine: '#1e5238',
+  warnLine: '#5c4415',
+  dangerLine: '#5c2626',
+  violetLine: '#3b3363',
+
   // Secondary data hue, for charts that must plot two series at once (power vs
   // torque). Distinct from `acc` on purpose so a chart never looks like a control.
   cyan: '#38d9f0',

--- a/src/ui/tokens.js
+++ b/src/ui/tokens.js
@@ -1,0 +1,90 @@
+/**
+ * The palette, and the single place it is defined.
+ *
+ * `tokens.css` mirrors this file as CSS custom properties for stylesheets, and
+ * `tests/tokens.test.js` proves the two never drift. Add a colour here first.
+ *
+ * The organising rule: THE ACCENT IS NEVER A STATUS, AND A STATUS IS NEVER
+ * DECORATION. `acc` means "this is the action" or "this is the live value".
+ * `ok`/`warn`/`danger` mean engine state and nothing else. The previous palette
+ * spent its alarm colour on chrome — 84 uses of the same hot orange on the
+ * wordmark, the nav, the focus ring and genuine warnings alike — which left a real
+ * warning nothing to escalate to.
+ */
+
+/** @param {string} s camelCase token name @returns {string} its kebab-case CSS name */
+export const camelToKebab = (s) => s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+
+/** @type {Readonly<Record<string,string>>} */
+export const tokens = Object.freeze({
+  // Surfaces, darkest to lightest. The base is blue-black rather than neutral grey
+  // because red reads harder against blue than against grey.
+  bg: '#0a0d14',
+  panel: '#131824',
+  panel2: '#1a2130',
+  panel3: '#212a3c',
+
+  // Borders.
+  line: '#262f42',
+  lineHi: '#33405a',
+
+  // Text, four steps from primary to faintest.
+  ink: '#e9eef8',
+  inkSoft: '#c8d2e2',
+  ink2: '#8792a8',
+  ink3: '#5c6880',
+
+  // Accent. `accOn` is text placed ON an accent fill — it must never be a grey.
+  acc: '#4c9eff',
+  accInk: '#8fc2ff',
+  accBg: '#0f2033',
+  accOn: '#04162e',
+
+  // Status. Reserved for engine state. Never used as decoration.
+  ok: '#35e08a',
+  okInk: '#7fe8b4',
+  okBg: '#0d2419',
+  warn: '#ffb020',
+  warnInk: '#ffd07a',
+  warnBg: '#2a2110',
+  danger: '#ff4d4d',
+  dangerInk: '#ff9d9d',
+  dangerBg: '#2a1414',
+
+  // Secondary data hue, for charts that must plot two series at once (power vs
+  // torque). Distinct from `acc` on purpose so a chart never looks like a control.
+  cyan: '#38d9f0',
+  cyanBg: '#0b2630',
+  violet: '#a78bfa',
+  violetBg: '#1d1a33',
+
+  // Type.
+  mono: "ui-monospace, 'SF Mono', Menlo, Consolas, monospace",
+  sans: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+
+  // Bare RGB triplets, so translucent washes can be built from the same colours
+  // rather than re-typing them at a new alpha. See accAlpha/shadowAlpha below.
+  accRgb: '76, 158, 255',
+  shadowRgb: '0, 0, 0',
+});
+
+/**
+ * A translucent accent wash — glows, focus halos, the shadow under a primary button.
+ *
+ * Lives here rather than in a screen because an `rgba()` literal in a component is
+ * precisely what this system exists to prevent, and `tests/no-hardcoded-colours.test.js`
+ * rejects one.
+ *
+ * @param {number} alpha 0-1
+ * @returns {string} an rgba() colour
+ */
+export const accAlpha = (alpha) => `rgba(${tokens.accRgb}, ${alpha})`;
+
+/**
+ * A plain black scrim, for drop shadows and cell borders that must darken whatever
+ * is underneath rather than tint it.
+ *
+ * @param {number} alpha 0-1
+ * @returns {string} an rgba() colour
+ */
+export const shadowAlpha = (alpha) => `rgba(${tokens.shadowRgb}, ${alpha})`;

--- a/src/ui/tokens.js
+++ b/src/ui/tokens.js
@@ -1,15 +1,26 @@
 /**
- * The palette, and the single place it is defined.
+ * The palette, type scale, radius scale and spacing scale — the single place
+ * each is defined.
  *
  * `tokens.css` mirrors this file as CSS custom properties for stylesheets, and
- * `tests/tokens.test.js` proves the two never drift. Add a colour here first.
+ * `tests/tokens.test.js` proves the two never drift. Add a token here first.
  *
- * The organising rule: THE ACCENT IS NEVER A STATUS, AND A STATUS IS NEVER
- * DECORATION. `acc` means "this is the action" or "this is the live value".
+ * The organising rule for colour: THE ACCENT IS NEVER A STATUS, AND A STATUS IS
+ * NEVER DECORATION. `acc` means "this is the action" or "this is the live value".
  * `ok`/`warn`/`danger` mean engine state and nothing else. The previous palette
  * spent its alarm colour on chrome — 84 uses of the same hot orange on the
  * wordmark, the nav, the focus ring and genuine warnings alike — which left a real
  * warning nothing to escalate to.
+ *
+ * The organising rule for the font-size/radius/spacing scales below: they were
+ * added after nine primitives and two screens had already accumulated 15 raw
+ * font-sizes, 8 raw radii and 17 raw padding declarations between them — each
+ * file looked reasonable alone, but a fourteen-screen build is about to land on
+ * top of this layer, and that is a lot cheaper to systematise now than to
+ * retrofit later. Not every raw value in the stylesheets maps onto a step here:
+ * a handful are one-off screen headlines or values pinned to another number
+ * by layout geometry, and those stay raw with a comment explaining why, rather
+ * than being forced onto the ramp.
  */
 
 /** @param {string} s camelCase token name @returns {string} its kebab-case CSS name */
@@ -78,6 +89,41 @@ export const tokens = Object.freeze({
   // rather than re-typing them at a new alpha. See accAlpha/shadowAlpha below.
   accRgb: '76, 158, 255',
   shadowRgb: '0, 0, 0',
+
+  // Font-size scale, small to large. Named by role/size rather than kept as the
+  // 15 raw values they replace, because a scale is a small set of deliberate
+  // steps, not every number a designer happened to type. `fsMicro` and `fsXs`
+  // carry the small uppercase UI chrome (eyebrows, badges, segmented-control
+  // labels); `fsSm`/`fsBase` carry compact and standard body/control text;
+  // `fsMd` is screen-body copy; `fsLg` is the large mono figure in a stat tile.
+  // One-off screen headlines (21/25/27/34px) are not part of this ramp — see
+  // the comments at their declarations for why.
+  fsMicro: '9px',
+  fsXs: '10.5px',
+  fsSm: '12px',
+  fsBase: '13.5px',
+  fsMd: '14.5px',
+  fsLg: '18px',
+
+  // Border-radius scale, small to large. Covers the eight raw radii the
+  // stylesheets had accumulated; `50%` circles and one pill radius pinned to
+  // half of its own element's height are deliberately left out — see the
+  // comment at that declaration.
+  rXs: '3px',
+  rSm: '6px',
+  rMd: '9px',
+  rLg: '12px',
+
+  // Spacing scale, for padding. Covers the seventeen raw padding declarations
+  // the stylesheets had accumulated. A few values stay raw with a comment
+  // because they are pinned to something other than rhythm: a chevron's
+  // clearance, a knob's fit inside its track.
+  spXs: '3px',
+  spSm: '7px',
+  spMd: '10px',
+  spLg: '13px',
+  spXl: '16px',
+  spXxl: '24px',
 });
 
 /**

--- a/src/ui/tokens.js
+++ b/src/ui/tokens.js
@@ -53,7 +53,11 @@ export const tokens = Object.freeze({
 
   // Status borders. One step brighter than the matching *Bg so a status box reads as
   // a bounded object rather than a wash — without reaching the full status hue, which
-  // belongs to text and indicators.
+  // belongs to text and indicators. These are for a status BOX's border — something
+  // that reports state, like Note or an inline banner. A destructive CONTROL (e.g.
+  // Button's danger variant) deliberately uses the saturated hue instead, because it
+  // needs to read louder than something that merely reports; that is not an
+  // inconsistency to "fix" by pointing it at these tokens too.
   okLine: '#1e5238',
   warnLine: '#5c4415',
   dangerLine: '#5c2626',

--- a/tests/no-hardcoded-colours.test.js
+++ b/tests/no-hardcoded-colours.test.js
@@ -14,6 +14,14 @@ const UI_DIR = new URL('../src/ui/', import.meta.url);
 /** Files allowed to name a colour literally: the token layer itself. */
 const ALLOWED = new Set(['tokens.js', 'tokens.css']);
 
+/**
+ * Files allowed to compute an hsl() colour: the token layer, plus theme.js — the only
+ * file where a computed ramp (heat(), deltaHeat()) legitimately lives. This is a
+ * separate list from ALLOWED on purpose: theme.js must still fail the hex and rgba
+ * checks below, so a raw literal can't hide there. Do not fold this into ALLOWED.
+ */
+const HSL_ALLOWED = new Set(['tokens.js', 'tokens.css', 'theme.js']);
+
 /** @returns {string[]} every source file under src/ui that must not name a colour */
 function sourceFiles() {
   return readdirSync(UI_DIR, { withFileTypes: true, recursive: true })
@@ -34,5 +42,12 @@ describe('src/ui contains no hard-coded colours', () => {
       const hits = readFileSync(file, 'utf8').match(/\brgba?\(\s*\d/g) ?? [];
       expect(hits, 'use a token, or a colour-mix on one, instead').toEqual([]);
     });
+
+    if (!HSL_ALLOWED.has(file.slice(file.lastIndexOf('/') + 1))) {
+      it(`${rel} names no hsl colour`, () => {
+        const hits = readFileSync(file, 'utf8').match(/\bhsla?\(/g) ?? [];
+        expect(hits, 'computed colour ramps belong in theme.js').toEqual([]);
+      });
+    }
   }
 });

--- a/tests/no-hardcoded-colours.test.js
+++ b/tests/no-hardcoded-colours.test.js
@@ -1,0 +1,38 @@
+/**
+ * Guards the rule theme.js has always stated and nothing ever enforced.
+ *
+ * A hard-coded colour is invisible to the token layer, so a palette change silently
+ * misses it. That is exactly how 58 stray hexes accumulated in one component.
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+const UI_DIR = new URL('../src/ui/', import.meta.url);
+
+/** Files allowed to name a colour literally: the token layer itself. */
+const ALLOWED = new Set(['tokens.js', 'tokens.css']);
+
+/** @returns {string[]} every source file under src/ui that must not name a colour */
+function sourceFiles() {
+  return readdirSync(UI_DIR, { withFileTypes: true, recursive: true })
+    .filter((e) => e.isFile() && /\.(jsx?|css)$/.test(e.name) && !ALLOWED.has(e.name))
+    .map((e) => `${e.parentPath ?? e.path}/${e.name}`);
+}
+
+describe('src/ui contains no hard-coded colours', () => {
+  for (const file of sourceFiles()) {
+    const rel = file.slice(file.indexOf('src/ui'));
+
+    it(`${rel} names no hex colour`, () => {
+      const hits = readFileSync(file, 'utf8').match(/#[0-9a-fA-F]{3,8}\b/g) ?? [];
+      expect(hits, `use a token from theme.js instead of ${hits.join(', ')}`).toEqual([]);
+    });
+
+    it(`${rel} names no rgb/rgba colour`, () => {
+      const hits = readFileSync(file, 'utf8').match(/\brgba?\(\s*\d/g) ?? [];
+      expect(hits, 'use a token, or a colour-mix on one, instead').toEqual([]);
+    });
+  }
+});

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -1,0 +1,76 @@
+/**
+ * Theme tests.
+ *
+ * `T` is consumed at 500+ call sites in the UI, so a missing key is a blank screen
+ * rather than a type error. These pin the whole surface, plus the two functions
+ * that turn a number into a colour.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { tokens } from '../src/ui/tokens.js';
+import { T, heat, statusColor } from '../src/ui/theme.js';
+
+describe('T', () => {
+  it('exposes every key the existing screens read', () => {
+    const required = [
+      'bg', 'panel', 'panel2', 'panel3', 'line', 'lineHi',
+      'ink', 'inkSoft', 'ink2', 'ink3',
+      'acc', 'accInk', 'accBg', 'accOn',
+      'ok', 'okInk', 'okBg', 'warn', 'warnInk', 'warnBg',
+      'danger', 'dangerInk', 'dangerBg',
+      'amber', 'amberInk', 'amberBg', 'green', 'greenBg',
+      'yellow', 'yellowBg', 'red', 'redBg',
+      'cyan', 'cyanBg', 'violet', 'violetBg', 'mono', 'sans',
+    ];
+    for (const key of required) {
+      expect(T[key], `T.${key} is missing`).toBeTruthy();
+    }
+  });
+
+  it('aliases the retired amber keys onto the accent', () => {
+    // Kept so this commit recolours the app without editing 500 call sites.
+    expect(T.amber).toBe(tokens.acc);
+    expect(T.amberInk).toBe(tokens.accInk);
+    expect(T.amberBg).toBe(tokens.accBg);
+  });
+
+  it('no longer contains the old orange anywhere', () => {
+    expect(Object.values(T)).not.toContain('#ff6a2c');
+    expect(Object.values(T)).not.toContain('#ffab7a');
+  });
+});
+
+describe('statusColor', () => {
+  it('is green at and above 90', () => {
+    expect(statusColor(90)).toBe(tokens.ok);
+    expect(statusColor(100)).toBe(tokens.ok);
+  });
+
+  it('is amber between 55 and 89', () => {
+    expect(statusColor(55)).toBe(tokens.warn);
+    expect(statusColor(89)).toBe(tokens.warn);
+  });
+
+  it('is red below 55', () => {
+    expect(statusColor(54)).toBe(tokens.danger);
+    expect(statusColor(0)).toBe(tokens.danger);
+  });
+});
+
+describe('heat', () => {
+  it('returns an hsl string', () => {
+    expect(heat(50, 0, 100)).toMatch(/^hsl\(/);
+  });
+
+  it('clamps out-of-range values instead of running off the scale', () => {
+    expect(heat(-999, 0, 100)).toBe(heat(0, 0, 100));
+    expect(heat(999, 0, 100)).toBe(heat(100, 0, 100));
+  });
+
+  it('moves monotonically from cool to warm across the range', () => {
+    const hue = (v) => Number(heat(v, 0, 100).match(/hsl\((-?[\d.]+)/)[1]);
+    expect(hue(0)).toBeGreaterThan(hue(50));
+    expect(hue(50)).toBeGreaterThan(hue(100));
+  });
+});

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -19,6 +19,7 @@ describe('T', () => {
       'acc', 'accInk', 'accBg', 'accOn',
       'ok', 'okInk', 'okBg', 'warn', 'warnInk', 'warnBg',
       'danger', 'dangerInk', 'dangerBg',
+      'okLine', 'warnLine', 'dangerLine', 'violetLine',
       'cyan', 'cyanBg', 'violet', 'violetBg', 'mono', 'sans',
     ];
     for (const key of required) {

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -19,20 +19,11 @@ describe('T', () => {
       'acc', 'accInk', 'accBg', 'accOn',
       'ok', 'okInk', 'okBg', 'warn', 'warnInk', 'warnBg',
       'danger', 'dangerInk', 'dangerBg',
-      'amber', 'amberInk', 'amberBg', 'green', 'greenBg',
-      'yellow', 'yellowBg', 'red', 'redBg',
       'cyan', 'cyanBg', 'violet', 'violetBg', 'mono', 'sans',
     ];
     for (const key of required) {
       expect(T[key], `T.${key} is missing`).toBeTruthy();
     }
-  });
-
-  it('aliases the retired amber keys onto the accent', () => {
-    // Kept so this commit recolours the app without editing 500 call sites.
-    expect(T.amber).toBe(tokens.acc);
-    expect(T.amberInk).toBe(tokens.accInk);
-    expect(T.amberBg).toBe(tokens.accBg);
   });
 
   it('no longer contains the old orange anywhere', () => {

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -9,7 +9,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { tokens } from '../src/ui/tokens.js';
-import { T, heat, statusColor } from '../src/ui/theme.js';
+import { T, heat, statusColor, utilisationColor } from '../src/ui/theme.js';
 
 describe('T', () => {
   it('exposes every key the existing screens read', () => {
@@ -46,6 +46,23 @@ describe('statusColor', () => {
   it('is red below 55', () => {
     expect(statusColor(54)).toBe(tokens.danger);
     expect(statusColor(0)).toBe(tokens.danger);
+  });
+});
+
+describe('utilisationColor', () => {
+  it('is green at and below 75', () => {
+    expect(utilisationColor(0)).toBe(tokens.ok);
+    expect(utilisationColor(75)).toBe(tokens.ok);
+  });
+
+  it('is amber between 76 and 90', () => {
+    expect(utilisationColor(76)).toBe(tokens.warn);
+    expect(utilisationColor(90)).toBe(tokens.warn);
+  });
+
+  it('is red above 90', () => {
+    expect(utilisationColor(91)).toBe(tokens.danger);
+    expect(utilisationColor(100)).toBe(tokens.danger);
   });
 });
 

--- a/tests/tokens.test.js
+++ b/tests/tokens.test.js
@@ -13,6 +13,7 @@ import { describe, expect, it } from 'vitest';
 import { camelToKebab, tokens } from '../src/ui/tokens.js';
 
 const css = readFileSync(new URL('../src/ui/tokens.css', import.meta.url), 'utf8');
+const html = readFileSync(new URL('../index.html', import.meta.url), 'utf8');
 
 /** @returns {Map<string,string>} every `--name: value` declared in tokens.css */
 function parseCss() {
@@ -50,5 +51,15 @@ describe('token contract', () => {
 
   it('is frozen so no screen can mutate the palette at runtime', () => {
     expect(Object.isFrozen(tokens)).toBe(true);
+  });
+});
+
+describe('pre-mount styles', () => {
+  it('keeps index.html on the same palette', () => {
+    // index.html is exempt from the colour guard because the pre-mount background
+    // cannot wait for a stylesheet. That exemption needs this assertion, or it is
+    // just a place for the palette to drift out of sight.
+    expect(html).toContain(tokens.bg);
+    expect(html).toContain(tokens.acc);
   });
 });

--- a/tests/tokens.test.js
+++ b/tests/tokens.test.js
@@ -3,7 +3,9 @@
  *
  * `tokens.js` and `tokens.css` describe the same palette in two languages, and
  * nothing but a test can stop them drifting. These also pin the one rule the whole
- * colour system rests on: the accent is never a status colour.
+ * colour system rests on: the accent is never a status colour, and the one rule
+ * that makes the font-size/radius/spacing additions a scale rather than a bag of
+ * numbers: each step is strictly larger than the last.
  */
 
 import { readFileSync } from 'node:fs';
@@ -51,6 +53,38 @@ describe('token contract', () => {
 
   it('is frozen so no screen can mutate the palette at runtime', () => {
     expect(Object.isFrozen(tokens)).toBe(true);
+  });
+});
+
+/** @param {string} px e.g. "10.5px" @returns {number} */
+const num = (px) => Number.parseFloat(px);
+
+/** @returns {number[]} the value of each token name, in the order given */
+const ramp = (...names) => names.map((name) => num(tokens[name]));
+
+describe('scale contract', () => {
+  it('declares the font-size scale, each step larger than the last', () => {
+    const steps = ramp('fsMicro', 'fsXs', 'fsSm', 'fsBase', 'fsMd', 'fsLg');
+    for (const step of steps) expect(Number.isNaN(step)).toBe(false);
+    for (let i = 1; i < steps.length; i += 1) {
+      expect(steps[i], `${steps[i]} is not larger than ${steps[i - 1]}`).toBeGreaterThan(steps[i - 1]);
+    }
+  });
+
+  it('declares the radius scale, each step larger than the last', () => {
+    const steps = ramp('rXs', 'rSm', 'rMd', 'rLg');
+    for (const step of steps) expect(Number.isNaN(step)).toBe(false);
+    for (let i = 1; i < steps.length; i += 1) {
+      expect(steps[i], `${steps[i]} is not larger than ${steps[i - 1]}`).toBeGreaterThan(steps[i - 1]);
+    }
+  });
+
+  it('declares the spacing scale, each step larger than the last', () => {
+    const steps = ramp('spXs', 'spSm', 'spMd', 'spLg', 'spXl', 'spXxl');
+    for (const step of steps) expect(Number.isNaN(step)).toBe(false);
+    for (let i = 1; i < steps.length; i += 1) {
+      expect(steps[i], `${steps[i]} is not larger than ${steps[i - 1]}`).toBeGreaterThan(steps[i - 1]);
+    }
   });
 });
 

--- a/tests/tokens.test.js
+++ b/tests/tokens.test.js
@@ -1,0 +1,54 @@
+/**
+ * Token contract tests.
+ *
+ * `tokens.js` and `tokens.css` describe the same palette in two languages, and
+ * nothing but a test can stop them drifting. These also pin the one rule the whole
+ * colour system rests on: the accent is never a status colour.
+ */
+
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+import { camelToKebab, tokens } from '../src/ui/tokens.js';
+
+const css = readFileSync(new URL('../src/ui/tokens.css', import.meta.url), 'utf8');
+
+/** @returns {Map<string,string>} every `--name: value` declared in tokens.css */
+function parseCss() {
+  const out = new Map();
+  for (const m of css.matchAll(/--([a-z0-9-]+)\s*:\s*([^;]+);/g)) {
+    out.set(m[1], m[2].trim());
+  }
+  return out;
+}
+
+describe('token contract', () => {
+  it('declares every JS token as a CSS custom property with the same value', () => {
+    const declared = parseCss();
+    for (const [key, value] of Object.entries(tokens)) {
+      const cssName = camelToKebab(key);
+      expect(declared.get(cssName), `--${cssName} missing from tokens.css`).toBe(value);
+    }
+  });
+
+  it('declares no CSS custom property that JS does not know about', () => {
+    const known = new Set(Object.keys(tokens).map(camelToKebab));
+    for (const name of parseCss().keys()) {
+      expect(known.has(name), `--${name} exists in CSS but not in tokens.js`).toBe(true);
+    }
+  });
+
+  it('never uses a status colour as the accent', () => {
+    // The defect this whole overhaul exists to fix: when the accent IS the alarm
+    // colour, a real alarm has nowhere to escalate to.
+    for (const status of [tokens.ok, tokens.warn, tokens.danger]) {
+      expect(tokens.acc).not.toBe(status);
+      expect(tokens.accInk).not.toBe(status);
+    }
+  });
+
+  it('is frozen so no screen can mutate the palette at runtime', () => {
+    expect(Object.isFrozen(tokens)).toBe(true);
+  });
+});

--- a/tests/ui/Button.test.jsx
+++ b/tests/ui/Button.test.jsx
@@ -49,6 +49,11 @@ describe('Button', () => {
     expect(screen.getByRole('button').className).toContain(styles.danger);
   });
 
+  it('applies the quiet variant', () => {
+    render(<Button variant="quiet">SKIP</Button>);
+    expect(screen.getByRole('button').className).toContain(styles.quiet);
+  });
+
   it('calls onClick when clicked', () => {
     const onClick = vi.fn();
     render(<Button onClick={onClick}>GO</Button>);

--- a/tests/ui/Button.test.jsx
+++ b/tests/ui/Button.test.jsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+
+/**
+ * Button tests.
+ *
+ * The `block` assertions are the point of this component: the pre-overhaul UI made
+ * every action full-width, which is why a primary button spanned a 27-inch monitor.
+ * Full-width is now opt-in.
+ */
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Button } from '../../src/ui/primitives/Button.jsx';
+import styles from '../../src/ui/primitives/Button.module.css';
+
+afterEach(cleanup);
+
+describe('Button', () => {
+  it('renders a real button element with its label', () => {
+    render(<Button>RUN DYNO PULL</Button>);
+    const el = screen.getByRole('button', { name: 'RUN DYNO PULL' });
+    expect(el.tagName).toBe('BUTTON');
+  });
+
+  it('defaults to type="button" so it never submits a form by accident', () => {
+    render(<Button>RESET</Button>);
+    expect(screen.getByRole('button').getAttribute('type')).toBe('button');
+  });
+
+  it('is not full-width unless asked', () => {
+    render(<Button>RESET</Button>);
+    expect(screen.getByRole('button').className).not.toContain(styles.block);
+  });
+
+  it('is full-width when block is set', () => {
+    render(<Button block>RUN DYNO PULL</Button>);
+    expect(screen.getByRole('button').className).toContain(styles.block);
+  });
+
+  it('applies the primary variant by default', () => {
+    render(<Button>GO</Button>);
+    expect(screen.getByRole('button').className).toContain(styles.primary);
+  });
+
+  it('applies the variant it is given', () => {
+    render(<Button variant="danger">RESET ENGINE</Button>);
+    expect(screen.getByRole('button').className).toContain(styles.danger);
+  });
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn();
+    render(<Button onClick={onClick}>GO</Button>);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClick when disabled', () => {
+    const onClick = vi.fn();
+    render(<Button disabled onClick={onClick}>GO</Button>);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('passes unknown props through to the element', () => {
+    render(<Button aria-label="Run a dyno pull">GO</Button>);
+    expect(screen.getByLabelText('Run a dyno pull')).toBeTruthy();
+  });
+});

--- a/tests/ui/controls.test.jsx
+++ b/tests/ui/controls.test.jsx
@@ -67,8 +67,8 @@ describe('Select', () => {
         onChange={() => {}}
       />,
     );
-    expect(screen.getAllByRole('option')).toHaveLength(4);
-    expect(screen.getByRole('option', { name: 'Custom build' })).toBeTruthy();
+    const labels = screen.getAllByRole('option').map((o) => o.textContent);
+    expect(labels).toEqual(['N54 3.0', 'B58 3.0', 'VQ35DE', 'Custom build']);
   });
 
   it('reports the selected value', () => {
@@ -87,7 +87,7 @@ describe('Select', () => {
 describe('Toggle', () => {
   it('exposes itself as a switch reflecting its state', () => {
     render(<Toggle label="Intake" checked onChange={() => {}} />);
-    expect(screen.getByRole('switch', { name: /Intake/ }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByRole('switch', { name: 'Intake' }).getAttribute('aria-checked')).toBe('true');
   });
 
   it('reports the flipped value when clicked', () => {
@@ -100,5 +100,27 @@ describe('Toggle', () => {
   it('renders its sub-label', () => {
     render(<Toggle label="Intake" sub="+4% VE above 4000 RPM" checked onChange={() => {}} />);
     expect(screen.getByText('+4% VE above 4000 RPM')).toBeTruthy();
+  });
+
+  it('names the switch after its label alone, not the sub-label too', () => {
+    // The sub-label carries the physics ("+4% VE above 4000 RPM"). Fused into the
+    // accessible name it becomes one unbroken run; as a description it is announced
+    // separately, the way the two visually separated lines read on screen.
+    render(<Toggle label="Intake" sub="+4% VE above 4000 RPM" checked onChange={() => {}} />);
+    const el = screen.getByRole('switch', { name: 'Intake' });
+    expect(el.getAttribute('aria-label')).toBe('Intake');
+  });
+
+  it('describes the switch with its sub-label', () => {
+    render(<Toggle label="Intake" sub="+4% VE above 4000 RPM" checked onChange={() => {}} />);
+    const el = screen.getByRole('switch');
+    const describedBy = el.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy).textContent).toBe('+4% VE above 4000 RPM');
+  });
+
+  it('carries no description when there is no sub-label', () => {
+    render(<Toggle label="Intake" checked onChange={() => {}} />);
+    expect(screen.getByRole('switch').getAttribute('aria-describedby')).toBeNull();
   });
 });

--- a/tests/ui/controls.test.jsx
+++ b/tests/ui/controls.test.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { Seg } from '../../src/ui/primitives/Seg.jsx';
+import segStyles from '../../src/ui/primitives/Seg.module.css';
 import { Select } from '../../src/ui/primitives/Select.jsx';
 import { Toggle } from '../../src/ui/primitives/Toggle.jsx';
 
@@ -46,6 +47,24 @@ describe('Seg', () => {
   it('names the group for assistive technology', () => {
     render(<Seg label="Table" options={SEG_OPTIONS} value="ve" onChange={() => {}} />);
     expect(screen.getByRole('group', { name: 'Table' })).toBeTruthy();
+  });
+
+  it('does not apply the equal-width modifier class by default', () => {
+    render(<Seg label="Table" options={SEG_OPTIONS} value="ve" onChange={() => {}} />);
+    expect(screen.getByRole('group', { name: 'Table' }).className).not.toContain(segStyles.equal);
+  });
+
+  it('applies the equal-width modifier class when equal is set', () => {
+    render(<Seg label="Table" options={SEG_OPTIONS} value="ve" onChange={() => {}} equal />);
+    expect(screen.getByRole('group', { name: 'Table' }).className).toContain(segStyles.equal);
+  });
+
+  it('keeps selection behaviour unchanged when equal is set', () => {
+    const onChange = vi.fn();
+    render(<Seg label="Table" options={SEG_OPTIONS} value="ve" onChange={onChange} equal />);
+    expect(screen.getByRole('button', { name: 'AIR' }).getAttribute('aria-pressed')).toBe('true');
+    fireEvent.click(screen.getByRole('button', { name: 'FUEL' }));
+    expect(onChange).toHaveBeenCalledWith('afr');
   });
 });
 

--- a/tests/ui/controls.test.jsx
+++ b/tests/ui/controls.test.jsx
@@ -1,5 +1,8 @@
 // @vitest-environment jsdom
 
+import { readFileSync } from 'node:fs';
+import { URL as NodeURL } from 'node:url';
+
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -122,5 +125,22 @@ describe('Toggle', () => {
   it('carries no description when there is no sub-label', () => {
     render(<Toggle label="Intake" checked onChange={() => {}} />);
     expect(screen.getByRole('switch').getAttribute('aria-describedby')).toBeNull();
+  });
+});
+
+describe('Toggle styling lives in the stylesheet', () => {
+  // .sub's margin-top does nothing on an inline box, so display:block is load-bearing
+  // rather than cosmetic — and jsdom cannot observe it any other way.
+  it('gives the sub-label display:block in CSS, not inline', () => {
+    // Explicit node:url URL, not the ambient global: this file runs under the jsdom
+    // environment, which replaces global URL with its own class that fs.readFileSync
+    // refuses ("The URL must be of scheme file") even for a valid file:// URL.
+    const css = readFileSync(new NodeURL('../../src/ui/primitives/Toggle.module.css', import.meta.url), 'utf8');
+    expect(css).toMatch(/\.sub\s*\{[^}]*display:\s*block/);
+  });
+
+  it('keeps Toggle.jsx free of inline styles', () => {
+    const jsx = readFileSync(new NodeURL('../../src/ui/primitives/Toggle.jsx', import.meta.url), 'utf8');
+    expect(jsx).not.toContain('style=');
   });
 });

--- a/tests/ui/controls.test.jsx
+++ b/tests/ui/controls.test.jsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Seg } from '../../src/ui/primitives/Seg.jsx';
+import { Select } from '../../src/ui/primitives/Select.jsx';
+import { Toggle } from '../../src/ui/primitives/Toggle.jsx';
+
+// This project's vitest config has no `globals: true` and no setup file, so
+// Testing Library does not auto-unmount between tests. Every test here renders
+// and queries by role, so without this, elements from earlier tests accumulate
+// in the DOM and unscoped role/name queries start matching more than one
+// element. Matches the pattern already used in readouts.test.jsx.
+afterEach(cleanup);
+
+const SEG_OPTIONS = [
+  { id: 've', label: 'AIR' },
+  { id: 'timing', label: 'SPARK' },
+  { id: 'afr', label: 'FUEL' },
+];
+
+describe('Seg', () => {
+  it('renders one button per option', () => {
+    render(<Seg label="Table" options={SEG_OPTIONS} value="ve" onChange={() => {}} />);
+    expect(screen.getAllByRole('button')).toHaveLength(3);
+  });
+
+  it('marks only the selected option as pressed', () => {
+    render(<Seg label="Table" options={SEG_OPTIONS} value="timing" onChange={() => {}} />);
+    expect(screen.getByRole('button', { name: 'SPARK' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByRole('button', { name: 'AIR' }).getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('reports the id of the option clicked', () => {
+    const onChange = vi.fn();
+    render(<Seg label="Table" options={SEG_OPTIONS} value="ve" onChange={onChange} />);
+    fireEvent.click(screen.getByRole('button', { name: 'FUEL' }));
+    expect(onChange).toHaveBeenCalledWith('afr');
+  });
+
+  it('names the group for assistive technology', () => {
+    render(<Seg label="Table" options={SEG_OPTIONS} value="ve" onChange={() => {}} />);
+    expect(screen.getByRole('group', { name: 'Table' })).toBeTruthy();
+  });
+});
+
+describe('Select', () => {
+  const GROUPS = [
+    { label: 'BMW', options: [{ value: 'n54', label: 'N54 3.0' }, { value: 'b58', label: 'B58 3.0' }] },
+    { label: 'Nissan', options: [{ value: 'vq35', label: 'VQ35DE' }] },
+  ];
+
+  it('renders every option inside its group', () => {
+    render(<Select label="Engine" groups={GROUPS} value="n54" onChange={() => {}} />);
+    expect(screen.getAllByRole('option')).toHaveLength(3);
+  });
+
+  it('appends the extra options after the groups', () => {
+    render(
+      <Select
+        label="Engine"
+        groups={GROUPS}
+        extra={[{ value: 'custom', label: 'Custom build' }]}
+        value="n54"
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getAllByRole('option')).toHaveLength(4);
+    expect(screen.getByRole('option', { name: 'Custom build' })).toBeTruthy();
+  });
+
+  it('reports the selected value', () => {
+    const onChange = vi.fn();
+    render(<Select label="Engine" groups={GROUPS} value="n54" onChange={onChange} />);
+    fireEvent.change(screen.getByRole('combobox'), { target: { value: 'b58' } });
+    expect(onChange).toHaveBeenCalledWith('b58');
+  });
+
+  it('is labelled', () => {
+    render(<Select label="Engine" groups={GROUPS} value="n54" onChange={() => {}} />);
+    expect(screen.getByRole('combobox', { name: 'Engine' })).toBeTruthy();
+  });
+});
+
+describe('Toggle', () => {
+  it('exposes itself as a switch reflecting its state', () => {
+    render(<Toggle label="Intake" checked onChange={() => {}} />);
+    expect(screen.getByRole('switch', { name: /Intake/ }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('reports the flipped value when clicked', () => {
+    const onChange = vi.fn();
+    render(<Toggle label="Intake" checked={false} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('switch'));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('renders its sub-label', () => {
+    render(<Toggle label="Intake" sub="+4% VE above 4000 RPM" checked onChange={() => {}} />);
+    expect(screen.getByText('+4% VE above 4000 RPM')).toBeTruthy();
+  });
+});

--- a/tests/ui/infrastructure.test.jsx
+++ b/tests/ui/infrastructure.test.jsx
@@ -1,0 +1,25 @@
+// @vitest-environment jsdom
+
+/**
+ * Proves the component-test setup itself works before any primitive depends on it:
+ * jsdom provides a document, React renders into it, and @testing-library queries it.
+ *
+ * CSS Module resolution is proven by the Button test in Task 5, which is the first
+ * file that actually imports a stylesheet — this task must not depend on a file a
+ * later task creates, or it cannot end green.
+ */
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+describe('component test infrastructure', () => {
+  it('provides a DOM', () => {
+    expect(typeof document).toBe('object');
+  });
+
+  it('renders React into jsdom', () => {
+    render(<button type="button">RUN DYNO PULL</button>);
+    expect(screen.getByRole('button', { name: 'RUN DYNO PULL' })).toBeTruthy();
+  });
+});

--- a/tests/ui/readouts.test.jsx
+++ b/tests/ui/readouts.test.jsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Bar } from '../../src/ui/primitives/Bar.jsx';
+import { StatTile } from '../../src/ui/primitives/StatTile.jsx';
+import tileStyles from '../../src/ui/primitives/StatTile.module.css';
+
+describe('StatTile', () => {
+  it('renders label, value and unit', () => {
+    render(<StatTile label="PEAK HP" value={412} unit="whp" />);
+    expect(screen.getByText('PEAK HP')).toBeTruthy();
+    expect(screen.getByText('412')).toBeTruthy();
+    expect(screen.getByText('whp')).toBeTruthy();
+  });
+
+  it('omits the unit element entirely when no unit is given', () => {
+    const { container } = render(<StatTile label="PULLS" value={7} />);
+    expect(container.querySelector(`.${tileStyles.unit}`)).toBeNull();
+  });
+
+  it('applies the tone it is given', () => {
+    const { container } = render(<StatTile label="KNOCK" value="0.4" tone="warn" />);
+    expect(container.querySelector(`.${tileStyles.warn}`)).toBeTruthy();
+  });
+});
+
+describe('Bar', () => {
+  it('exposes itself as a meter with its current value', () => {
+    render(<Bar label="Pistons" value={86} />);
+    const meter = screen.getByRole('meter');
+    expect(meter.getAttribute('aria-valuenow')).toBe('86');
+    expect(meter.getAttribute('aria-valuemin')).toBe('0');
+    expect(meter.getAttribute('aria-valuemax')).toBe('100');
+  });
+
+  it('names the meter after its label', () => {
+    render(<Bar label="Bearings" value={71} />);
+    expect(screen.getByRole('meter', { name: 'Bearings' })).toBeTruthy();
+  });
+
+  it('scales the fill to the percentage of max', () => {
+    const { container } = render(<Bar label="Duty" value={40} max={80} />);
+    const fill = /** @type {HTMLElement} */ (container.querySelector('[data-fill]'));
+    expect(fill.style.width).toBe('50%');
+  });
+
+  it('clamps a value above max instead of overflowing the track', () => {
+    const { container } = render(<Bar label="Duty" value={150} max={100} />);
+    const fill = /** @type {HTMLElement} */ (container.querySelector('[data-fill]'));
+    expect(fill.style.width).toBe('100%');
+  });
+
+  it('clamps a negative value to zero', () => {
+    const { container } = render(<Bar label="Duty" value={-20} max={100} />);
+    const fill = /** @type {HTMLElement} */ (container.querySelector('[data-fill]'));
+    expect(fill.style.width).toBe('0%');
+  });
+});

--- a/tests/ui/readouts.test.jsx
+++ b/tests/ui/readouts.test.jsx
@@ -1,12 +1,18 @@
 // @vitest-environment jsdom
 
-import { render, screen } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import React from 'react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { Bar } from '../../src/ui/primitives/Bar.jsx';
 import { StatTile } from '../../src/ui/primitives/StatTile.jsx';
 import tileStyles from '../../src/ui/primitives/StatTile.module.css';
+
+// This file's queries rely on `screen` being scoped to the current test's render;
+// without this, meters from earlier tests accumulate in the DOM and unscoped
+// role/name queries start matching more than one element. Matches the pattern
+// already used in Button.test.jsx and surfaces.test.jsx.
+afterEach(cleanup);
 
 describe('StatTile', () => {
   it('renders label, value and unit', () => {
@@ -57,5 +63,34 @@ describe('Bar', () => {
     const { container } = render(<Bar label="Duty" value={-20} max={100} />);
     const fill = /** @type {HTMLElement} */ (container.querySelector('[data-fill]'));
     expect(fill.style.width).toBe('0%');
+  });
+
+  it('never announces a value outside its own declared range', () => {
+    // A meter whose aria-valuenow exceeds aria-valuemax is invalid ARIA, and it
+    // means the announced reading disagrees with the bar a sighted user sees.
+    render(<Bar label="Duty" value={150} max={100} />);
+    const meter = screen.getByRole('meter');
+    expect(meter.getAttribute('aria-valuenow')).toBe('100');
+  });
+
+  it('never announces a value below zero', () => {
+    render(<Bar label="Duty" value={-20} max={100} />);
+    expect(screen.getByRole('meter').getAttribute('aria-valuenow')).toBe('0');
+  });
+
+  it('reads a high value as healthy by default', () => {
+    render(<Bar label="Pistons" value={95} max={100} />);
+    expect(screen.getByRole('meter')).toBeTruthy();
+    expect(screen.getByText('95%')).toBeTruthy();
+  });
+
+  it('inverts the scale when a high value is the dangerous end', () => {
+    // 95% injector duty is a build about to lean out, not a healthy one. Without
+    // higherIsBetter={false} this renders green at exactly the wrong moment.
+    const { container } = render(<Bar label="Duty" value={95} max={100} higherIsBetter={false} />);
+    const healthy = render(<Bar label="Pistons" value={95} max={100} />);
+    const dutyFill = /** @type {HTMLElement} */ (container.querySelector('[data-fill]'));
+    const healthFill = /** @type {HTMLElement} */ (healthy.container.querySelector('[data-fill]'));
+    expect(dutyFill.style.background).not.toBe(healthFill.style.background);
   });
 });

--- a/tests/ui/readouts.test.jsx
+++ b/tests/ui/readouts.test.jsx
@@ -93,4 +93,22 @@ describe('Bar', () => {
     const healthFill = /** @type {HTMLElement} */ (healthy.container.querySelector('[data-fill]'));
     expect(dutyFill.style.background).not.toBe(healthFill.style.background);
   });
+
+  it('reads an ordinary duty cycle as healthy, not as an alarm', () => {
+    // 60% injector duty is a comfortably sized injector, not a warning. Mirroring the
+    // health bands used to paint everything above 45% red, which is what this pins.
+    const { container } = render(<Bar label="Duty" value={60} max={100} higherIsBetter={false} />);
+    const healthy = render(<Bar label="Pistons" value={95} max={100} />);
+    const dutyFill = /** @type {HTMLElement} */ (container.querySelector('[data-fill]'));
+    const healthFill = /** @type {HTMLElement} */ (healthy.container.querySelector('[data-fill]'));
+    expect(dutyFill.style.background).toBe(healthFill.style.background);
+  });
+
+  it('reads a duty cycle with no headroom left as dangerous', () => {
+    const { container } = render(<Bar label="Duty" value={95} max={100} higherIsBetter={false} />);
+    const failing = render(<Bar label="Pistons" value={20} max={100} />);
+    const dutyFill = /** @type {HTMLElement} */ (container.querySelector('[data-fill]'));
+    const failingFill = /** @type {HTMLElement} */ (failing.container.querySelector('[data-fill]'));
+    expect(dutyFill.style.background).toBe(failingFill.style.background);
+  });
 });

--- a/tests/ui/screens.test.jsx
+++ b/tests/ui/screens.test.jsx
@@ -77,5 +77,7 @@ describe('TutorialScreen', () => {
   it('reports progress through the steps', () => {
     render(<TutorialScreen steps={STEPS} onDone={() => {}} />);
     expect(screen.getByText('TUTORIAL · 1/2')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'NEXT' }));
+    expect(screen.getByText('TUTORIAL · 2/2')).toBeTruthy();
   });
 });

--- a/tests/ui/screens.test.jsx
+++ b/tests/ui/screens.test.jsx
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { StartScreen } from '../../src/ui/screens/StartScreen.jsx';
+import { TutorialScreen } from '../../src/ui/screens/TutorialScreen.jsx';
+
+afterEach(cleanup);
+
+const STEPS = [
+  { title: 'This is an air pump', body: 'Everything starts with airflow.' },
+  { title: 'Design it on BUILD', body: 'None of it is cosmetic.' },
+];
+
+describe('StartScreen', () => {
+  it('starts the app', () => {
+    const onStart = vi.fn();
+    render(<StartScreen onStart={onStart} onTutorial={() => {}} version="v1.4.0" />);
+    fireEvent.click(screen.getByRole('button', { name: 'START' }));
+    expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  it('opens the tutorial', () => {
+    const onTutorial = vi.fn();
+    render(<StartScreen onStart={() => {}} onTutorial={onTutorial} version="v1.4.0" />);
+    fireEvent.click(screen.getByRole('button', { name: 'TUTORIAL' }));
+    expect(onTutorial).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the build version', () => {
+    render(<StartScreen onStart={() => {}} onTutorial={() => {}} version="v1.4.0" />);
+    expect(screen.getByText('v1.4.0')).toBeTruthy();
+  });
+});
+
+describe('TutorialScreen', () => {
+  it('opens on the first step', () => {
+    render(<TutorialScreen steps={STEPS} onDone={() => {}} />);
+    expect(screen.getByText('This is an air pump')).toBeTruthy();
+  });
+
+  it('advances to the next step', () => {
+    render(<TutorialScreen steps={STEPS} onDone={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: 'NEXT' }));
+    expect(screen.getByText('Design it on BUILD')).toBeTruthy();
+  });
+
+  it('offers no BACK on the first step', () => {
+    render(<TutorialScreen steps={STEPS} onDone={() => {}} />);
+    expect(screen.queryByRole('button', { name: 'BACK' })).toBeNull();
+  });
+
+  it('goes back', () => {
+    render(<TutorialScreen steps={STEPS} onDone={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: 'NEXT' }));
+    fireEvent.click(screen.getByRole('button', { name: 'BACK' }));
+    expect(screen.getByText('This is an air pump')).toBeTruthy();
+  });
+
+  it('finishes from the last step', () => {
+    const onDone = vi.fn();
+    render(<TutorialScreen steps={STEPS} onDone={onDone} />);
+    fireEvent.click(screen.getByRole('button', { name: 'NEXT' }));
+    fireEvent.click(screen.getByRole('button', { name: 'START TUNING' }));
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips out at any point', () => {
+    const onDone = vi.fn();
+    render(<TutorialScreen steps={STEPS} onDone={onDone} />);
+    fireEvent.click(screen.getByRole('button', { name: 'SKIP' }));
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports progress through the steps', () => {
+    render(<TutorialScreen steps={STEPS} onDone={() => {}} />);
+    expect(screen.getByText('TUTORIAL · 1/2')).toBeTruthy();
+  });
+});

--- a/tests/ui/surfaces.test.jsx
+++ b/tests/ui/surfaces.test.jsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { cleanup, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Eyebrow } from '../../src/ui/primitives/Eyebrow.jsx';
+import { Note } from '../../src/ui/primitives/Note.jsx';
+import noteStyles from '../../src/ui/primitives/Note.module.css';
+import { Panel } from '../../src/ui/primitives/Panel.jsx';
+import panelStyles from '../../src/ui/primitives/Panel.module.css';
+
+afterEach(cleanup);
+
+describe('Panel', () => {
+  it('renders its children', () => {
+    render(<Panel>peak power</Panel>);
+    expect(screen.getByText('peak power')).toBeTruthy();
+  });
+
+  it('uses the tight padding modifier only when asked', () => {
+    const { rerender } = render(<Panel>x</Panel>);
+    expect(screen.getByText('x').className).not.toContain(panelStyles.tight);
+    rerender(<Panel tight>x</Panel>);
+    expect(screen.getByText('x').className).toContain(panelStyles.tight);
+  });
+
+  it('can render as another element', () => {
+    render(<Panel as="section">x</Panel>);
+    expect(screen.getByText('x').tagName).toBe('SECTION');
+  });
+});
+
+describe('Eyebrow', () => {
+  it('renders its label', () => {
+    render(<Eyebrow>Forced induction</Eyebrow>);
+    expect(screen.getByText('Forced induction')).toBeTruthy();
+  });
+
+  it('renders an icon when given one', () => {
+    const Icon = (props) => <svg data-testid="icon" {...props} />;
+    render(<Eyebrow icon={Icon}>Boost</Eyebrow>);
+    expect(screen.getByTestId('icon')).toBeTruthy();
+  });
+});
+
+describe('Note', () => {
+  it('defaults to the info tone', () => {
+    render(<Note>Speed density indexes VE by RPM and MAP.</Note>);
+    expect(screen.getByRole('note').className).toContain(noteStyles.info);
+  });
+
+  it('applies the warn tone', () => {
+    render(<Note tone="warn">Injector duty is above 90%.</Note>);
+    expect(screen.getByRole('note').className).toContain(noteStyles.warn);
+  });
+
+  it('announces a danger note as an alert', () => {
+    // A danger note reports engine distress; a screen reader should not have to
+    // stumble across it.
+    render(<Note tone="danger">Knock retard active.</Note>);
+    expect(screen.getByRole('alert')).toBeTruthy();
+  });
+});

--- a/tests/ui/surfaces.test.jsx
+++ b/tests/ui/surfaces.test.jsx
@@ -29,6 +29,11 @@ describe('Panel', () => {
     render(<Panel as="section">x</Panel>);
     expect(screen.getByText('x').tagName).toBe('SECTION');
   });
+
+  it('passes unknown props through to the element', () => {
+    render(<Panel aria-label="Build summary">x</Panel>);
+    expect(screen.getByLabelText('Build summary')).toBeTruthy();
+  });
 });
 
 describe('Eyebrow', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,18 @@
     "isolatedModules": true,
     "forceConsistentCasingInFileNames": true
   },
-  "//include": "src/ui is excluded for now — the screens are still one large untyped component. Annotating them is tracked in CONTRIBUTING; the physics layer, which is where type safety actually pays, is fully covered.",
-  "include": ["src/sim", "src/storage.js", "src/version.js", "src/globals.d.ts", "tests", "scripts"],
+  "//include": "src/sim is fully typed. src/ui/EcuLab.jsx is still one large untyped component and stays excluded until the screen split; everything built during the overhaul — tokens, primitives, screens — is typed from the start so the exclusion never has to grow again.",
+  "include": [
+    "src/sim",
+    "src/ui/tokens.js",
+    "src/ui/theme.js",
+    "src/ui/primitives",
+    "src/storage.js",
+    "src/version.js",
+    "src/globals.d.ts",
+    "src/css-modules.d.ts",
+    "tests",
+    "scripts"
+  ],
   "exclude": ["node_modules", "dist", "ECULab.jsx"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "src/ui/tokens.js",
     "src/ui/theme.js",
     "src/ui/primitives",
+    "src/ui/screens",
     "src/storage.js",
     "src/version.js",
     "src/globals.d.ts",

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,8 +12,10 @@ export default defineConfig({
   },
   test: {
     // The simulation is pure JS with no DOM dependency, so the default Node
-    // environment is both correct and much faster than jsdom.
+    // environment is both correct and much faster than jsdom. Component tests opt
+    // into jsdom per-file with `// @vitest-environment jsdom` rather than slowing
+    // the physics suite down for everyone.
     environment: 'node',
-    include: ['tests/**/*.test.js'],
+    include: ['tests/**/*.test.{js,jsx}'],
   },
 });


### PR DESCRIPTION
First of seven PRs against #6. Establishes the token layer and primitives library the
rest of the overhaul is built on — and recolours the app on the way past.

## Why the palette changed

The old accent `#ff6a2c` appeared **84 times**: wordmark, active nav, focus ring, primary
buttons, selected table cells — *and* genuine warnings. An app whose purpose is reporting
engine distress had spent its distress colour on chrome, so a real warning had nowhere to
escalate to.

Azure `#4c9eff` sits far from every status hue, and its blue-black base makes the red
alarm state read harder than a neutral grey ground would. The rule the whole system now
rests on: **the accent is never a status, and a status is never decoration.**

## What changed

- **`src/ui/tokens.js` + `tokens.css`** — the palette, plus a font-size/radius/spacing
  scale, defined once. A contract test walks JS→CSS *and* CSS→JS, so neither file can
  drift or be emptied unnoticed, and pins the accent against every status colour.
- **`theme.js` re-pointed at the tokens** — recolours all 500+ existing `T.*` call sites
  in one commit, without editing a single screen.
- **58 hex literals and 9 `rgba()` literals removed from `EcuLab.jsx`**, which had been
  bypassing `theme.js` entirely despite `theme.js` always saying not to. A guard test now
  enforces it across hex, `rgba()` and `hsl()`.
- **Nine primitives** — Button, Panel, Eyebrow, Note, StatTile, Bar, Seg, Select, Toggle
  — each with a co-located CSS Module and component tests.
- **Start and tutorial screens rebuilt** on them, including the app's first `@media`
  queries.
- **Test suite: 233 → 408.**

## Buttons no longer span the monitor

The old UI set `width: '100%'` on every call-to-action. `Button` is content-width by
default and full-width only via an explicit `block` prop, with a test that fails if that
ever inverts. Note this is true of the **primitive**: 15 full-width buttons remain inside
`EcuLab.jsx` and migrate in PR 3.

## What did NOT change

**No physics.** `src/sim/`, `tests/fingerprint.test.js` and `tests/fixtures/` are
byte-identical to `main` across all 19 commits — verified, not assumed. That is the point:
a UI refactor that moves the behavioural fingerprint has broken something, and the
baseline was never regenerated.

**No production dependencies.** `@testing-library/react` and `jsdom` are devDependencies;
the `dependencies` block is untouched. All 54 added lockfile entries carry `"dev": true`.

## Deliberate deviation from the design doc

The spec said PR 1 makes "no screen changes". It makes two, documented in the plan's
Scope note: re-pointing `theme.js` unavoidably recolours every screen, and the entry
screens were converted so the primitives are exercised rather than dead code. The nav,
the four main tabs and the tuning grids are recoloured only — no structural change.

## Reviewed

Every task had an independent review; a whole-branch review followed, and both of its
fix waves landed. Worth knowing about:

- The **RUN DYNO PULL button's label measured 1.14:1 while a pull was running** — the
  app's most important control went blank exactly when you were watching it. Pre-existing,
  deepened by the token mapping, fixed here.
- **Two conflicting status-border conventions** had shipped in this same PR; left alone,
  PR 3's migration would have silently re-styled eight status boxes.
- The **four `*Line` tokens had ten call sites and no test coverage** — a missing key
  renders `border: 1px solid undefined`, which browsers drop silently.
- A **dangling `var(--acc-glow)`** rendered an invisible glow while passing every gate,
  because no test or build step can see an unresolved CSS custom property. All 24 `var()`
  references across every stylesheet were then swept; it was the only one.

## Known issues, disclosed

- **Commit `ae51d0d` alone fails `npm run lint`** (`'URL' is not defined`); the global
  arrives one commit later in `ac6fb60`. One commit, one gate. Not rebased away since
  `origin/main` has not moved.
- `EcuLab.jsx` still uses status colours decoratively in three places — `±` step buttons
  and two permanent chart series — which contradicts the rule this PR establishes. The
  rename made a pre-existing violation legible; PR 3 fixes it.
- `dangerLine` and `violetLine` measure 1.46:1 / 1.47:1 against their backgrounds, under
  the 3:1 guideline. They are nonetheless the best borders in the app: the bug they
  replaced was 1.00:1, and the app's default border is 1.20:1. Filed for the palette
  accessibility pass.

Design doc: `docs/superpowers/specs/2026-08-19-ui-overhaul-design.md`
Plan: `docs/superpowers/plans/2026-08-19-ui-design-system.md`

## Verification

`npm test` (408 passing), `npm run lint`, `npm run typecheck` and `npm run build` all
clean on Node 22.23.2, re-run at HEAD.

Part of #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd