### PR TITLE
UI overhaul PR 2: move EcuLab's state into a reducer-backed store

### DIFF
--- a/docs/superpowers/plans/2026-08-20-state-contexts.md
+++ b/docs/superpowers/plans/2026-08-20-state-contexts.md
@@ -922,15 +922,61 @@ Search for every write to `ve`/`timing`/`afr`, including the VE-acceptance path.
 
 Same method, for the 14 session fields.
 
+**Six of the fourteen were missing from earlier handover notes:** `histogram`, `live`,
+`throttleInput`, `loadKpa`, `soundOn`, `journeyStep`. They are already declared in
+`initialState.js`'s session typedef and initial value, but are still local `useState` in
+`EcuLabApp`. Do not work from a shorter list.
+
+**Like Task 5, this task is largely ADDITIVE.** `BANK_PULL` is the only session write the
+store receives today. `repairEngine` (`EcuLab.jsx:717`) writes local state ONLY — while
+`REPAIR_ENGINE` already exists in the reducer and is dispatched from nowhere. **Delete that
+setter without adding the dispatch and the REPAIR button goes inert, with no error
+anywhere and no test failing.**
+
+Two mirrors are the opposite case — already covered by the reducer, so **delete** them
+rather than converting: `applyEnginePreset`'s `setResult(null)` / `setPrevResult(null)`
+are written by `APPLY_PRESET`. And check `doRun`'s banking path for a local
+`setPrevResult(result)` whose ordering `BANK_PULL` now owns — the reducer's own comment
+warns that reversing it makes `prevResult` equal the NEW result.
+
 - [ ] **Step 1: Replace the `useState` calls with `useSession()` and destructuring**
 
 - [ ] **Step 2: Take particular care with `live` and `revealCount`**
 
-`live` is driven by an interval in a `useEffect` and updated at high frequency; `revealCount` drives the dyno reveal animation. Both are written from inside effects and refs. **Read those effects fully before changing them** — a stale closure over `dispatch` is not possible (React guarantees dispatch identity is stable), but a stale closure over a *slice value* is. Where an effect reads state to compute the next value, use the functional form via an action the reducer resolves, not a captured variable.
+`live` is driven by an interval in a `useEffect` and updated at high frequency;
+`revealCount` drives the dyno reveal animation. Both are written from inside effects and
+refs. **Read those effects fully before changing them** — a stale closure over `dispatch`
+is not possible (React guarantees dispatch identity is stable), but a stale closure over a
+*slice value* is. Where an effect reads state to compute the next value, use the functional
+form via an action the reducer resolves, not a captured variable.
 
-- [ ] **Step 3: Replace `resetToStock` and `repairEngine` with their actions**
+**`live` is the hardest thing in this PR. Do not paper over it.** It is written by
+`setLive((prev) => ...)` inside a 50 ms `setInterval` (`EcuLab.jsx:896-903`). A
+`SET_SESSION_FIELD` dispatch there would carry a value computed from whatever `live` the
+closure captured at mount, and the engine readout would freeze or jitter — a bug that
+looks like a physics problem, not a state problem. The interval must not read `live` from
+the render scope at all.
 
-`repairEngine` becomes a `REPAIR_ENGINE` dispatch. `resetToStock` becomes a `RESET_TO_STOCK` dispatch carrying the recomputed `ve`.
+Give it a dedicated action that computes the next value **inside** the reducer — a
+`LIVE_STEP` carrying only the inputs the step needs — so `prev` comes from the store
+rather than a closure. Actions must not carry functions.
+
+**`liveCfgRef.current` is assigned DURING RENDER** (`EcuLab.jsx:887`) from the destructured
+store values. Whatever you do here must keep that assignment happening on every render, or
+the live engine keeps running against stale tuning after an edit.
+
+If you conclude `LIVE_STEP` cannot be made to reproduce current behaviour exactly, **report
+BLOCKED with evidence rather than shipping an approximation.** A live readout that is
+subtly wrong is worse than an unconverted field: `live` may stay local and move in PR 3
+if that is the honest answer.
+
+- [ ] **Step 3: Dispatch `REPAIR_ENGINE`**
+
+`repairEngine` becomes a `REPAIR_ENGINE` dispatch. (`resetToStock` was already converted in
+Task 5 — leave it alone.) `REPAIR_ENGINE`'s reducer case is tested; its call site will not
+be. Add a component-level test that drives the real REPAIR control and asserts health
+actually returns to 100, then prove it bites by stubbing `repairEngine` and watching it
+fail.
 
 - [ ] **Step 4: Run the characterisation tests, then the full gate**
 

--- a/docs/superpowers/plans/2026-08-20-state-contexts.md
+++ b/docs/superpowers/plans/2026-08-20-state-contexts.md
@@ -549,6 +549,33 @@ it('patching the engine config merges and invalidates', () => {
 Confirm the merge preserves the config's other fields — a patch that replaces rather than
 merges would silently drop displacement, and the app would still render.
 
+**Close the nested-mutation blind spot while you are in this file.** Task 2's reviewer
+broke `SET_SESSION_FIELD` by mutating `state.session[action.field] = action.value` in
+place instead of spreading, re-ran `tests/ui/state/reducer.test.js`, and **all 16 tests
+still passed.** The shipped reducer is correct — every case spreads properly — but the
+suite cannot tell. The existing reference tests only assert that the slices you did NOT
+touch keep their identity; nothing asserts the slice you DID touch gets a fresh one.
+
+That is the exact bug class this design is meant to be safe against: a nested mutation
+survives a shallow equality check, so React skips the re-render and the screen silently
+stops matching the state. Task 3 adds several more cases to this reducer, so add the
+assertion now and let the new cases inherit it:
+
+```js
+describe('every write produces a fresh slice reference', () => {
+  it('replaces the changed slice rather than mutating it', () => {
+    const before = makeInitialState();
+    const after = reducer(before, { type: ACTIONS.SET_SESSION_FIELD, field: 'pullCount', value: 3 });
+    expect(after.session).not.toBe(before.session);
+    expect(before.session.pullCount).toBe(0); // the input state is untouched
+  });
+});
+```
+
+Apply the same two assertions to at least one build write and one tune write. Prove it
+bites: temporarily mutate the state argument in place in the case under test, confirm the
+new test fails, restore, and record the output in your report.
+
 - [ ] **Step 1: Write the failing tests**
 
 Append to `tests/ui/state/reducer.test.js`:

--- a/docs/superpowers/plans/2026-08-20-state-contexts.md
+++ b/docs/superpowers/plans/2026-08-20-state-contexts.md
@@ -28,7 +28,7 @@
 
 The design doc says "three contexts". Three *hooks* is what consumers get, and that part is unchanged. Internally this is one reducer, because the operations that matter cross every boundary:
 
-`applyEnginePreset` currently makes **23 sequential `setState` calls** spanning hardware, calibration tables and run results. Its own comment warns that routing its writes through the invalidating setters "would make that order-dependent". `resetToStock` makes six writes and documents that "the last call pins `tablesDirty` back to false". `withTableEdit` writes a **tune** table, then clears `presetId` (**build**), then sets `tablesDirty` (**tune**).
+`applyEnginePreset` currently makes **21 sequential `setState` calls** spanning hardware, calibration tables and run results. Its own comment warns that routing its writes through the invalidating setters "would make that order-dependent". `resetToStock` makes six writes and documents that "the last call pins `tablesDirty` back to false". `withTableEdit` writes a **tune** table, then clears `presetId` (**build**), then sets `tablesDirty` (**tune**).
 
 Three independent contexts would turn each of those into cross-context choreography, preserving the ordering hazards and adding provider-nesting rules to remember. A reducer computes the next state in one pass, so `APPLY_PRESET` becomes atomic and the hazard disappears rather than being documented.
 
@@ -294,7 +294,7 @@ Create `tests/ui/state/reducer.test.js`:
  * Reducer tests — pure, no DOM.
  *
  * The reducer exists so that operations spanning several slices happen in ONE pass.
- * EcuLab's applyEnginePreset makes 23 sequential setState calls and its own comment
+ * EcuLab's applyEnginePreset makes 21 sequential setState calls and its own comment
  * warns the order matters; resetToStock documents that "the last call pins tablesDirty
  * back to false". Those hazards are what this file exists to make impossible.
  */
@@ -687,7 +687,7 @@ npm run build
 git add src/ui/state/reducer.js tests/ui/state/reducer.test.js
 git commit -m "Make preset load, reset and repair atomic actions
 
-applyEnginePreset made 23 sequential setState calls and warned in a comment
+applyEnginePreset made 21 sequential setState calls and warned in a comment
 that routing them through the invalidating setters would make the result
 order-dependent. resetToStock made six and documented that the last one had to
 pin tablesDirty back to false.

--- a/docs/superpowers/plans/2026-08-20-state-contexts.md
+++ b/docs/superpowers/plans/2026-08-20-state-contexts.md
@@ -487,6 +487,68 @@ Claude-Session: https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd"
 
 These are the actions that justify the whole design. Read `applyEnginePreset` and `resetToStock` in `EcuLab.jsx` line by line before writing them; every field they touch must be accounted for.
 
+**Amendment (found during Task 2, decided by the controller).** Task 2 built
+`SET_BUILD_FIELD` to always clear `presetId`, faithfully mirroring `withPresetField`
+(`EcuLab.jsx:602`). But two of the fifteen build-slice fields are written today WITHOUT
+invalidating, and correctly so:
+
+- `boostSel` (`EcuLab.jsx:579`, written at `:1658`) is which RPM column the boost-curve
+  editor has selected — a cursor, not hardware. It is the build-side analogue of
+  `tune.selection`. Moving the cursor changes nothing about the engine.
+- `presetPrompt` (`:566`, written at `:775`, `:785`, `:1514`) is the overwrite-confirmation
+  dialog. Opening or dismissing a dialog is not a build change.
+
+Routing either through `SET_BUILD_FIELD` would clear `presetId` and make the header stop
+claiming a factory preset because the player clicked a column header or opened a dialog.
+
+**Add two dedicated actions — `ACTIONS.SET_BOOST_SEL` and `ACTIONS.SET_PRESET_PROMPT` —
+not one generic non-invalidating setter.** The comment at `EcuLab.jsx:596` says the
+`withPresetField` wrapper "is what stops the next field from being forgotten". A generic
+`SET_BUILD_FIELD_RAW` would be an escape hatch a future caller could reach for on a
+hardware field, silently reintroducing exactly the stale-preset bug the wrapper exists to
+prevent. Two narrow, single-purpose actions cannot be misused that way.
+
+Each needs a test asserting `presetId` SURVIVES the write:
+
+```js
+describe('non-invalidating build writes', () => {
+  it('moving the boost-curve cursor does not disown the preset', () => {
+    const loaded = makeInitialState();
+    loaded.build = { ...loaded.build, presetId: 'n54' };
+    const s = reducer(loaded, { type: ACTIONS.SET_BOOST_SEL, value: 6 });
+    expect(s.build.boostSel).toBe(6);
+    expect(s.build.presetId).toBe('n54');
+  });
+
+  it('opening the overwrite prompt does not disown the preset', () => {
+    const loaded = makeInitialState();
+    loaded.build = { ...loaded.build, presetId: 'n54' };
+    const s = reducer(loaded, { type: ACTIONS.SET_PRESET_PROMPT, value: { presetId: 'k20' } });
+    expect(s.build.presetPrompt).toEqual({ presetId: 'k20' });
+    expect(s.build.presetId).toBe('n54');
+  });
+});
+```
+
+**Also add `ACTIONS.SET_ENGINE_CONFIG_PATCH`** here rather than in Task 4. `setCfg`
+(`EcuLab.jsx:738`) is `setEngineConfigInvalidating((c) => ({ ...c, ...patch }))` — a
+functional update. The reducer already holds the current state, so the action carries a
+plain `patch` object and the reducer does the merge. Do not pass functions through
+actions. It DOES invalidate, like every other hardware write:
+
+```js
+it('patching the engine config merges and invalidates', () => {
+  const loaded = makeInitialState();
+  loaded.build = { ...loaded.build, presetId: 'n54' };
+  const s = reducer(loaded, { type: ACTIONS.SET_ENGINE_CONFIG_PATCH, patch: { cylinders: 8 } });
+  expect(s.build.engineConfig.cylinders).toBe(8);
+  expect(s.build.presetId).toBeNull();
+});
+```
+
+Confirm the merge preserves the config's other fields — a patch that replaces rather than
+merges would silently drop displacement, and the app would still render.
+
 - [ ] **Step 1: Write the failing tests**
 
 Append to `tests/ui/state/reducer.test.js`:

--- a/docs/superpowers/plans/2026-08-20-state-contexts.md
+++ b/docs/superpowers/plans/2026-08-20-state-contexts.md
@@ -15,6 +15,29 @@
 - **No changes to `src/sim/`.**
 - **No new dependencies**, of any kind.
 - **No observable behaviour change.** This is a refactor. If a characterisation test needs editing to pass, the refactor is wrong — not the test.
+- **The reducer is pure, with exactly one documented exception.** No `Date.now()`, no
+  `Math.random()`, no mutation of the state argument — **except `LIVE_STEP`**, which is a
+  simulation integrator. It calls `liveStep` (`src/sim/live.js:73`), whose `sensorRead`
+  (`:47`) uses `Math.random()` for sensor noise. No other case may do this.
+
+  This was measured, not conceded. The pure alternative — a render-assigned `liveRef`
+  read by the interval, with `liveStep` called outside the reducer — applies roughly
+  **half** the integration steps it should (0.51 vs 0.96 applied-step ratio over 40
+  interleaved ticks; 1 step in 81 with renders fully deferred). `live` is a fold
+  accumulator, not an input: `liveCfgRef` and `throttleRef` may be one commit stale
+  because a stale *input* for one tick is invisible, but if the commit has not landed
+  when the next tick fires, a ref-read `prev` makes that tick recompute from the same
+  base and **discard** the previous step. Queued `LIVE_STEP` actions instead fold off one
+  another on the hook queue and lose nothing. The error is load-dependent, so it would
+  read as an engine that spins up at a silently variable fraction of real time — a
+  physics bug, not a state bug.
+
+  **PR 4 must exclude `LIVE_STEP` from the undo log**, and would have had to regardless of
+  purity: 20 actions/second is 72,000 entries an hour, each pinning a `cfg` that
+  references the full VE/timing/AFR tables. The live engine is ephemeral simulation
+  state. One-step replay divergence is fractional; multi-step replay is a bounded random
+  walk through the learned fuel trim, because noise feeds `sensedLambda` → `stft` →
+  `ltft` → `mafScalar`.
 - Test files import assertions explicitly from `vitest` — there are no globals, and no setup file, so component tests need `afterEach(cleanup)`.
 - Under `@vitest-environment jsdom` the global `URL` is jsdom's, which `fs.readFileSync` rejects. Use `import { URL as NodeURL } from 'node:url'` for source-text assertions.
 - `no-undef` and `no-unused-vars` are active in ESLint.

--- a/docs/superpowers/plans/2026-08-20-state-contexts.md
+++ b/docs/superpowers/plans/2026-08-20-state-contexts.md
@@ -847,6 +847,52 @@ Commit with a message describing which slice moved and confirming the characteri
 
 Same method as Task 4, for `ve`, `timing`, `afr`, `tablesDirty`, `selection`.
 
+**But not the same shape as Task 4, and assuming otherwise will cost you.** Task 4 left the
+store's `build` slice authoritative — every build write goes through a dispatch. It did
+**not** do the same for `tune`. Only two paths write the store's tune slice today, both
+inside cross-slice actions: `APPLY_PRESET` and `RESET_TO_STOCK`. Everything else still
+writes local state ONLY:
+
+- `withTableEdit` (`EcuLab.jsx:599`) — every hand edit to VE, spark or fuel
+- `recalcVE` (`:662`) — the VE-acceptance path
+- `changeTab` (`:699`) and `SelectionDock`'s `setData` — both write `selection`
+
+So Task 5 must **add** `SET_TABLE` / `SET_TUNE_FIELD` dispatches at those sites, not merely
+delete local setters. Verify each against the store rather than assuming Task 4 populated
+it. A field you only delete the local writer for goes silently stale.
+
+**`tests/ui/build-store.test.jsx`'s overwrite-prompt test WILL break, and the reason is
+subtle.** Its setup depends on `tablesDirty` being local: it hand-edits a table (local
+`tablesDirty → true`, the store's stays `false`), then dispatches `APPLY_PRESET` to put a
+preset label back — which clears the *store's* `tune.tablesDirty` but cannot touch the
+local one, so `hasTuningWork()` still returns true and the prompt opens. The moment
+`tablesDirty` moves to the store, `APPLY_PRESET` clears it and the prompt stops opening;
+the test dies at its `/^LOAD /` query.
+
+**Reseed it — do not weaken it.** After the `APPLY_PRESET` dispatch, add:
+
+```jsx
+act(() => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'tablesDirty', value: true }));
+```
+
+`SET_TUNE_FIELD` deliberately does not clear `presetId`, which is exactly the seam this
+needs. The test's assertions must not change — only its setup. That test is the only thing
+standing between `presetPrompt` and a regression, so if you find yourself deleting an
+assertion to make it pass, stop and report instead.
+
+**One functional update to resolve.** `setVeEdited` has a functional call site at
+`EcuLab.jsx:992`. `SET_TABLE` carries a value, not a function, so resolve it against the
+current `ve` at the call site.
+
+**Fix `clearPresetId` while you are here.** It currently dispatches
+`{ type: SET_BUILD_FIELD, field: 'presetId', value: null }` (`EcuLab.jsx:598`), which works
+only by coincidence: the computed key is overwritten by the reducer's own trailing
+`presetId: null`. A future caller passing a non-null value would silently get `null` — a
+header that refuses to name a preset, with no error anywhere. Task 5 collapses
+`withTableEdit` into `SET_TABLE` and leaves `clearPresetId` with a single caller (the
+picker's "Custom build" option at `:1464`), so this is the cheapest moment to fix it: add
+`ACTIONS.CLEAR_PRESET_ID`, give it a reducer case and a test, and use it at that one site.
+
 - [ ] **Step 1: Replace the five `useState` calls with `useTune()` and destructuring**
 
 - [ ] **Step 2: Replace `withTableEdit`**

--- a/docs/superpowers/plans/2026-08-20-state-contexts.md
+++ b/docs/superpowers/plans/2026-08-20-state-contexts.md
@@ -713,6 +713,60 @@ Claude-Session: https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd"
 
 This is the first mechanical wiring task. **Work one field at a time and run the characterisation tests between each** — that is what they are for.
 
+**This task is not actually mechanical, and the reason is worth reading before you start.**
+
+Three functions in `EcuLab.jsx` write across slice boundaries: `applyEnginePreset` (21
+writes), `resetToStock` (7), and the score-banking tail of `doRun`. Task 4 removes the
+build slice's `useState` declarations — so the moment they are gone, those functions have
+no `setEngineConfig` to call. You cannot leave them alone, and you cannot fully convert
+them either, because `tune` and `session` are still local `useState` until Tasks 5 and 6.
+
+**The interim shape, for each of the three:** dispatch the atomic action AND keep the
+still-local setters for the slices that have not moved yet.
+
+```jsx
+const applyEnginePreset = (preset) => {
+  const p = applyPreset(preset);
+  dispatch({ type: ACTIONS.APPLY_PRESET, preset: p });   // build lands in the store
+  // tune + session are still local useState until Tasks 5 and 6 — keep writing them.
+  setVe(p.ve); setTiming(p.timing); setAfr(p.afr);
+  setSelection(null); setTablesDirty(false);
+  setResult(null); setPrevResult(null);
+};
+```
+
+This is safe because nothing reads `state.tune` or `state.session` yet. The store's copies
+of those slices are written and simply unread until their task arrives, at which point the
+duplicate local setters are deleted. Task 5 removes the tune lines, Task 6 the session
+lines. **Do not skip the store dispatch for the not-yet-moved slices** — writing the
+store's tune/session now is what makes Task 5 and Task 6 a deletion rather than a rewrite.
+
+**Four traps the review of Task 3 identified. Each produces a plausible-looking wrong
+result, not a crash:**
+
+1. **`APPLY_PRESET`'s payload is `applyPreset(rawPreset)`'s OUTPUT, not the raw
+   `ENGINE_PRESETS` entry.** Pass the raw entry and `p.engineConfig` is `undefined` — a
+   build with no short block.
+
+2. **`RESET_TO_STOCK` takes `ve` in its payload; the reducer does not compute it.** The
+   call site must pass `computeHardwareVE(engineConfig, DEFAULT_MODS, hwForVe)` — note the
+   asymmetry: `DEFAULT_MODS` for the mods argument, but the **current** `hwForVe`
+   (`EcuLab.jsx:665`) for hardware. Resetting the calibration does not un-install the
+   turbo. Passing current mods, or a stock `hwForVe`, both yield a table that looks
+   entirely reasonable and is wrong.
+
+3. **`boostSel` and `presetPrompt` go through `SET_BOOST_SEL` and `SET_PRESET_PROMPT`
+   only.** Routing either through `SET_BUILD_FIELD` clears `presetId`, so the header stops
+   claiming the factory preset because the player clicked an RPM column header or opened a
+   dialog. Task 1's characterisation tests will not catch this — write a test that does.
+
+4. **`choosePreset` (`EcuLab.jsx:784-787`) branches on `hasTuningWork()`, which reads
+   `tablesDirty` — still local in this task.** Keep reading the local one; Task 5 moves it.
+
+**`SET_ENGINE_CONFIG_PATCH` already exists** (added in Task 3) — `setCfg` becomes
+`dispatch({ type: ACTIONS.SET_ENGINE_CONFIG_PATCH, patch })`. Do not re-add it, and do not
+pass the function form through an action.
+
 - [ ] **Step 1: Wrap the app in the provider**
 
 In `src/main.jsx`, wrap `<EcuLab />` in `<StoreProvider>`, inside the existing `<ErrorBoundary>`.
@@ -740,7 +794,9 @@ dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: v });
 
 `setTurbineIdxInvalidating` becomes `{ type: ACTIONS.SET_TURBINE, value: idx }`.
 
-**Watch for functional updates.** `setCfg` does `setEngineConfigInvalidating((c) => ({ ...c, ...patch }))`. The reducer already has the current state, so this becomes a patch action — add `SET_ENGINE_CONFIG_PATCH` if it is cleaner than resolving the function at the call site. Do not pass functions through actions.
+**Functional updates are already handled.** `setCfg` was
+`setEngineConfigInvalidating((c) => ({ ...c, ...patch }))`; it becomes
+`dispatch({ type: ACTIONS.SET_ENGINE_CONFIG_PATCH, patch })`, which the reducer merges.
 
 - [ ] **Step 4: Run the characterisation tests after every few fields**
 

--- a/docs/superpowers/plans/2026-08-20-state-contexts.md
+++ b/docs/superpowers/plans/2026-08-20-state-contexts.md
@@ -447,7 +447,7 @@ Implement at minimum: `SET_BUILD_FIELD`, `SET_TURBINE`, `SET_TABLE`, `SET_SESSIO
 
 Every case must return new objects only for the slices it changes — the other slices keep their identity, which is what the "leaves the other slices untouched by reference" test pins.
 
-Write a file header explaining why this is one reducer over three, referencing the 23-write `applyEnginePreset` and the order hazard.
+Write a file header explaining why this is one reducer over three, referencing the 21-write `applyEnginePreset` and the order hazard.
 
 - [ ] **Step 5: Write the provider and hooks**
 
@@ -1016,16 +1016,22 @@ fail.
 - [ ] **Step 1: Confirm the wrappers and their setters are gone**
 
 ```bash
-grep -c "withPresetField\|withTableEdit\|Invalidating\|setVeEdited\|setTimingEdited\|setAfrEdited" src/ui/EcuLab.jsx
+grep -n "withPresetField\|withTableEdit\|Invalidating\|setVeEdited\|setTimingEdited\|setAfrEdited" src/ui/EcuLab.jsx
 ```
-Expected: **0**.
+
+Expect **only comments**. Four surviving references at `:584`, `:589`, `:590` and `:1007`
+name the removed wrappers in order to explain what replaced them and why — that is
+documentation worth keeping, not leftover code. What must NOT appear is any of these
+names being *called* or *assigned*. Read the hits rather than counting them.
 
 - [ ] **Step 2: Confirm only view state remains local**
 
 ```bash
 grep -n "const \[.*\] = useState" src/ui/EcuLab.jsx
 ```
-Expected: only `appView`, `tab`, `tuneView`, `dynoView`, `dashSection`, `buildSection` — six, plus `ExpandableInfo`'s own `open`, which is a different component. Anything else means a field was missed.
+Expected: exactly seven — `open` (`:85`, inside `ExpandableInfo`, a different component)
+plus `appView`, `tab`, `buildSection`, `tuneView`, `dynoView`, `dashSection`. Anything
+else means a field was missed. All seven become route state in PR 3.
 
 - [ ] **Step 3: Check the docs for stale structural claims**
 
@@ -1072,7 +1078,7 @@ Expected: **no output.** This PR adds nothing.
 git push -u origin feat/58-state-contexts
 ```
 
-The PR body must state: what moved and what deliberately did not (view state, because PR 3 absorbs it into routing); that the render is unchanged; that `applyEnginePreset`'s 23-write ordering hazard is now absent rather than documented; that the characterisation tests were written first and stayed green throughout; and the fingerprint evidence from step 6. Close #58 and reference #6.
+The PR body must state: what moved and what deliberately did not (view state, because PR 3 absorbs it into routing); that the render is unchanged; that `applyEnginePreset`'s 21-write ordering hazard is now absent rather than documented; that the characterisation tests were written first and stayed green throughout; and the fingerprint evidence from step 6. Close #58 and reference #6.
 
 - [ ] **Step 9: Check no auto-merge is queued**
 
@@ -1082,6 +1088,48 @@ gh pr view --json autoMergeRequest
 Expected `null`. If not, `gh pr merge <N> --disable-auto`. **Do not merge this PR.**
 
 ---
+
+- [ ] **Step 10: Sweep the findings this PR deferred**
+
+These were all found and deliberately deferred during Tasks 1-6. Fix what is cheap and
+correct; report anything you judge should wait for PR 3 rather than doing it badly here.
+
+1. **Stale docblock references in `src/ui/state/`.** `initialState.js`'s header says its
+   defaults are "copied verbatim from EcuLab.jsx's `useState` initialisers (around lines
+   535-592)" — those `useState` calls no longer exist and `initialState.js` is now the
+   sole definition, not a copy. `reducer.js`'s `SET_ENGINE_CONFIG_PATCH` typedef cites
+   `setEngineConfigInvalidating`, an identifier that no longer exists anywhere. Line
+   citations drifting is unavoidable; a docblock naming a deleted identifier as if it
+   were live code is what misleads.
+
+2. **`initialState.js:80` documents `throttleInput` as `0..1`; the code writes `0`/`100`.**
+   Pre-existing, unrelated to this PR, and a one-word fix. Confirm which is true from the
+   call sites before editing — do not assume the comment is the wrong half.
+
+3. **`LivePatchAction.patch` is typed `object` (`reducer.js:~234`), and `LiveStepAction.cfg`
+   likewise.** So `dispatch({type: LIVE_PATCH, patch: {crankign: true}})` typechecks and
+   the reducer spreads the typo into `live`. The root cause is `SessionState.live` being
+   typed `object` in `initialState.js:78`. A real `LiveState` typedef would close all
+   three. `src/sim/live.js` defines the shape — read it, do not invent one. If that turns
+   out to be more than a small job, say so and leave it: the `KnownStoreAction` union's
+   value is weakened by this, not defeated.
+
+4. **`T.panelHi` is a dead alias** for `tokens.panel3` in `src/ui/theme.js` — deferred from
+   PR 1. Delete it if nothing references it.
+
+- [ ] **Step 11: Record what is NOT covered**
+
+Two gaps are known and should be stated in the PR body rather than discovered later:
+
+- **No single test spans hand-edit → `tablesDirty` → overwrite prompt end to end.** Moving
+  `tablesDirty` into the store made that impossible in one test; it is now covered in
+  three pieces across two files (characterisation test 2 proves a real UI edit reaches
+  `SET_TABLE`; a reducer test proves `SET_TABLE` sets the flag; `build-store.test.jsx`
+  proves the flag opens the prompt). The now-inert hand-edit block in that test's setup is
+  what keeps its preconditions realistic — **do not tidy it away.**
+- **Everything here is jsdom.** The live engine, the audio synth, animation and the reveal
+  timer are exercised only as far as the suites reach. Nobody has loaded the app in a
+  browser during this PR.
 
 ## Notes for the implementer
 

--- a/docs/superpowers/plans/2026-08-20-state-contexts.md
+++ b/docs/superpowers/plans/2026-08-20-state-contexts.md
@@ -1,0 +1,812 @@
+# State Extraction (PR 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move 34 pieces of domain state out of `src/ui/EcuLab.jsx` into a tested store, without changing a single observable behaviour — so PR 3 can split the component into screens.
+
+**Architecture:** One root reducer over three slices (`build`, `tune`, `session`), exposed through three hooks — `useBuild()`, `useTune()`, `useSession()` — so consumers see the three-way split the design doc specifies. The render stays monolithic; only state moves.
+
+**Tech Stack:** React 18 `useReducer` + context, Vitest, `@testing-library/react`, JSDoc types checked by `tsc --checkJs`. No new dependencies.
+
+## Global Constraints
+
+- **Node 20 or 22 only — never 26.** `.nvmrc` pins 22. Newer V8 shifts float results and invalidates the fingerprint hash.
+- **`tests/fingerprint.test.js` must stay green and must NOT be regenerated.** No task here touches physics. Never run `npm run test:fingerprint:update`.
+- **No changes to `src/sim/`.**
+- **No new dependencies**, of any kind.
+- **No observable behaviour change.** This is a refactor. If a characterisation test needs editing to pass, the refactor is wrong — not the test.
+- Test files import assertions explicitly from `vitest` — there are no globals, and no setup file, so component tests need `afterEach(cleanup)`.
+- Under `@vitest-environment jsdom` the global `URL` is jsdom's, which `fs.readFileSync` rejects. Use `import { URL as NodeURL } from 'node:url'` for source-text assertions.
+- `no-undef` and `no-unused-vars` are active in ESLint.
+- `git status` permanently shows ` D node_modules` — a tracked self-referential symlink replaced by a real directory. **Never stage it.** Always `git add` explicit paths.
+- macOS: BSD `sed` has no `\b`.
+- Capture exit codes on the line **after** the command, never after a pipe.
+- Branch is `feat/58-state-contexts`. Never commit to `main`.
+- Every commit message ends with the repo's `Co-Authored-By:` and `Claude-Session:` trailers.
+
+## Why one reducer and not three contexts
+
+The design doc says "three contexts". Three *hooks* is what consumers get, and that part is unchanged. Internally this is one reducer, because the operations that matter cross every boundary:
+
+`applyEnginePreset` currently makes **23 sequential `setState` calls** spanning hardware, calibration tables and run results. Its own comment warns that routing its writes through the invalidating setters "would make that order-dependent". `resetToStock` makes six writes and documents that "the last call pins `tablesDirty` back to false". `withTableEdit` writes a **tune** table, then clears `presetId` (**build**), then sets `tablesDirty` (**tune**).
+
+Three independent contexts would turn each of those into cross-context choreography, preserving the ordering hazards and adding provider-nesting rules to remember. A reducer computes the next state in one pass, so `APPLY_PRESET` becomes atomic and the hazard disappears rather than being documented.
+
+It also makes PR 4's undo natural: one ordered action log instead of three.
+
+## What is deliberately NOT extracted
+
+Seven pieces of **view** state (six in `EcuLab`, one in `ExpandableInfo`) stay as local `useState` in `EcuLab.jsx`:
+
+`appView`, `tab`, `tuneView`, `dynoView`, `dashSection`, `buildSection`, and `ExpandableInfo`'s local `open`.
+
+Every one of those becomes **route** state in PR 3 when hash routing lands. Extracting them now is work PR 3 would immediately undo. `journeyStep` is not view state — it is onboarding progress that must survive navigation — so it goes in `session`.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/ui/state/initialState.js` | The three slices' starting values, and the defaults they derive from |
+| `src/ui/state/reducer.js` | The root reducer and its action types |
+| `src/ui/state/StoreProvider.jsx` | The provider plus `useBuild`/`useTune`/`useSession` hooks |
+| `tests/ui/characterisation.test.jsx` | Behavioural tests written **before** any state moves |
+| `tests/ui/state/reducer.test.js` | Pure reducer tests, no DOM |
+
+## Slice membership
+
+**build** (15): `engineConfig`, `mods`, `turboOn`, `boostCurve`, `octaneIdx`, `injIdx`, `mafScalar`, `turbineIdx`, `turbineCount`, `compressorIdx`, `exhaustDiaIdx`, `ecuInjectorCc`, `presetId`, `presetPrompt`, `boostSel`
+
+**tune** (5): `ve`, `timing`, `afr`, `tablesDirty`, `selection`
+
+**session** (14): `running`, `result`, `prevResult`, `revealCount`, `bestScore`, `totalScore`, `pullCount`, `health`, `histogram`, `live`, `throttleInput`, `loadKpa`, `soundOn`, `journeyStep`
+
+---
+
+### Task 1: Pin the behaviour before moving anything
+
+**Files:**
+- Create: `tests/ui/characterisation.test.jsx`
+
+**Interfaces:**
+- Consumes: `EcuLab` default export from `src/ui/EcuLab.jsx`, unchanged.
+- Produces: nothing importable. Produces the safety net every later task depends on.
+
+This task exists because the 408 existing tests cover physics, tokens and primitives — **almost nothing exercises `EcuLab`'s behaviour.** A mis-wired setter in Task 4 would compile, typecheck, build and pass CI while silently breaking the app. These tests are the only thing that will notice.
+
+Write them against the CURRENT code. They must pass before you change anything.
+
+- [ ] **Step 1: Read the flows before testing them**
+
+Open `src/ui/EcuLab.jsx` and find how the app reaches each screen. Note in particular: the start screen dispatches on `appView`, the preset picker uses a `<select>`, and the overwrite-confirmation prompt keys off `hasTuningWork()`. Do not guess at the DOM — read it.
+
+- [ ] **Step 2: Write the characterisation tests**
+
+Create `tests/ui/characterisation.test.jsx`:
+
+```jsx
+// @vitest-environment jsdom
+
+/**
+ * Characterisation tests: what the app DOES today, pinned before its state moves.
+ *
+ * PR 2 is a pure refactor — 34 pieces of state leave EcuLab.jsx for a store, and by
+ * definition nothing observable should change. The problem is that a refactor with no
+ * behavioural tests is unverifiable: a setter wired to the wrong slice still compiles,
+ * still typechecks, still builds, and still passes 408 tests about physics and buttons.
+ *
+ * These do not describe what the app SHOULD do. They describe what it does now, so the
+ * refactor has something to preserve. If one of these fails after the extraction, the
+ * extraction is wrong — do not edit the test to match the new behaviour.
+ */
+
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import EcuLab from '../../src/ui/EcuLab.jsx';
+
+afterEach(cleanup);
+
+/** Renders the app and clicks past the start screen into the build tab. */
+function launch() {
+  const view = render(<EcuLab />);
+  fireEvent.click(screen.getByRole('button', { name: 'START' }));
+  return view;
+}
+
+describe('entry', () => {
+  it('opens on the start screen', () => {
+    render(<EcuLab />);
+    expect(screen.getByRole('button', { name: 'START' })).toBeTruthy();
+  });
+
+  it('enters the app on START and lands on BUILD', () => {
+    launch();
+    expect(screen.getByRole('button', { name: /BUILD/ })).toBeTruthy();
+  });
+
+  it('opens the tutorial and comes back', () => {
+    render(<EcuLab />);
+    fireEvent.click(screen.getByRole('button', { name: 'TUTORIAL' }));
+    expect(screen.getByText(/TUTORIAL · 1\//)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'SKIP' }));
+    expect(screen.getByRole('button', { name: /BUILD/ })).toBeTruthy();
+  });
+});
+
+describe('navigation', () => {
+  it('moves between the four tabs', () => {
+    launch();
+    for (const tab of ['TUNE', 'DYNO', 'HOME', 'BUILD']) {
+      fireEvent.click(screen.getByRole('button', { name: new RegExp(tab) }));
+      expect(screen.getByRole('button', { name: new RegExp(tab) })).toBeTruthy();
+    }
+  });
+});
+
+describe('the header reflects the build', () => {
+  it('names the current engine and fuel', () => {
+    launch();
+    // The header line is `${engineName} · ${turbo} · ${octane} oct · ${injector} · ${version}`.
+    // Pin that it renders at all and carries an octane figure; the exact preset name is
+    // not the point.
+    expect(screen.getByText(/oct/)).toBeTruthy();
+  });
+});
+```
+
+**Then add the three flows that matter most.** These queries were derived by reading the current DOM, not guessed — but verify each still matches before trusting it.
+
+The facts they rest on, all confirmed in `EcuLab.jsx` at time of writing:
+- The header line (`:1142`) renders `` `${engineName} · ${turbo} · ${octane} oct · ${injector} · ${version}` ``.
+- `engineName` (`:1093`) is the preset's name when one is loaded, and otherwise falls back to `` `${displacementL.toFixed(1)}L ${configuration}` `` — e.g. `3.0L I6`. **That fallback is how you detect preset invalidation from the DOM.**
+- The preset picker is the only `<select>` carrying `<optgroup>` elements — `GroupedSelect` (`:127`, used at `:1443`). It has no accessible name, so `getByRole('combobox', {name})` will not find it.
+- Table cells are plain `<button>`s whose text is the formatted cell value (`:358`).
+- `SelectionDock` (`:407`) renders delta buttons labelled `+1`, `-1` and so on (`{d > 0 ? '+' : ''}{d}`).
+- The dyno button reads `RUN DYNO PULL`, or `SWEEPING…` while running (`:2012`).
+- The reveal is a `setInterval` (`:883`) that clears itself and sets `running` false when done.
+
+```jsx
+/** The preset picker is the only select with optgroups. */
+function presetPicker() {
+  return screen.getAllByRole('combobox').find((el) => el.querySelector('optgroup'));
+}
+
+describe('loading a preset', () => {
+  it('rewrites the header to name that preset', () => {
+    // Exercises applyEnginePreset's 23 writes across all three slices in one go.
+    launch();
+    const picker = presetPicker();
+    expect(picker).toBeTruthy();
+    const target = [...picker.querySelectorAll('option')]
+      .map((o) => o.value)
+      .find((v) => v && v !== picker.value);
+    fireEvent.change(picker, { target: { value: target } });
+    // With a preset loaded the header shows its NAME, not the "3.0L I6" fallback.
+    expect(screen.getByText(/oct/).textContent).not.toMatch(/^\d\.\dL /);
+  });
+});
+
+describe('editing a calibration table', () => {
+  it('stops the header claiming the factory preset', () => {
+    // The single most important behaviour in this PR: withTableEdit crosses the
+    // build/tune boundary, clearing presetId (build) and setting tablesDirty (tune).
+    // If the extraction drops that link, the header goes on claiming a factory
+    // calibration the player has just edited away from.
+    launch();
+    const picker = presetPicker();
+    const target = [...picker.querySelectorAll('option')]
+      .map((o) => o.value)
+      .find((v) => v && v !== picker.value);
+    fireEvent.change(picker, { target: { value: target } });
+
+    fireEvent.click(screen.getByRole('button', { name: /TUNE/ }));
+    // Any grid cell; the first numeric-labelled button inside the grid will do.
+    const cells = screen.getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent));
+    fireEvent.click(cells[Math.floor(cells.length / 2)]);
+    fireEvent.click(screen.getByRole('button', { name: '+1' }));
+
+    // Header falls back to the derived "3.0L I6" form once the preset is invalidated.
+    expect(screen.getByText(/oct/).textContent).toMatch(/^\d\.\dL /);
+  });
+});
+
+describe('running a dyno pull', () => {
+  it('produces a result', async () => {
+    launch();
+    fireEvent.click(screen.getByRole('button', { name: /DYNO/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'RUN DYNO PULL' }));
+    // The reveal is a setInterval that ends by setting running false, so the button
+    // returns to its idle label. Real timers + waitFor is less brittle here than fake
+    // timers, which would need act() wrapping around every tick.
+    await waitFor(
+      () => expect(screen.getByRole('button', { name: 'RUN DYNO PULL' })).toBeTruthy(),
+      { timeout: 10000 },
+    );
+  });
+});
+```
+
+Add `waitFor` and `within` to the `@testing-library/react` import as needed.
+
+If a flow proves genuinely untestable in jsdom (canvas, Web Audio, `requestAnimationFrame`), **report that rather than deleting the test** — an untestable flow is a finding the controller needs, and it tells PR 3 where the risk is. Likewise if the dyno pull needs Web Audio stubbing: `ensureAudio()` is called on user gesture, so it may need a `window.AudioContext` stub. Report what you had to stub.
+
+- [ ] **Step 3: Run them against unmodified code**
+
+```bash
+npm test -- tests/ui/characterisation.test.jsx
+```
+Expected: **PASS**. These describe current behaviour, so they must be green before anything moves. If one fails, either your query is wrong or you have found a real bug — investigate and report which.
+
+- [ ] **Step 4: Prove they can fail**
+
+Temporarily break something small and real in `EcuLab.jsx` — for example, make `changeTab` a no-op — and confirm the navigation test fails. Restore it. **Report which test caught it.** A characterisation suite that passes against a broken app is worthless, and this is the only chance to check.
+
+- [ ] **Step 5: Run the full gate and commit**
+
+```bash
+npm test
+npm run lint
+npm run typecheck
+npm run build
+```
+
+```bash
+git add tests/ui/characterisation.test.jsx
+git commit -m "Pin EcuLab's behaviour before its state moves
+
+408 tests cover physics, tokens and primitives; almost nothing exercises the
+app's own flows. A state extraction that mis-wires a setter would compile,
+typecheck, build and pass CI while silently breaking the app.
+
+These describe what the app does today, not what it should do. If one fails
+after the extraction, the extraction is wrong.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd"
+```
+
+---
+
+### Task 2: The store — initial state, reducer, provider
+
+**Files:**
+- Create: `src/ui/state/initialState.js`
+- Create: `src/ui/state/reducer.js`
+- Create: `src/ui/state/StoreProvider.jsx`
+- Test: `tests/ui/state/reducer.test.js`
+- Modify: `tsconfig.json` (add `src/ui/state` to `include`)
+
+**Interfaces:**
+- Consumes: `DEFAULT_ENGINE_CONFIG`, `DEFAULT_MODS`, `DEFAULT_TIMING`, `DEFAULT_AFR`, `DEFAULT_BOOST`, `EXHAUST_DIA_OPTS`, `computeHardwareVE`, `makeLiveState`, `clone2D` — all already imported by `EcuLab.jsx`; copy its import list.
+- Produces:
+  - `makeInitialState(): {build, tune, session}`
+  - `reducer(state, action): state`
+  - `StoreProvider({children})`, `useBuild()`, `useTune()`, `useSession()` — each hook returns `[slice, dispatch]`.
+  - Action types as a frozen `ACTIONS` object.
+
+- [ ] **Step 1: Write the failing reducer test**
+
+Create `tests/ui/state/reducer.test.js`:
+
+```js
+/**
+ * Reducer tests — pure, no DOM.
+ *
+ * The reducer exists so that operations spanning several slices happen in ONE pass.
+ * EcuLab's applyEnginePreset makes 23 sequential setState calls and its own comment
+ * warns the order matters; resetToStock documents that "the last call pins tablesDirty
+ * back to false". Those hazards are what this file exists to make impossible.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { makeInitialState } from '../../../src/ui/state/initialState.js';
+import { ACTIONS, reducer } from '../../../src/ui/state/reducer.js';
+
+describe('makeInitialState', () => {
+  it('returns the three slices', () => {
+    const s = makeInitialState();
+    expect(Object.keys(s).sort()).toEqual(['build', 'session', 'tune']);
+  });
+
+  it('starts with no preset loaded and clean tables', () => {
+    const s = makeInitialState();
+    expect(s.build.presetId).toBeNull();
+    expect(s.tune.tablesDirty).toBe(false);
+  });
+
+  it('returns a fresh object each call, not a shared reference', () => {
+    // A shared initial state would let one test's mutation leak into the next, and
+    // one player's reset leak into their next build.
+    const a = makeInitialState();
+    const b = makeInitialState();
+    expect(a).not.toBe(b);
+    expect(a.tune.ve).not.toBe(b.tune.ve);
+  });
+});
+
+describe('SET_BUILD_FIELD', () => {
+  it('sets the field', () => {
+    const s = reducer(makeInitialState(), {
+      type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: true,
+    });
+    expect(s.build.turboOn).toBe(true);
+  });
+
+  it('clears the preset label, because a hand edit is no longer that preset', () => {
+    const loaded = { ...makeInitialState() };
+    loaded.build = { ...loaded.build, presetId: 'n54' };
+    const s = reducer(loaded, {
+      type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: true,
+    });
+    expect(s.build.presetId).toBeNull();
+  });
+
+  it('does not flag the calibration tables as dirty', () => {
+    // Hardware edits invalidate the preset LABEL only. tablesDirty means unsaved
+    // player work on the calibration, and is what the overwrite prompt keys off.
+    const s = reducer(makeInitialState(), {
+      type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: true,
+    });
+    expect(s.tune.tablesDirty).toBe(false);
+  });
+
+  it('leaves the other slices untouched by reference', () => {
+    const before = makeInitialState();
+    const after = reducer(before, {
+      type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: true,
+    });
+    expect(after.session).toBe(before.session);
+  });
+});
+
+describe('SET_TURBINE', () => {
+  it('fits one of the chosen housing, because a twin-turbo count belongs to a preset', () => {
+    const twin = { ...makeInitialState() };
+    twin.build = { ...twin.build, turbineIdx: 2, turbineCount: 2 };
+    const s = reducer(twin, { type: ACTIONS.SET_TURBINE, value: 1 });
+    expect(s.build.turbineIdx).toBe(1);
+    expect(s.build.turbineCount).toBe(1);
+  });
+});
+
+describe('SET_TABLE', () => {
+  it('sets the table', () => {
+    const next = [[1, 2], [3, 4]];
+    const s = reducer(makeInitialState(), {
+      type: ACTIONS.SET_TABLE, table: 'timing', value: next,
+    });
+    expect(s.tune.timing).toBe(next);
+  });
+
+  it('clears the preset AND flags the tables dirty, in one pass', () => {
+    // This is the cross-slice write that three independent contexts could not express
+    // atomically: a table edit invalidates a BUILD field and a TUNE field together.
+    const loaded = { ...makeInitialState() };
+    loaded.build = { ...loaded.build, presetId: 'n54' };
+    const s = reducer(loaded, {
+      type: ACTIONS.SET_TABLE, table: 'timing', value: [[1]],
+    });
+    expect(s.build.presetId).toBeNull();
+    expect(s.tune.tablesDirty).toBe(true);
+  });
+});
+
+describe('unknown actions', () => {
+  it('returns the same state object, so React skips the re-render', () => {
+    const before = makeInitialState();
+    expect(reducer(before, { type: 'NOT_A_REAL_ACTION' })).toBe(before);
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+npm test -- tests/ui/state/reducer.test.js
+```
+Expected: FAIL — cannot resolve `../../../src/ui/state/initialState.js`.
+
+- [ ] **Step 3: Write the initial state**
+
+Create `src/ui/state/initialState.js`. Copy every default from `EcuLab.jsx`'s current `useState` initialisers **exactly** — including `EXHAUST_DIA_OPTS.findIndex((o) => o.dia === 3.0)`, which is pinned by diameter rather than position on purpose, and `computeHardwareVE(DEFAULT_ENGINE_CONFIG, DEFAULT_MODS)` for `ve`.
+
+The function must return a **fresh** object every call — clone the 2D tables with `clone2D`, and do not hoist any mutable value to module scope.
+
+Document each slice with a comment saying what belongs in it and what does not.
+
+- [ ] **Step 4: Write the reducer**
+
+Create `src/ui/state/reducer.js`. Export a frozen `ACTIONS` object and a `reducer(state, action)`.
+
+Implement at minimum: `SET_BUILD_FIELD`, `SET_TURBINE`, `SET_TABLE`, `SET_SESSION_FIELD`, `SET_TUNE_FIELD`. The default branch **must return `state` unchanged by reference** so React can skip the render.
+
+Every case must return new objects only for the slices it changes — the other slices keep their identity, which is what the "leaves the other slices untouched by reference" test pins.
+
+Write a file header explaining why this is one reducer over three, referencing the 23-write `applyEnginePreset` and the order hazard.
+
+- [ ] **Step 5: Write the provider and hooks**
+
+Create `src/ui/state/StoreProvider.jsx`. One `useReducer`, one context carrying `[state, dispatch]`, and three hooks that select their slice:
+
+```jsx
+export function useBuild() {
+  const [state, dispatch] = useStore();
+  return [state.build, dispatch];
+}
+```
+
+Each hook must throw a clear error if used outside the provider — a silent `undefined` here surfaces as an unrelated crash three components away.
+
+- [ ] **Step 6: Run the test, then put the directory under the typechecker**
+
+```bash
+npm test -- tests/ui/state/reducer.test.js
+```
+Expected: PASS.
+
+Add `"src/ui/state"` to `tsconfig.json`'s `include`, after `"src/ui/screens"`. Then `npm run typecheck` must still exit 0.
+
+- [ ] **Step 7: Full gate and commit**
+
+```bash
+npm test
+npm run lint
+npm run typecheck
+npm run build
+```
+
+```bash
+git add src/ui/state/ tests/ui/state/ tsconfig.json
+git commit -m "Add the store: one reducer, three slices, three hooks
+
+Consumers get useBuild/useTune/useSession, which is the three-way split the
+design doc specifies. Internally it is one reducer, because the operations
+that matter cross every boundary — a table edit clears a build field and sets
+a tune flag together, and applyEnginePreset writes 23 fields across all three
+in an order its own comment warns about.
+
+Nothing consumes it yet; EcuLab is wired up in the tasks that follow.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd"
+```
+
+---
+
+### Task 3: The cross-cutting actions
+
+**Files:**
+- Modify: `src/ui/state/reducer.js`
+- Test: `tests/ui/state/reducer.test.js`
+
+**Interfaces:**
+- Consumes: everything from Task 2.
+- Produces: `ACTIONS.APPLY_PRESET`, `ACTIONS.RESET_TO_STOCK`, `ACTIONS.REPAIR_ENGINE`, `ACTIONS.BANK_PULL` — each atomic.
+
+These are the actions that justify the whole design. Read `applyEnginePreset` and `resetToStock` in `EcuLab.jsx` line by line before writing them; every field they touch must be accounted for.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/ui/state/reducer.test.js`:
+
+```js
+describe('APPLY_PRESET', () => {
+  const preset = {
+    presetId: 'n54', engineConfig: { cylinders: 6 }, mods: { intake: true },
+    turboOn: true, boostCurve: [8, 8, 8, 8, 8, 8, 8, 8], turbineIdx: 1,
+    turbineCount: 2, compressorIdx: 1, injIdx: 2, ecuInjectorCc: 440,
+    octaneIdx: 1, exhaustDiaIdx: 2, ve: [[80]], timing: [[20]], afr: [[12]],
+  };
+
+  it('ends with the preset LOADED, not invalidated', () => {
+    // The ordering hazard this whole design removes: applying a preset writes the same
+    // fields a hand edit would, and a hand edit clears presetId. Done as 23 separate
+    // setState calls that is order-dependent; done as one action it cannot race.
+    const s = reducer(makeInitialState(), { type: ACTIONS.APPLY_PRESET, preset });
+    expect(s.build.presetId).toBe('n54');
+  });
+
+  it('loads the preset\'s own calibration, not a recomputed one', () => {
+    const s = reducer(makeInitialState(), { type: ACTIONS.APPLY_PRESET, preset });
+    expect(s.tune.timing).toEqual([[20]]);
+  });
+
+  it('leaves the tables clean — a freshly loaded preset is not unsaved work', () => {
+    const dirty = { ...makeInitialState() };
+    dirty.tune = { ...dirty.tune, tablesDirty: true };
+    const s = reducer(dirty, { type: ACTIONS.APPLY_PRESET, preset });
+    expect(s.tune.tablesDirty).toBe(false);
+  });
+
+  it('clears the previous run, which measured a different engine', () => {
+    const ran = { ...makeInitialState() };
+    ran.session = { ...ran.session, result: { peakHp: 400 }, prevResult: { peakHp: 380 } };
+    const s = reducer(ran, { type: ACTIONS.APPLY_PRESET, preset });
+    expect(s.session.result).toBeNull();
+    expect(s.session.prevResult).toBeNull();
+  });
+
+  it('carries the twin-turbo count a preset owns', () => {
+    const s = reducer(makeInitialState(), { type: ACTIONS.APPLY_PRESET, preset });
+    expect(s.build.turbineCount).toBe(2);
+  });
+
+  it('clears any pending overwrite prompt and cell selection', () => {
+    const s = reducer(makeInitialState(), { type: ACTIONS.APPLY_PRESET, preset });
+    expect(s.build.presetPrompt).toBeNull();
+    expect(s.tune.selection).toBeNull();
+  });
+});
+
+describe('RESET_TO_STOCK', () => {
+  it('clears the preset label, because a reset is not that preset\'s calibration', () => {
+    const loaded = { ...makeInitialState() };
+    loaded.build = { ...loaded.build, presetId: 'n54' };
+    const s = reducer(loaded, { type: ACTIONS.RESET_TO_STOCK, ve: [[70]] });
+    expect(s.build.presetId).toBeNull();
+  });
+
+  it('ends with the tables CLEAN — a reset baseline is not unsaved player work', () => {
+    // The old code achieved this by ordering setTablesDirty(false) last, after three
+    // invalidating setters that each set it true. As one action there is no order to get
+    // wrong.
+    const dirty = { ...makeInitialState() };
+    dirty.tune = { ...dirty.tune, tablesDirty: true };
+    const s = reducer(dirty, { type: ACTIONS.RESET_TO_STOCK, ve: [[70]] });
+    expect(s.tune.tablesDirty).toBe(false);
+  });
+});
+
+describe('REPAIR_ENGINE', () => {
+  it('restores every component to full health', () => {
+    const worn = { ...makeInitialState() };
+    worn.session = { ...worn.session, health: { piston: 40, bearing: 55, valve: 70 } };
+    const s = reducer(worn, { type: ACTIONS.REPAIR_ENGINE });
+    expect(s.session.health).toEqual({ piston: 100, bearing: 100, valve: 100 });
+  });
+});
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+npm test -- tests/ui/state/reducer.test.js
+```
+Expected: FAIL — `ACTIONS.APPLY_PRESET` is undefined.
+
+- [ ] **Step 3: Implement the four actions**
+
+Add them to `src/ui/state/reducer.js`. `APPLY_PRESET` must set every field `applyEnginePreset` sets — go through the function in `EcuLab.jsx` and account for all 23. `RESET_TO_STOCK` takes the recomputed `ve` as part of the action, because computing it needs `computeHardwareVE` with hardware the reducer should not be reaching for.
+
+Comment each action with what the old imperative version had to get right about ordering, and why this version cannot get it wrong.
+
+- [ ] **Step 4: Run, then run the full gate**
+
+```bash
+npm test -- tests/ui/state/reducer.test.js
+npm test
+npm run lint
+npm run typecheck
+npm run build
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/state/reducer.js tests/ui/state/reducer.test.js
+git commit -m "Make preset load, reset and repair atomic actions
+
+applyEnginePreset made 23 sequential setState calls and warned in a comment
+that routing them through the invalidating setters would make the result
+order-dependent. resetToStock made six and documented that the last one had to
+pin tablesDirty back to false.
+
+Both are now single actions. The ordering hazard is not documented, it is
+absent.
+
+Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd"
+```
+
+---
+
+### Task 4: Wire the build slice into EcuLab
+
+**Files:**
+- Modify: `src/ui/EcuLab.jsx`
+- Modify: `src/main.jsx` (wrap in `StoreProvider`)
+
+**Interfaces:**
+- Consumes: `useBuild`, `ACTIONS` from Task 2/3.
+- Produces: `EcuLab` reading its 15 build fields from the store instead of local state.
+
+This is the first mechanical wiring task. **Work one field at a time and run the characterisation tests between each** — that is what they are for.
+
+- [ ] **Step 1: Wrap the app in the provider**
+
+In `src/main.jsx`, wrap `<EcuLab />` in `<StoreProvider>`, inside the existing `<ErrorBoundary>`.
+
+- [ ] **Step 2: Replace the build `useState` calls**
+
+Delete the 15 build `useState` declarations. Add near the top of the component:
+
+```jsx
+  const [build, dispatch] = useBuild();
+  const { engineConfig, mods, turboOn, boostCurve, octaneIdx, injIdx, mafScalar,
+          turbineIdx, turbineCount, compressorIdx, exhaustDiaIdx, ecuInjectorCc,
+          presetId, presetPrompt, boostSel } = build;
+```
+
+Destructuring keeps every existing read site working unchanged — only the *writes* need rewriting.
+
+- [ ] **Step 3: Replace the invalidating setters**
+
+The `withPresetField` wrapper and its eleven derived setters are now the reducer's job. Delete them, and replace each call site with a dispatch. For example `setTurboOnInvalidating(v)` becomes:
+
+```jsx
+dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: v });
+```
+
+`setTurbineIdxInvalidating` becomes `{ type: ACTIONS.SET_TURBINE, value: idx }`.
+
+**Watch for functional updates.** `setCfg` does `setEngineConfigInvalidating((c) => ({ ...c, ...patch }))`. The reducer already has the current state, so this becomes a patch action — add `SET_ENGINE_CONFIG_PATCH` if it is cleaner than resolving the function at the call site. Do not pass functions through actions.
+
+- [ ] **Step 4: Run the characterisation tests after every few fields**
+
+```bash
+npm test -- tests/ui/characterisation.test.jsx
+```
+Expected: PASS throughout. **If one fails, you have just broken something — stop and fix it before continuing.** Do not batch up the whole file and debug at the end.
+
+- [ ] **Step 5: Full gate and commit**
+
+```bash
+npm test
+npm run lint
+npm run typecheck
+npm run build
+```
+
+Commit with a message describing which slice moved and confirming the characterisation tests stayed green throughout.
+
+---
+
+### Task 5: Wire the tune slice
+
+**Files:**
+- Modify: `src/ui/EcuLab.jsx`
+
+Same method as Task 4, for `ve`, `timing`, `afr`, `tablesDirty`, `selection`.
+
+- [ ] **Step 1: Replace the five `useState` calls with `useTune()` and destructuring**
+
+- [ ] **Step 2: Replace `withTableEdit`**
+
+This is the wrapper that crossed the build/tune boundary. `setVeEdited(next)` becomes:
+
+```jsx
+dispatch({ type: ACTIONS.SET_TABLE, table: 've', value: next });
+```
+
+The reducer clears `presetId` and sets `tablesDirty` in the same pass. Delete `withTableEdit` and all three derived setters.
+
+- [ ] **Step 3: Handle `acceptVe` and any other table writer**
+
+Search for every write to `ve`/`timing`/`afr`, including the VE-acceptance path. Each becomes a `SET_TABLE` dispatch. Miss one and hand edits stop invalidating the preset — which characterisation test 2 exists to catch.
+
+- [ ] **Step 4: Run the characterisation tests, then the full gate**
+
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 6: Wire the session slice
+
+**Files:**
+- Modify: `src/ui/EcuLab.jsx`
+
+Same method, for the 14 session fields.
+
+- [ ] **Step 1: Replace the `useState` calls with `useSession()` and destructuring**
+
+- [ ] **Step 2: Take particular care with `live` and `revealCount`**
+
+`live` is driven by an interval in a `useEffect` and updated at high frequency; `revealCount` drives the dyno reveal animation. Both are written from inside effects and refs. **Read those effects fully before changing them** — a stale closure over `dispatch` is not possible (React guarantees dispatch identity is stable), but a stale closure over a *slice value* is. Where an effect reads state to compute the next value, use the functional form via an action the reducer resolves, not a captured variable.
+
+- [ ] **Step 3: Replace `resetToStock` and `repairEngine` with their actions**
+
+`repairEngine` becomes a `REPAIR_ENGINE` dispatch. `resetToStock` becomes a `RESET_TO_STOCK` dispatch carrying the recomputed `ve`.
+
+- [ ] **Step 4: Run the characterisation tests, then the full gate**
+
+- [ ] **Step 5: Commit**
+
+---
+
+### Task 7: Remove the scaffolding, verify, and open the PR
+
+**Files:**
+- Modify: `src/ui/EcuLab.jsx`
+- Modify: `README.md` / `CONTRIBUTING.md` only if they describe the old structure
+
+- [ ] **Step 1: Confirm the wrappers and their setters are gone**
+
+```bash
+grep -c "withPresetField\|withTableEdit\|Invalidating\|setVeEdited\|setTimingEdited\|setAfrEdited" src/ui/EcuLab.jsx
+```
+Expected: **0**.
+
+- [ ] **Step 2: Confirm only view state remains local**
+
+```bash
+grep -n "const \[.*\] = useState" src/ui/EcuLab.jsx
+```
+Expected: only `appView`, `tab`, `tuneView`, `dynoView`, `dashSection`, `buildSection` — six, plus `ExpandableInfo`'s own `open`, which is a different component. Anything else means a field was missed.
+
+- [ ] **Step 3: Check the docs for stale structural claims**
+
+```bash
+grep -rn "one large component\|2365\|2330" README.md CONTRIBUTING.md docs/*.md 2>/dev/null | grep -v superpowers
+```
+`CONTRIBUTING.md` mentions the UI being one large component pending decomposition. That is still true after this PR — the render did not move — so only correct it if it says something this PR made false. Do not invent documentation changes.
+
+- [ ] **Step 4: Re-sync with the base**
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+If anything conflicts, resolve it deliberately and say how in the PR. Then **re-run step 5 in full** — a pre-rebase green says nothing about the post-rebase tree.
+
+- [ ] **Step 5: The full gate, with exit codes captured correctly**
+
+```bash
+node --version    # must print v20.x or v22.x
+npm test
+npm run lint
+npm run typecheck
+npm run build
+```
+
+- [ ] **Step 6: Prove the physics never moved**
+
+```bash
+git diff origin/main --stat -- tests/fixtures/ tests/fingerprint.test.js src/sim/
+```
+Expected: **no output.** Any change here means the refactor reached into the physics and the PR must not open until that is understood.
+
+- [ ] **Step 7: Confirm no dependency changed**
+
+```bash
+git diff origin/main -- package.json
+```
+Expected: **no output.** This PR adds nothing.
+
+- [ ] **Step 8: Push and open the PR**
+
+```bash
+git push -u origin feat/58-state-contexts
+```
+
+The PR body must state: what moved and what deliberately did not (view state, because PR 3 absorbs it into routing); that the render is unchanged; that `applyEnginePreset`'s 23-write ordering hazard is now absent rather than documented; that the characterisation tests were written first and stayed green throughout; and the fingerprint evidence from step 6. Close #58 and reference #6.
+
+- [ ] **Step 9: Check no auto-merge is queued**
+
+```bash
+gh pr view --json autoMergeRequest
+```
+Expected `null`. If not, `gh pr merge <N> --disable-auto`. **Do not merge this PR.**
+
+---
+
+## Notes for the implementer
+
+**The characterisation tests are the point of this plan.** If one starts failing during Tasks 4–6, the refactor broke something — fix the refactor, never the test. If you find yourself wanting to change an assertion to make it pass, stop and report instead.
+
+**Work one field at a time.** Thirty-four pieces of state moved in one edit, then debugged at the end, is the failure mode this plan is shaped to avoid.
+
+**Do not move the render.** The component stays monolithic; only state moves. Splitting screens is PR 3, and doing both at once produces a diff nobody can review.
+
+**Check your Node version before believing a failure.** `node --version` must be 20 or 22. On 26 the fingerprint fails on an untouched checkout and looks exactly like a physics break.

--- a/docs/superpowers/plans/2026-08-20-state-contexts.md
+++ b/docs/superpowers/plans/2026-08-20-state-contexts.md
@@ -705,7 +705,8 @@ Claude-Session: https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd"
 
 **Files:**
 - Modify: `src/ui/EcuLab.jsx`
-- Modify: `src/main.jsx` (wrap in `StoreProvider`)
+- ~~Modify: `src/main.jsx`~~ — **superseded during implementation.** The provider is
+  mounted inside `EcuLab.jsx` instead; see Step 1.
 
 **Interfaces:**
 - Consumes: `useBuild`, `ACTIONS` from Task 2/3.
@@ -769,7 +770,28 @@ pass the function form through an action.
 
 - [ ] **Step 1: Wrap the app in the provider**
 
-In `src/main.jsx`, wrap `<EcuLab />` in `<StoreProvider>`, inside the existing `<ErrorBoundary>`.
+**Do NOT put the provider in `src/main.jsx`.** That was this plan's original instruction and
+it is wrong: `tests/ui/characterisation.test.jsx` renders `<EcuLab />` bare, so a provider
+mounted only in `main.jsx` throws `useStore()`'s guard and breaks all eight of them —
+fixable only by editing tests that must not be edited. Doing both would nest a live
+provider inside a dead one.
+
+Instead, rename the component to `EcuLabApp` and make `EcuLab.jsx`'s default export a
+shell:
+
+```jsx
+export default function EcuLab() {
+  return (
+    <StoreProvider>
+      <EcuLabApp />
+    </StoreProvider>
+  );
+}
+```
+
+`main.jsx` stays exactly as it is — the thin "mount the app in an error boundary" entry
+point it documents itself as — and a test that renders `<EcuLab />` gets the same single
+store the browser does.
 
 - [ ] **Step 2: Replace the build `useState` calls**
 

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -533,7 +533,15 @@ function TrimBar({ label, value }) {
 }
 
 // ============================================================
-function EngineManagementSandbox() {
+/**
+ * The application body. Exported so a caller can mount it inside its OWN
+ * `<StoreProvider>` and share the store with it — which is how the tests reach
+ * build states this component's own guards cannot produce on their own (see
+ * tests/ui/build-store.test.jsx). The default export below is the same component
+ * with a provider already around it, and is what the app and most tests use.
+ * @returns {React.ReactElement}
+ */
+export function EcuLabApp() {
   const [appView, setAppView] = useState('start');
   const [tab, setTab] = useState('dash');
   // The BUILD slice — hardware and ECU configuration — lives in the store. Destructured
@@ -1628,7 +1636,7 @@ function EngineManagementSandbox() {
 
                   <Panel tight style={{ marginBottom: 10 }}>
                     {/* Tap a bar to select that RPM point, then edit it below with full-width controls. */}
-                    <div style={{ display: 'flex', gap: 3, alignItems: 'flex-end', height: 104 }}>
+                    <div data-testid="boost-columns" style={{ display: 'flex', gap: 3, alignItems: 'flex-end', height: 104 }}>
                       {RPM.map((r, i) => {
                         const on = boostSel === i;
                         const ceiling = COMPRESSOR_OPTS[compressorIdx].boostCeiling;
@@ -2340,7 +2348,7 @@ function EngineManagementSandbox() {
 export default function EcuLab() {
   return (
     <StoreProvider>
-      <EngineManagementSandbox />
+      <EcuLabApp />
     </StoreProvider>
   );
 }

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -39,8 +39,8 @@ import {
 } from 'lucide-react';
 
 import {
-  BARO_KPA, COMPRESSOR_OPTS, CONFIG_OPTS, CYL_COUNT, DEFAULT_AFR,
-  DEFAULT_ENGINE_CONFIG, DEFAULT_MODS, DEFAULT_TIMING, ENGINE_PRESETS, EXHAUST_DIA_OPTS,
+  BARO_KPA, COMPRESSOR_OPTS, CONFIG_OPTS, CYL_COUNT,
+  DEFAULT_MODS, ENGINE_PRESETS, EXHAUST_DIA_OPTS,
   INJ_DEADTIME_MS, INJECTOR_OPTS, LOAD, MATERIAL_OPTS, MOD_INFO, OCTANE_OPTS,
   PRESET_GROUPS, PSI_TO_KPA, SPARK_MAX_DEG, SPARK_MIN_DEG,
   R_AIR, RPM, TURBINE_OPTS, applyPreset, calibrationAdvice, chargeTempK, clamp, clone2D,
@@ -53,7 +53,7 @@ import { BUILD_VERSION } from '../version.js';
 import { loadCareer, saveCareer } from '../storage.js';
 import { StartScreen } from './screens/StartScreen.jsx';
 import { TutorialScreen } from './screens/TutorialScreen.jsx';
-import { StoreProvider, useBuild } from './state/StoreProvider.jsx';
+import { StoreProvider, useBuild, useTune } from './state/StoreProvider.jsx';
 import { ACTIONS } from './state/reducer.js';
 
 const Eyebrow = ({ children, icon: Icon }) => (
@@ -546,20 +546,22 @@ export function EcuLabApp() {
   const [tab, setTab] = useState('dash');
   // The BUILD slice — hardware and ECU configuration — lives in the store. Destructured
   // so every READ site below stays a bare `engineConfig` / `mods` / ...; only the WRITES
-  // changed, from setters to dispatches. `tune` and `session` are still local useState
-  // below until Tasks 5 and 6 move them.
+  // changed, from setters to dispatches. `session` is still local useState below until
+  // Task 6 moves it.
   const [build, dispatch] = useBuild();
   const {
     engineConfig, mods, turboOn, boostCurve, octaneIdx, injIdx, mafScalar,
     turbineIdx, turbineCount, compressorIdx, exhaustDiaIdx, ecuInjectorCc,
     presetId, presetPrompt, boostSel,
   } = build;
-  const [ve, setVe] = useState(() => computeHardwareVE(DEFAULT_ENGINE_CONFIG, DEFAULT_MODS));
-  const [timing, setTiming] = useState(clone2D(DEFAULT_TIMING));
-  const [afr, setAfr] = useState(clone2D(DEFAULT_AFR));
+  // The TUNE slice — calibration tables, the unsaved-work flag, and the grid cursor.
+  // Same destructuring shape as `build` above; `dispatch` is the SAME function
+  // useBuild() returned (one reducer, one useReducer call — see StoreProvider.jsx),
+  // so it is not re-bound here.
+  const [tune] = useTune();
+  const { ve, timing, afr, tablesDirty, selection } = tune;
   const [loadKpa, setLoadKpa] = useState(100);
   const [health, setHealth] = useState({ piston: 100, bearing: 100, valve: 100 });
-  const [selection, setSelection] = useState(null);
   const [running, setRunning] = useState(false);
   const [result, setResult] = useState(null);
   const [prevResult, setPrevResult] = useState(null);
@@ -567,10 +569,6 @@ export function EcuLabApp() {
   const [bestScore, setBestScore] = useState(0);
   const [totalScore, setTotalScore] = useState(0);
   const [pullCount, setPullCount] = useState(0);
-  // True once the player has hand-edited VE/spark/fuel since the last preset load
-  // or reset-to-stock. This — not pull count — is what the overwrite-confirmation
-  // prompt keys off; see hasTuningWork below.
-  const [tablesDirty, setTablesDirty] = useState(false);
   const [buildSection, setBuildSection] = useState('engine');
   const [tuneView, setTuneView] = useState('ve');
   const [dynoView, setDynoView] = useState('result');
@@ -589,18 +587,22 @@ export function EcuLabApp() {
 
   // `withPresetField` is gone: SET_BUILD_FIELD clears `presetId` itself, so the
   // invalidation now happens inside the reducer rather than in a wrapper each new
-  // hardware field had to remember to be threaded through. What is left here is the
-  // one hand-edit path whose slices have NOT both moved yet — a calibration edit
-  // writes a table (`tune`, still local useState until Task 5), clears `presetId`
-  // (`build`, in the store) and flags unsaved work, which is what the overwrite-
-  // confirmation prompt (hasTuningWork) keys off. Task 5 collapses this into the
-  // single SET_TABLE action that already exists for it.
-  const clearPresetId = () => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'presetId', value: null });
-  const withTableEdit = (setter) => (...args) => { setter(...args); clearPresetId(); setTablesDirty(true); };
-
-  const setVeEdited = withTableEdit(setVe);
-  const setTimingEdited = withTableEdit(setTiming);
-  const setAfrEdited = withTableEdit(setAfr);
+  // hardware field had to remember to be threaded through. The one hand-edit path that
+  // used to cross the build/tune boundary in two local calls (`clearPresetId` then
+  // `setTablesDirty(true)`) is now the single SET_TABLE action, which clears `presetId`
+  // and flags unsaved work in the SAME reducer pass — see reducer.js. `withTableEdit`
+  // and its three derived setters (`setVeEdited`/`setTimingEdited`/`setAfrEdited`) are
+  // gone; every table-edit call site below dispatches SET_TABLE directly.
+  //
+  // `clearPresetId` itself survives with a narrower job: CLEAR_PRESET_ID touches
+  // `presetId` alone, with no `tablesDirty` side effect, for the one caller that wants
+  // exactly that — the preset picker's "Custom build" option, below.
+  const clearPresetId = () => dispatch({ type: ACTIONS.CLEAR_PRESET_ID });
+  // The build-side analogue of a table edit is a cursor, not a calibration edit:
+  // `SET_TUNE_FIELD` deliberately does NOT clear `presetId` or flag `tablesDirty`
+  // (see reducer.js), so moving the highlighted grid cell never disowns a loaded
+  // preset.
+  const setSelection = (value) => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value });
 
   const octaneBonus = OCTANE_OPTS[octaneIdx].bonus;
   const engineDerived = useMemo(() => deriveEngine(engineConfig), [engineConfig]);
@@ -658,7 +660,7 @@ export function EcuLabApp() {
     [engineConfig, mods, hwForVe],
   );
 
-  const recalcVE = () => setVeEdited(veTruth);
+  const recalcVE = () => dispatch({ type: ACTIONS.SET_TABLE, table: 've', value: veTruth });
 
   // Every boost-curve write goes through here. Rebuilding from the RPM axis makes it
   // structurally impossible for the curve to be the wrong length or to contain a
@@ -717,12 +719,6 @@ export function EcuLabApp() {
     // that is wrong.
     const stockVe = computeHardwareVE(engineConfig, DEFAULT_MODS, hwForVe);
     dispatch({ type: ACTIONS.RESET_TO_STOCK, ve: stockVe });
-    // `tune` is still local useState until Task 5, so it is written here too. Note these
-    // are the RAW setters, not the ...Edited wrappers: the wrappers exist to flag unsaved
-    // player work, and a reset baseline is not that — which is why the original's last
-    // call had to pin tablesDirty back to false.
-    setVe(stockVe); setTiming(clone2D(DEFAULT_TIMING)); setAfr(clone2D(DEFAULT_AFR));
-    setTablesDirty(false);
   };
   const repairEngine = () => setHealth({ piston: 100, bearing: 100, valve: 100 });
   // Actions cannot carry functions, so the old functional update becomes a patch the
@@ -748,15 +744,10 @@ export function EcuLabApp() {
     // raw entry has no `engineConfig`, so passing it builds an engine with no short
     // block.
     dispatch({ type: ACTIONS.APPLY_PRESET, preset: p });
-    // APPLY_PRESET already wrote all of this to the store's `tune` and `session`
-    // slices; those are still local useState until Tasks 5 and 6, so they are written
-    // here too. Each line below is a deletion for those tasks, not a rewrite.
-    setVe(p.ve);
-    setTiming(p.timing);
-    setAfr(p.afr);
-    setSelection(null);
-    // Fresh factory calibration is not unsaved player work.
-    setTablesDirty(false);
+    // APPLY_PRESET already wrote the `tune` slice (ve/timing/afr/tablesDirty/selection)
+    // in the same pass. `session` is still local useState until Task 6, so it is
+    // written here too.
+    //
     // A factory rating from the newly loaded engine must never sit next to a pull
     // logged on whatever was running before it.
     setResult(null);
@@ -989,10 +980,14 @@ export function EcuLabApp() {
   };
   const applyHistogram = () => {
     if (!histogram) return;
-    setVeEdited((prev) => prev.map((row, ri) => row.map((v, ci) => {
+    // SET_TABLE carries a value, not a function, so the old functional update
+    // (`setVeEdited((prev) => ...)`) is resolved here against the CURRENT `ve` — the
+    // one already in scope from the store — before dispatching.
+    const nextVe = ve.map((row, ri) => row.map((v, ci) => {
       const e = histogram[ri][ci];
       return e == null ? v : Number(clamp(v * (1 + e / 100), 10, 130).toFixed(1));
-    })));
+    }));
+    dispatch({ type: ACTIONS.SET_TABLE, table: 've', value: nextVe });
     setHistogram(null);
   };
 
@@ -1804,7 +1799,7 @@ export function EcuLabApp() {
               </ExpandableInfo>
             </div>
             <div style={{ flex: 1 }} />
-            <SelectionDock data={ve} setData={setVeEdited} selection={selection} min={10} max={130} decimals={0} unit="%" onClose={() => setSelection(null)} kind="ve" />
+            <SelectionDock data={ve} setData={(value) => dispatch({ type: ACTIONS.SET_TABLE, table: 've', value })} selection={selection} min={10} max={130} decimals={0} unit="%" onClose={() => setSelection(null)} kind="ve" />
           </>
         )}
 
@@ -1856,7 +1851,7 @@ export function EcuLabApp() {
               </ExpandableInfo>
             </div>
             <div style={{ flex: 1 }} />
-            <SelectionDock data={timing} setData={setTimingEdited} selection={selection} min={SPARK_MIN_DEG} max={SPARK_MAX_DEG} decimals={0} unit="°" onClose={() => setSelection(null)} kind="timing" />
+            <SelectionDock data={timing} setData={(value) => dispatch({ type: ACTIONS.SET_TABLE, table: 'timing', value })} selection={selection} min={SPARK_MIN_DEG} max={SPARK_MAX_DEG} decimals={0} unit="°" onClose={() => setSelection(null)} kind="timing" />
           </>
         )}
 
@@ -1891,7 +1886,7 @@ export function EcuLabApp() {
               </ExpandableInfo>
             </div>
             <div style={{ flex: 1 }} />
-            <SelectionDock data={afr} setData={setAfrEdited} selection={selection} min={10} max={18} decimals={1} unit=":1" onClose={() => setSelection(null)} kind="afr" />
+            <SelectionDock data={afr} setData={(value) => dispatch({ type: ACTIONS.SET_TABLE, table: 'afr', value })} selection={selection} min={10} max={18} decimals={1} unit=":1" onClose={() => setSelection(null)} kind="afr" />
           </>
         )}
 

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -39,7 +39,7 @@ import {
 } from 'lucide-react';
 
 import {
-  BARO_KPA, COMPRESSOR_OPTS, CONFIG_OPTS, CYL_COUNT, DEFAULT_AFR, DEFAULT_BOOST,
+  BARO_KPA, COMPRESSOR_OPTS, CONFIG_OPTS, CYL_COUNT, DEFAULT_AFR,
   DEFAULT_ENGINE_CONFIG, DEFAULT_MODS, DEFAULT_TIMING, ENGINE_PRESETS, EXHAUST_DIA_OPTS,
   INJ_DEADTIME_MS, INJECTOR_OPTS, LOAD, MATERIAL_OPTS, MOD_INFO, OCTANE_OPTS,
   PRESET_GROUPS, PSI_TO_KPA, SPARK_MAX_DEG, SPARK_MIN_DEG,
@@ -540,17 +540,15 @@ function EngineManagementSandbox() {
   // so every READ site below stays a bare `engineConfig` / `mods` / ...; only the WRITES
   // changed, from setters to dispatches. `tune` and `session` are still local useState
   // below until Tasks 5 and 6 move them.
-  const [, dispatch] = useBuild();
-  const [engineConfig, setEngineConfig] = useState(DEFAULT_ENGINE_CONFIG);
-  const [mods, setMods] = useState(DEFAULT_MODS);
+  const [build, dispatch] = useBuild();
+  const {
+    engineConfig, mods, turboOn, boostCurve, octaneIdx, injIdx, mafScalar,
+    turbineIdx, turbineCount, compressorIdx, exhaustDiaIdx, ecuInjectorCc,
+    presetId, presetPrompt, boostSel,
+  } = build;
   const [ve, setVe] = useState(() => computeHardwareVE(DEFAULT_ENGINE_CONFIG, DEFAULT_MODS));
   const [timing, setTiming] = useState(clone2D(DEFAULT_TIMING));
   const [afr, setAfr] = useState(clone2D(DEFAULT_AFR));
-  const [turboOn, setTurboOn] = useState(false);
-  const [boostCurve, setBoostCurve] = useState([...DEFAULT_BOOST]);
-  const [octaneIdx, setOctaneIdx] = useState(0);
-  const [injIdx, setInjIdx] = useState(0);
-  const [mafScalar, setMafScalar] = useState(1.0);
   const [loadKpa, setLoadKpa] = useState(100);
   const [health, setHealth] = useState({ piston: 100, bearing: 100, valve: 100 });
   const [selection, setSelection] = useState(null);
@@ -561,29 +559,12 @@ function EngineManagementSandbox() {
   const [bestScore, setBestScore] = useState(0);
   const [totalScore, setTotalScore] = useState(0);
   const [pullCount, setPullCount] = useState(0);
-  const [turbineIdx, setTurbineIdx] = useState(1);
-  // How many of that housing are fitted. Only a preset can set this above 1 — the picker
-  // below fits one turbo, so choosing from it resets the count.
-  const [turbineCount, setTurbineCount] = useState(1);
-  const [compressorIdx, setCompressorIdx] = useState(1);
-  // Which factory preset (if any) is currently loaded stock. Cleared the moment any
-  // Engine Architecture control is hand-edited, and offered as a warning prompt
-  // before a loaded tune with logged pulls gets overwritten.
-  const [presetId, setPresetId] = useState(null);
-  const [presetPrompt, setPresetPrompt] = useState(null);
   // True once the player has hand-edited VE/spark/fuel since the last preset load
   // or reset-to-stock. This — not pull count — is what the overwrite-confirmation
   // prompt keys off; see hasTuningWork below.
   const [tablesDirty, setTablesDirty] = useState(false);
-  // Pinned by diameter, not by position: adding sizes to the catalogue must not
-  // silently change which pipe a new build starts with.
-  const [exhaustDiaIdx, setExhaustDiaIdx] = useState(
-    () => EXHAUST_DIA_OPTS.findIndex((o) => o.dia === 3.0),
-  );
   const [buildSection, setBuildSection] = useState('engine');
-  const [ecuInjectorCc, setEcuInjectorCc] = useState(315);
   const [tuneView, setTuneView] = useState('ve');
-  const [boostSel, setBoostSel] = useState(4);
   const [dynoView, setDynoView] = useState('result');
   const [histogram, setHistogram] = useState(null);
   const [live, setLive] = useState(() => makeLiveState());
@@ -598,32 +579,16 @@ function EngineManagementSandbox() {
   const audioRef = useRef(null);
   const [soundOn, setSoundOn] = useState(true);
 
-  // Every field applyPreset() owns funnels its hand-edit path through one of these
-  // two wrappers instead of sprinkling `setPresetId(null)` at each call site — a
-  // wrapper is what stops the next field from being forgotten. `withPresetField`
-  // covers hardware/ECU fields that only invalidate the preset label;
-  // `withTableEdit` additionally flags the calibration tables as having unsaved
-  // work, which is what the overwrite-confirmation prompt (hasTuningWork) keys off.
-  // `applyEnginePreset` itself must NOT use these — it needs to end with `presetId`
-  // SET, and routing its own writes through invalidation would race that.
-  const withPresetField = (setter) => (...args) => { setter(...args); setPresetId(null); };
-  const withTableEdit = (setter) => (...args) => { setter(...args); setPresetId(null); setTablesDirty(true); };
-
-  const setEngineConfigInvalidating = withPresetField(setEngineConfig);
-  const setModsInvalidating = withPresetField(setMods);
-  const setTurboOnInvalidating = withPresetField(setTurboOn);
-  const setBoostCurveInvalidating = withPresetField(setBoostCurve);
-  // Fitting a turbine by hand fits ONE of it; the twin-turbo count belongs to a preset.
-  const setTurbineIdxInvalidating = withPresetField((idx) => {
-    setTurbineIdx(idx);
-    setTurbineCount(1);
-  });
-  const setCompressorIdxInvalidating = withPresetField(setCompressorIdx);
-  const setInjIdxInvalidating = withPresetField(setInjIdx);
-  const setOctaneIdxInvalidating = withPresetField(setOctaneIdx);
-  const setExhaustDiaIdxInvalidating = withPresetField(setExhaustDiaIdx);
-  const setEcuInjectorCcInvalidating = withPresetField(setEcuInjectorCc);
-  const setMafScalarInvalidating = withPresetField(setMafScalar);
+  // `withPresetField` is gone: SET_BUILD_FIELD clears `presetId` itself, so the
+  // invalidation now happens inside the reducer rather than in a wrapper each new
+  // hardware field had to remember to be threaded through. What is left here is the
+  // one hand-edit path whose slices have NOT both moved yet — a calibration edit
+  // writes a table (`tune`, still local useState until Task 5), clears `presetId`
+  // (`build`, in the store) and flags unsaved work, which is what the overwrite-
+  // confirmation prompt (hasTuningWork) keys off. Task 5 collapses this into the
+  // single SET_TABLE action that already exists for it.
+  const clearPresetId = () => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'presetId', value: null });
+  const withTableEdit = (setter) => (...args) => { setter(...args); clearPresetId(); setTablesDirty(true); };
 
   const setVeEdited = withTableEdit(setVe);
   const setTimingEdited = withTableEdit(setTiming);
@@ -690,9 +655,11 @@ function EngineManagementSandbox() {
   // Every boost-curve write goes through here. Rebuilding from the RPM axis makes it
   // structurally impossible for the curve to be the wrong length or to contain a
   // non-number, which is what previously let a single edit poison the whole sim.
-  const setBoostAt = (i, value) => setBoostCurveInvalidating(
-    RPM.map((_, idx) => clamp(Number(idx === i ? value : boostCurve[idx]) || 0, 0, 25)),
-  );
+  const setBoostAt = (i, value) => dispatch({
+    type: ACTIONS.SET_BUILD_FIELD,
+    field: 'boostCurve',
+    value: RPM.map((_, idx) => clamp(Number(idx === i ? value : boostCurve[idx]) || 0, 0, 25)),
+  });
   const calAdvice = useMemo(() => calibrationAdvice({
     ve, veTruth, timing, afr, derived: engineDerived, octaneBonus, fuel, mods, turboOn, boostCurve,
     compressor: COMPRESSOR_OPTS[compressorIdx],
@@ -725,17 +692,16 @@ function EngineManagementSandbox() {
 
   const installMod = (key) => {
     if (mods[key]) return;
-    if (key === 'intercooler') { setModsInvalidating((m) => ({ ...m, intercooler: true })); return; }
     // Fitting a part changes airflow but does NOT edit your logged VE table — the
     // VE tab will show the gap and let you accept it once you understand why.
-    setModsInvalidating({ ...mods, [key]: true });
+    dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'mods', value: { ...mods, [key]: true } });
   };
   const resetToStock = () => {
     // Wipes the calibration back to a generic stock baseline — which, if a factory
-    // preset was loaded, is NOT that preset's validated tables. Route every write
-    // through the invalidating setters so the header stops claiming a factory
-    // calibration this just deleted, and the last call pins tablesDirty back to
-    // false: a reset baseline is not unsaved player work.
+    // preset was loaded, is NOT that preset's validated tables, so RESET_TO_STOCK
+    // drops the preset label with it and pins tablesDirty back to false in the same
+    // pass: a reset baseline is not unsaved player work.
+    //
     // The reducer does NOT compute the stock VE table; the caller does, and the mix of
     // arguments is the point: DEFAULT_MODS (the bolt-ons come off) against the CURRENT
     // `hwForVe` (the turbo does not — resetting the calibration is not uninstalling the
@@ -749,11 +715,12 @@ function EngineManagementSandbox() {
     // call had to pin tablesDirty back to false.
     setVe(stockVe); setTiming(clone2D(DEFAULT_TIMING)); setAfr(clone2D(DEFAULT_AFR));
     setTablesDirty(false);
-    // Build fields this task has not moved into the store yet; deleted as each moves.
-    setMods(DEFAULT_MODS); setMafScalar(1.0); setPresetId(null);
   };
   const repairEngine = () => setHealth({ piston: 100, bearing: 100, valve: 100 });
-  const setCfg = (patch) => setEngineConfigInvalidating((c) => ({ ...c, ...patch }));
+  // Actions cannot carry functions, so the old functional update becomes a patch the
+  // reducer merges into the engineConfig it already holds. It invalidates the preset
+  // label like every other hardware write.
+  const setCfg = (patch) => dispatch({ type: ACTIONS.SET_ENGINE_CONFIG_PATCH, patch });
 
   /** Whether the player has unsaved calibration work — hand-edited VE/spark/fuel —
    *  that loading a preset would silently overwrite. Tracked directly via
@@ -763,52 +730,33 @@ function EngineManagementSandbox() {
   const hasTuningWork = () => tablesDirty;
 
   const applyEnginePreset = (preset) => {
-    // Deliberately writes through the RAW setters, not the invalidating wrappers
-    // above — this function's whole job is to SET presetId at the end, and
-    // routing its own writes through setPresetId(null) would make that order-
-    // dependent on React's batching instead of explicit here.
     const p = applyPreset(preset);
-    // The BUILD slice lands atomically in the store, in one pass, with no "last call"
-    // to get right. NOTE the payload is applyPreset()'s OUTPUT, not the raw catalogue
-    // entry — the raw entry has no `engineConfig`, so passing it would build an engine
-    // with no short block.
+    // The whole BUILD slice — including `mafScalar` back to 1.0, and `presetId` SET
+    // rather than cleared — lands in ONE pass. That is what the original's comment
+    // about not routing these writes through the invalidating setters was working
+    // around: there is no longer a "last call" whose ordering decides the outcome.
+    //
+    // NOTE the payload is applyPreset()'s OUTPUT, not the raw catalogue entry — the
+    // raw entry has no `engineConfig`, so passing it builds an engine with no short
+    // block.
     dispatch({ type: ACTIONS.APPLY_PRESET, preset: p });
-    // `tune` and `session` are still local useState until Tasks 5 and 6, so their
-    // writes below stay. So do the build-field writes for whichever fields this task
-    // has not moved into the store yet; each one is deleted as its field moves.
-    setEngineConfig(p.engineConfig);
-    setMods(p.mods);
-    setTurboOn(p.turboOn);
-    setBoostCurve(p.boostCurve);
-    setTurbineIdx(p.turbineIdx);
-    setTurbineCount(p.turbineCount);
-    setCompressorIdx(p.compressorIdx);
-    setInjIdx(p.injIdx);
-    setEcuInjectorCc(p.ecuInjectorCc);
-    setOctaneIdx(p.octaneIdx);
-    setExhaustDiaIdx(p.exhaustDiaIdx);
+    // APPLY_PRESET already wrote all of this to the store's `tune` and `session`
+    // slices; those are still local useState until Tasks 5 and 6, so they are written
+    // here too. Each line below is a deletion for those tasks, not a rewrite.
     setVe(p.ve);
     setTiming(p.timing);
     setAfr(p.afr);
-    // The preset's AFR table already bakes in a correction for the MAF error that
-    // the mod set implies (see factoryCalibration in src/sim/presets.js) — that
-    // correction is only valid at the neutral scalar. Loading a preset while a
-    // player has this dragged away from 1.0 would otherwise silently double-correct
-    // the mixture the very next pull.
-    setMafScalar(1.0);
-    setPresetId(p.presetId);
     setSelection(null);
-    setPresetPrompt(null);
+    // Fresh factory calibration is not unsaved player work.
+    setTablesDirty(false);
     // A factory rating from the newly loaded engine must never sit next to a pull
     // logged on whatever was running before it.
     setResult(null);
     setPrevResult(null);
-    // Fresh factory calibration is not unsaved player work.
-    setTablesDirty(false);
   };
 
   const choosePreset = (preset) => {
-    if (hasTuningWork()) setPresetPrompt(preset);
+    if (hasTuningWork()) dispatch({ type: ACTIONS.SET_PRESET_PROMPT, value: preset });
     else applyEnginePreset(preset);
   };
 
@@ -1505,7 +1453,7 @@ function EngineManagementSandbox() {
                 extra={[{ label: 'Custom build', value: '__custom__' }]}
                 value={presetId ?? '__custom__'}
                 onChange={(v) => {
-                  if (v === '__custom__') { setPresetId(null); return; }
+                  if (v === '__custom__') { clearPresetId(); return; }
                   const p = ENGINE_PRESETS.find((e) => e.id === v);
                   if (p) choosePreset(p);
                 }}
@@ -1542,7 +1490,7 @@ function EngineManagementSandbox() {
                     <button onClick={() => applyEnginePreset(presetPrompt)} style={{ flex: 1, padding: '10px 0', borderRadius: 8, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 12 }}>
                       LOAD {presetPrompt.name.toUpperCase()}
                     </button>
-                    <button onClick={() => setPresetPrompt(null)} style={{ flex: 1, padding: '10px 0', borderRadius: 8, border: `1px solid ${T.line}`, background: T.panel, color: T.ink2, fontWeight: 700, fontSize: 12 }}>
+                    <button onClick={() => dispatch({ type: ACTIONS.SET_PRESET_PROMPT, value: null })} style={{ flex: 1, padding: '10px 0', borderRadius: 8, border: `1px solid ${T.line}`, background: T.panel, color: T.ink2, fontWeight: 700, fontSize: 12 }}>
                       CANCEL
                     </button>
                   </div>
@@ -1657,14 +1605,14 @@ function EngineManagementSandbox() {
               icon={Wind} label="Forced Induction"
               sub={turboOn ? `On · ${turbineCount > 1 ? `Twin ${TURBINE_OPTS[turbineIdx].label.split(' ')[0].toLowerCase()}` : TURBINE_OPTS[turbineIdx].label.split(' ')[0]} turbine · peak ${Math.max(...boostCurve)} psi` : 'Not installed'}
             >
-              <ToggleRow label="Turbo kit" sub="Adds boost near WOT, with spool lag off idle" checked={turboOn} onChange={setTurboOnInvalidating} />
+              <ToggleRow label="Turbo kit" sub="Adds boost near WOT, with spool lag off idle" checked={turboOn} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: v })} />
 
               <div style={{ maxHeight: turboOn ? 3000 : 0, opacity: turboOn ? 1 : 0, overflow: 'hidden', transition: 'max-height .4s ease, opacity .3s ease' }}>
                 <div style={{ paddingTop: 12 }}>
                   <div style={{ fontSize: 12, color: T.ink2, marginBottom: 6, fontWeight: 600 }}>Turbine Size</div>
-                  <PickList options={TURBINE_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={TURBINE_OPTS[turbineIdx].label} onChange={(v) => setTurbineIdxInvalidating(TURBINE_OPTS.findIndex((o) => o.label === v))} />
+                  <PickList options={TURBINE_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={TURBINE_OPTS[turbineIdx].label} onChange={(v) => dispatch({ type: ACTIONS.SET_TURBINE, value: TURBINE_OPTS.findIndex((o) => o.label === v) })} />
                   <div style={{ fontSize: 12, color: T.ink2, marginBottom: 6, marginTop: 4, fontWeight: 600 }}>Compressor Size</div>
-                  <Seg options={COMPRESSOR_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={COMPRESSOR_OPTS[compressorIdx].label} onChange={(v) => setCompressorIdxInvalidating(COMPRESSOR_OPTS.findIndex((o) => o.label === v))} />
+                  <Seg options={COMPRESSOR_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={COMPRESSOR_OPTS[compressorIdx].label} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'compressorIdx', value: COMPRESSOR_OPTS.findIndex((o) => o.label === v) })} />
                   <div style={{ fontSize: 11, color: T.ink3, marginBottom: 10, marginTop: 4 }}>Ceiling before it runs outside its efficient range: ~{COMPRESSOR_OPTS[compressorIdx].boostCeiling} psi</div>
                   <ExpandableInfo title="Turbine vs. compressor — different jobs">
                     The turbine sits in the exhaust and spins from exhaust energy — its size sets how quickly it spools (small = fast but chokes exhaust flow up top; large = laggy but flows more at redline). The compressor sits in the intake and does the actual pressurizing — its size sets a practical boost ceiling before it's forced outside its efficient operating range, making hot, inefficient, knock-prone air.
@@ -1673,7 +1621,7 @@ function EngineManagementSandbox() {
                   </ExpandableInfo>
 
                   <div style={{ marginTop: 4, marginBottom: 14 }}>
-                    <ToggleRow label="Intercooler" sub="Cools charge air, buys knock margin under boost" checked={mods.intercooler} onChange={(v) => setModsInvalidating((m) => ({ ...m, intercooler: v }))} color={T.cyan} />
+                    <ToggleRow label="Intercooler" sub="Cools charge air, buys knock margin under boost" checked={mods.intercooler} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'mods', value: { ...mods, intercooler: v } })} color={T.cyan} />
                   </div>
 
                   <div style={{ fontSize: 12, color: T.ink2, marginBottom: 8, fontWeight: 600 }}>Boost Target Curve</div>
@@ -1686,7 +1634,7 @@ function EngineManagementSandbox() {
                         const ceiling = COMPRESSOR_OPTS[compressorIdx].boostCeiling;
                         const over = boostCurve[i] > ceiling;
                         return (
-                          <button key={r} onClick={() => setBoostSel(i)} style={{
+                          <button key={r} onClick={() => dispatch({ type: ACTIONS.SET_BOOST_SEL, value: i })} style={{
                             flex: 1, height: '100%', padding: 0, borderRadius: 7,
                             border: `1px solid ${on ? T.acc : T.line}`,
                             background: on ? T.accBg : T.panel,
@@ -1729,11 +1677,11 @@ function EngineManagementSandbox() {
                       ))}
                     </div>
                     <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
-                      <button onClick={() => setBoostCurveInvalidating(RPM.map(() => clamp(Number(boostCurve[boostSel]) || 0, 0, 25)))}
+                      <button onClick={() => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'boostCurve', value: RPM.map(() => clamp(Number(boostCurve[boostSel]) || 0, 0, 25)) })}
                         style={{ flex: 1, padding: '9px 0', borderRadius: 8, border: `1px solid ${T.line}`, background: T.panel, color: T.ink2, fontWeight: 700, fontSize: 11 }}>
                         FLAT ACROSS ALL
                       </button>
-                      <button onClick={() => { const peak = boostCurve[boostSel]; setBoostCurveInvalidating(RPM.map((r) => Math.round(peak * clamp((r - 1500) / 2600, 0, 1)))); }}
+                      <button onClick={() => { const peak = boostCurve[boostSel]; dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'boostCurve', value: RPM.map((r) => Math.round(peak * clamp((r - 1500) / 2600, 0, 1))) }); }}
                         style={{ flex: 1, padding: '9px 0', borderRadius: 8, border: `1px solid ${T.line}`, background: T.panel, color: T.ink2, fontWeight: 700, fontSize: 11 }}>
                         SPOOL RAMP
                       </button>
@@ -1741,7 +1689,7 @@ function EngineManagementSandbox() {
                           axis. A hand-written literal previously had seven entries
                           for eight breakpoints, and the next edit put NaN through
                           the entire simulation. */}
-                      <button onClick={() => setBoostCurveInvalidating(RPM.map(() => 0))}
+                      <button onClick={() => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'boostCurve', value: RPM.map(() => 0) })}
                         style={{ flex: 1, padding: '9px 0', borderRadius: 8, border: `1px solid ${T.line}`, background: T.panel, color: T.ink2, fontWeight: 700, fontSize: 11 }}>
                         ZERO
                       </button>
@@ -1766,7 +1714,7 @@ function EngineManagementSandbox() {
               sub={EXHAUST_DIA_OPTS[exhaustDiaIdx].label}
             >
               <div style={{ fontSize: 12, color: T.ink2, marginBottom: 6, fontWeight: 600 }}>Exhaust Diameter</div>
-              <Seg options={EXHAUST_DIA_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={EXHAUST_DIA_OPTS[exhaustDiaIdx].label} onChange={(v) => setExhaustDiaIdxInvalidating(EXHAUST_DIA_OPTS.findIndex((o) => o.label === v))} />
+              <Seg options={EXHAUST_DIA_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={EXHAUST_DIA_OPTS[exhaustDiaIdx].label} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'exhaustDiaIdx', value: EXHAUST_DIA_OPTS.findIndex((o) => o.label === v) })} />
               <div style={{ fontSize: 11, color: T.ink3, marginBottom: 4 }}>
                 Estimated ideal for this build: ~{idealExhaustDia.toFixed(2)} in
                 {turboOn && Math.max(...boostCurve) > 0 && <span style={{ color: T.accInk }}> (raised by boost)</span>}
@@ -1946,7 +1894,7 @@ function EngineManagementSandbox() {
             {turboOn && <Note>Turbo hardware and the boost target curve live on <b>BUILD</b> — this tab is fuel-side tuning: octane, injectors, and MAF/ECU.</Note>}
 
             <div style={{ fontSize: 12, color: T.ink2, margin: '12px 0 6px', fontWeight: 600 }}>Fuel Octane</div>
-            <Seg options={OCTANE_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={OCTANE_OPTS[octaneIdx].label} onChange={(v) => setOctaneIdxInvalidating(OCTANE_OPTS.findIndex((o) => o.label === v))} />
+            <Seg options={OCTANE_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={OCTANE_OPTS[octaneIdx].label} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'octaneIdx', value: OCTANE_OPTS.findIndex((o) => o.label === v) })} />
             <ExpandableInfo title="What octane actually does — and what E85 costs you">
               Octane measures a fuel's resistance to auto-igniting under heat and pressure before the spark fires it — not energy content or "power." Higher octane tolerates more cylinder pressure and temperature before knock, letting a tuner run more advance or more boost safely. It does not add power on its own; it raises the ceiling for how much timing/boost you can use before knock becomes the limit.
               <br /><br /><b style={{ color: T.ink }}>E85 is not a free upgrade.</b> Its stoichiometric point is about 9.8:1, not gasoline's 14.7:1 — so hitting the same lambda takes roughly <b style={{ color: T.accInk }}>1.43× the fuel volume</b>. Switch to E85 without upsizing injectors and you will run out of duty cycle long before you cash in that knock margin. Watch the duty preview below change the moment you select it.
@@ -1954,15 +1902,15 @@ function EngineManagementSandbox() {
             </ExpandableInfo>
 
             <div style={{ fontSize: 12, color: T.ink2, margin: '10px 0 6px', fontWeight: 600 }}>Fuel Injectors</div>
-            <PickList options={INJECTOR_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={INJECTOR_OPTS[injIdx].label} onChange={(v) => setInjIdxInvalidating(INJECTOR_OPTS.findIndex((o) => o.label === v))} />
+            <PickList options={INJECTOR_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={INJECTOR_OPTS[injIdx].label} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'injIdx', value: INJECTOR_OPTS.findIndex((o) => o.label === v) })} />
             <div style={{ fontSize: 12, color: T.ink2, margin: '12px 0 6px', fontWeight: 600 }}>
               ECU Injector Scaling <span style={{ color: T.ink3, fontWeight: 400 }}>— what the ECU thinks is fitted</span>
             </div>
-            <Seg options={INJECTOR_OPTS.map((o) => ({ label: `${o.cc}`, value: o.cc }))} value={ecuInjectorCc} onChange={setEcuInjectorCcInvalidating} wrap />
+            <Seg options={INJECTOR_OPTS.map((o) => ({ label: `${o.cc}`, value: o.cc }))} value={ecuInjectorCc} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'ecuInjectorCc', value: v })} wrap />
             {ecuInjectorCc !== injectorCc ? (
               <div style={{ background: T.dangerBg, border: `1px solid ${T.dangerLine}`, borderRadius: 10, padding: '11px 13px', margin: '8px 0', fontSize: 12, color: T.dangerInk, lineHeight: 1.5 }}>
                 <b>Scaling mismatch.</b> Hardware is {injectorCc}cc but the ECU is calibrated for {ecuInjectorCc}cc — every pulse delivers about {((injectorCc / ecuInjectorCc) * 100).toFixed(0)}% of the intended fuel, so the engine runs {injectorCc > ecuInjectorCc ? 'far too rich' : 'dangerously lean'} everywhere.
-                <button onClick={() => setEcuInjectorCcInvalidating(injectorCc)} style={{ display: 'block', width: '100%', marginTop: 9, padding: '10px 0', borderRadius: 8, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 12.5 }}>
+                <button onClick={() => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'ecuInjectorCc', value: injectorCc })} style={{ display: 'block', width: '100%', marginTop: 9, padding: '10px 0', borderRadius: 8, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 12.5 }}>
                   RESCALE ECU TO {injectorCc}cc
                 </button>
               </div>
@@ -2005,7 +1953,7 @@ function EngineManagementSandbox() {
             </Panel>
             <div style={{ fontSize: 12, color: T.ink2, marginBottom: 7, fontWeight: 600 }}>MAF Scalar</div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 11, marginBottom: 6 }}>
-              <input type="range" min={0.75} max={1.25} step={0.01} value={mafScalar} onChange={(e) => setMafScalarInvalidating(Number(e.target.value))} style={{ flex: 1, accentColor: T.acc }} />
+              <input type="range" min={0.75} max={1.25} step={0.01} value={mafScalar} onChange={(e) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'mafScalar', value: Number(e.target.value) })} style={{ flex: 1, accentColor: T.acc }} />
               <div style={{ fontFamily: T.mono, fontWeight: 800, fontSize: 15, width: 52, textAlign: 'right', color: T.ink }}>{mafScalar.toFixed(2)}</div>
             </div>
             <ExpandableInfo title="VE tuning vs. MAF tuning — platforms differ">

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -1,3 +1,19 @@
+// @ts-nocheck
+/*
+ * This file opts out of type checking, deliberately and temporarily.
+ *
+ * `tsconfig.json` leaves EcuLab.jsx out of `include` because it is still one large
+ * untyped component. That keeps it from being checked as a ROOT file — but `include`
+ * and `exclude` only choose root files. tsc still checks anything a root file imports
+ * transitively, so the moment a test under `tests/` imports this module, its ~26
+ * pre-existing type errors fail `npm run typecheck`.
+ *
+ * This directive is what actually holds the line the tsconfig comment describes, and it
+ * lets the characterisation tests import the component normally instead of hiding it
+ * from tsc behind a dynamic import.
+ *
+ * It disappears with the file: PR 3 splits this component into typed screens.
+ */
 /**
  * ECU LAB — the application shell and screens.
  *

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -345,7 +345,7 @@ function TuningGrid({ data, min, max, decimals, selection, setSelection }) {
     return false;
   };
   return (
-    <div>
+    <div data-testid="tuning-grid">
     <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 9.5, color: T.ink3, fontWeight: 700, letterSpacing: 0.8, marginBottom: 4 }}>
       <span>MAP kPa &darr;</span><span>RPM &rarr;</span>
     </div>
@@ -449,7 +449,7 @@ function SelectionDock({ data, setData, selection, min, max, decimals, unit, onC
   else sel = `${RPM[selection.col]} RPM · ${LOAD[selection.row]} kPa MAP`;
 
   return (
-    <div style={{ position: 'sticky', bottom: 0, background: T.panel, borderTop: `1px solid ${T.line}`, padding: '11px 14px 13px', boxShadow: `0 -8px 20px ${shadowAlpha(0.45)}` }}>
+    <div data-testid="selection-dock" style={{ position: 'sticky', bottom: 0, background: T.panel, borderTop: `1px solid ${T.line}`, padding: '11px 14px 13px', boxShadow: `0 -8px 20px ${shadowAlpha(0.45)}` }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 7 }}>
         <div>
           <div style={{ fontSize: 10, letterSpacing: 1, color: T.ink2, textTransform: 'uppercase', fontWeight: 700 }}>{sel}</div>

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -53,6 +53,8 @@ import { BUILD_VERSION } from '../version.js';
 import { loadCareer, saveCareer } from '../storage.js';
 import { StartScreen } from './screens/StartScreen.jsx';
 import { TutorialScreen } from './screens/TutorialScreen.jsx';
+import { StoreProvider, useBuild } from './state/StoreProvider.jsx';
+import { ACTIONS } from './state/reducer.js';
 
 const Eyebrow = ({ children, icon: Icon }) => (
   <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
@@ -531,9 +533,14 @@ function TrimBar({ label, value }) {
 }
 
 // ============================================================
-export default function EngineManagementSandbox() {
+function EngineManagementSandbox() {
   const [appView, setAppView] = useState('start');
   const [tab, setTab] = useState('dash');
+  // The BUILD slice — hardware and ECU configuration — lives in the store. Destructured
+  // so every READ site below stays a bare `engineConfig` / `mods` / ...; only the WRITES
+  // changed, from setters to dispatches. `tune` and `session` are still local useState
+  // below until Tasks 5 and 6 move them.
+  const [, dispatch] = useBuild();
   const [engineConfig, setEngineConfig] = useState(DEFAULT_ENGINE_CONFIG);
   const [mods, setMods] = useState(DEFAULT_MODS);
   const [ve, setVe] = useState(() => computeHardwareVE(DEFAULT_ENGINE_CONFIG, DEFAULT_MODS));
@@ -729,10 +736,21 @@ export default function EngineManagementSandbox() {
     // through the invalidating setters so the header stops claiming a factory
     // calibration this just deleted, and the last call pins tablesDirty back to
     // false: a reset baseline is not unsaved player work.
-    setVeEdited(computeHardwareVE(engineConfig, DEFAULT_MODS, hwForVe));
-    setTimingEdited(clone2D(DEFAULT_TIMING)); setAfrEdited(clone2D(DEFAULT_AFR));
-    setModsInvalidating(DEFAULT_MODS); setMafScalarInvalidating(1.0);
+    // The reducer does NOT compute the stock VE table; the caller does, and the mix of
+    // arguments is the point: DEFAULT_MODS (the bolt-ons come off) against the CURRENT
+    // `hwForVe` (the turbo does not — resetting the calibration is not uninstalling the
+    // hardware). Either half swapped for the other yields a perfectly plausible table
+    // that is wrong.
+    const stockVe = computeHardwareVE(engineConfig, DEFAULT_MODS, hwForVe);
+    dispatch({ type: ACTIONS.RESET_TO_STOCK, ve: stockVe });
+    // `tune` is still local useState until Task 5, so it is written here too. Note these
+    // are the RAW setters, not the ...Edited wrappers: the wrappers exist to flag unsaved
+    // player work, and a reset baseline is not that — which is why the original's last
+    // call had to pin tablesDirty back to false.
+    setVe(stockVe); setTiming(clone2D(DEFAULT_TIMING)); setAfr(clone2D(DEFAULT_AFR));
     setTablesDirty(false);
+    // Build fields this task has not moved into the store yet; deleted as each moves.
+    setMods(DEFAULT_MODS); setMafScalar(1.0); setPresetId(null);
   };
   const repairEngine = () => setHealth({ piston: 100, bearing: 100, valve: 100 });
   const setCfg = (patch) => setEngineConfigInvalidating((c) => ({ ...c, ...patch }));
@@ -750,6 +768,14 @@ export default function EngineManagementSandbox() {
     // routing its own writes through setPresetId(null) would make that order-
     // dependent on React's batching instead of explicit here.
     const p = applyPreset(preset);
+    // The BUILD slice lands atomically in the store, in one pass, with no "last call"
+    // to get right. NOTE the payload is applyPreset()'s OUTPUT, not the raw catalogue
+    // entry — the raw entry has no `engineConfig`, so passing it would build an engine
+    // with no short block.
+    dispatch({ type: ACTIONS.APPLY_PRESET, preset: p });
+    // `tune` and `session` are still local useState until Tasks 5 and 6, so their
+    // writes below stay. So do the build-field writes for whichever fields this task
+    // has not moved into the store yet; each one is deleted as its field moves.
     setEngineConfig(p.engineConfig);
     setMods(p.mods);
     setTurboOn(p.turboOn);
@@ -889,6 +915,11 @@ export default function EngineManagementSandbox() {
       exhaustDiaError, dutyPreview, displacementL: engineDerived.displacementL, fuel, mods,
     });
     const pull = computePullScore({ peakHp: r.peakHp, peakTq: r.peakTq, tuningScore: ts.score, engineerScore: es.score });
+    // Banking the pull — prevResult rotation, wear, scores, pull count — lands in the
+    // store in one pass. `result` and `pullScore` are precomputed here because the
+    // reducer has no access to the useMemo-derived hardware `computePullScore` needs.
+    // The still-local session setters above and below stay until Task 6.
+    dispatch({ type: ACTIONS.BANK_PULL, result: r, pullScore: pull });
     const nextBest = Math.max(bestScore, pull);
     const nextTotal = totalScore + pull;
     const nextPulls = pullCount + 1;
@@ -2342,5 +2373,26 @@ export default function EngineManagementSandbox() {
         })}
       </div>
     </div>
+  );
+}
+
+/**
+ * The app shell: the store, then the app inside it.
+ *
+ * The provider is mounted HERE rather than in `main.jsx` because the store is this
+ * module's own state — every consumer of it lives inside this file (and, after PR 3,
+ * inside the screens this file splits into). Mounting it at the module boundary means
+ * `<EcuLab />` is self-contained: `main.jsx` stays the thin "mount the app in an error
+ * boundary" entry point it documents itself as, and a test that renders `<EcuLab />`
+ * gets the same single store the browser does instead of having to reconstruct the
+ * app's root providers by hand.
+ *
+ * @returns {React.ReactElement}
+ */
+export default function EcuLab() {
+  return (
+    <StoreProvider>
+      <EngineManagementSandbox />
+    </StoreProvider>
   );
 }

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -45,7 +45,7 @@ import {
   PRESET_GROUPS, PSI_TO_KPA, SPARK_MAX_DEG, SPARK_MIN_DEG,
   R_AIR, RPM, TURBINE_OPTS, applyPreset, calibrationAdvice, chargeTempK, clamp, clone2D,
   computeEngineerScore, computeHardwareVE, computePullScore, computeTuningScore,
-  deriveEngine, idealExhaustDiameter, interp2, liveStep, makeLiveState, presetById,
+  deriveEngine, idealExhaustDiameter, interp2, presetById,
   simulateSweep, turbineWithCount, veRecommendations
 } from '../sim/index.js';
 import { T, accAlpha, deltaHeat, heat, shadowAlpha, statusColor } from './theme.js';
@@ -53,7 +53,7 @@ import { BUILD_VERSION } from '../version.js';
 import { loadCareer, saveCareer } from '../storage.js';
 import { StartScreen } from './screens/StartScreen.jsx';
 import { TutorialScreen } from './screens/TutorialScreen.jsx';
-import { StoreProvider, useBuild, useTune } from './state/StoreProvider.jsx';
+import { StoreProvider, useBuild, useSession, useTune } from './state/StoreProvider.jsx';
 import { ACTIONS } from './state/reducer.js';
 
 const Eyebrow = ({ children, icon: Icon }) => (
@@ -546,8 +546,7 @@ export function EcuLabApp() {
   const [tab, setTab] = useState('dash');
   // The BUILD slice — hardware and ECU configuration — lives in the store. Destructured
   // so every READ site below stays a bare `engineConfig` / `mods` / ...; only the WRITES
-  // changed, from setters to dispatches. `session` is still local useState below until
-  // Task 6 moves it.
+  // changed, from setters to dispatches. All three domain slices are in the store now.
   const [build, dispatch] = useBuild();
   const {
     engineConfig, mods, turboOn, boostCurve, octaneIdx, injIdx, mafScalar,
@@ -560,30 +559,27 @@ export function EcuLabApp() {
   // so it is not re-bound here.
   const [tune] = useTune();
   const { ve, timing, afr, tablesDirty, selection } = tune;
-  const [loadKpa, setLoadKpa] = useState(100);
-  const [health, setHealth] = useState({ piston: 100, bearing: 100, valve: 100 });
-  const [running, setRunning] = useState(false);
-  const [result, setResult] = useState(null);
-  const [prevResult, setPrevResult] = useState(null);
-  const [revealCount, setRevealCount] = useState(0);
-  const [bestScore, setBestScore] = useState(0);
-  const [totalScore, setTotalScore] = useState(0);
-  const [pullCount, setPullCount] = useState(0);
+  // The SESSION slice — everything about the current run and career progress that is
+  // neither hardware nor calibration. Same destructuring shape again, same `dispatch`.
+  // What is left as local `useState` below is deliberate: `appView`, `tab`,
+  // `buildSection`, `tuneView`, `dynoView` and `dashSection` are VIEW state (which
+  // screen and which accordion panel is open), which PR 3 moves when it splits this
+  // component into screens.
+  const [session] = useSession();
+  const {
+    loadKpa, soundOn, journeyStep, throttleInput, histogram, health,
+    result, prevResult, running, revealCount, bestScore, totalScore, pullCount,
+    live,
+  } = session;
   const [buildSection, setBuildSection] = useState('engine');
   const [tuneView, setTuneView] = useState('ve');
   const [dynoView, setDynoView] = useState('result');
-  const [histogram, setHistogram] = useState(null);
-  const [live, setLive] = useState(() => makeLiveState());
-  const [throttleInput, setThrottleInput] = useState(0);
   const [dashSection, setDashSection] = useState('live');
-  // Guided first run: BUILD -> TUNE -> LIVE -> DYNO, then free play (step 4).
-  const [journeyStep, setJourneyStep] = useState(0);
   const revealTimer = useRef(null);
   const liveTimer = useRef(null);
   const liveCfgRef = useRef(null);
   const throttleRef = useRef(0);
   const audioRef = useRef(null);
-  const [soundOn, setSoundOn] = useState(true);
 
   // `withPresetField` is gone: SET_BUILD_FIELD clears `presetId` itself, so the
   // invalidation now happens inside the reducer rather than in a wrapper each new
@@ -720,7 +716,11 @@ export function EcuLabApp() {
     const stockVe = computeHardwareVE(engineConfig, DEFAULT_MODS, hwForVe);
     dispatch({ type: ACTIONS.RESET_TO_STOCK, ve: stockVe });
   };
-  const repairEngine = () => setHealth({ piston: 100, bearing: 100, valve: 100 });
+  // The REPAIR button's only handler. Before the extraction this wrote a local
+  // `health` that the store never saw, while REPAIR_ENGINE sat in the reducer with no
+  // caller at all — so this is an ADDED dispatch, not a converted one. Drop it and the
+  // button goes inert with nothing raising an error: see tests/ui/session-store.test.jsx.
+  const repairEngine = () => dispatch({ type: ACTIONS.REPAIR_ENGINE });
   // Actions cannot carry functions, so the old functional update becomes a patch the
   // reducer merges into the engineConfig it already holds. It invalidates the preset
   // label like every other hardware write.
@@ -743,15 +743,12 @@ export function EcuLabApp() {
     // NOTE the payload is applyPreset()'s OUTPUT, not the raw catalogue entry — the
     // raw entry has no `engineConfig`, so passing it builds an engine with no short
     // block.
+    // APPLY_PRESET writes all three slices in that one pass — including clearing
+    // `session.result` and `session.prevResult`, so that a factory rating from the
+    // newly loaded engine never sits next to a pull logged on whatever was running
+    // before it. The two local `setResult(null)`/`setPrevResult(null)` calls that used
+    // to follow this line were mirroring writes the reducer already made.
     dispatch({ type: ACTIONS.APPLY_PRESET, preset: p });
-    // APPLY_PRESET already wrote the `tune` slice (ve/timing/afr/tablesDirty/selection)
-    // in the same pass. `session` is still local useState until Task 6, so it is
-    // written here too.
-    //
-    // A factory rating from the newly loaded engine must never sit next to a pull
-    // logged on whatever was running before it.
-    setResult(null);
-    setPrevResult(null);
   };
 
   const choosePreset = (preset) => {
@@ -841,20 +838,17 @@ export function EcuLabApp() {
   const doRun = () => {
     const a = ensureAudio();
     if (a && a.ctx.state === 'suspended') a.ctx.resume();
-    setRunning(true);
-    setRevealCount(0);
+    // The reveal animation's own state: `running` gates the RUN button's label and the
+    // partial chart, `revealCount` is how much of the sweep has been drawn so far.
+    // Neither has an ordering hazard (unlike the banking tail below, which BANK_PULL
+    // owns), so they stay plain field writes.
+    dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'running', value: true });
+    dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'revealCount', value: 0 });
     const r = simulateSweep({
       loadKpa, ve, veTruth, timing, afr, turboOn, boostCurve, octaneBonus, octaneLabel: OCTANE_OPTS[octaneIdx].label,
       fuel, injectorCc, ecuInjectorCc, injectorLabel: INJECTOR_OPTS[injIdx].label, mods, mafScalar, derived: engineDerived,
       turbine, compressor: COMPRESSOR_OPTS[compressorIdx],
     });
-    setPrevResult(result);
-    setResult(r);
-    setHealth((h) => ({
-      piston: clamp(h.piston - r.wear.piston, 0, 100),
-      bearing: clamp(h.bearing - r.wear.bearing, 0, 100),
-      valve: clamp(h.valve - r.wear.valve, 0, 100),
-    }));
     const ts = computeTuningScore(r);
     const es = computeEngineerScore({
       engineConfig, turboOn, peakBoostPsi: turboOn ? Math.max(...boostCurve) : 0,
@@ -865,19 +859,26 @@ export function EcuLabApp() {
     // Banking the pull — prevResult rotation, wear, scores, pull count — lands in the
     // store in one pass. `result` and `pullScore` are precomputed here because the
     // reducer has no access to the useMemo-derived hardware `computePullScore` needs.
-    // The still-local session setters above and below stay until Task 6.
+    // The local `setPrevResult`/`setResult`/`setHealth` calls that used to sit above
+    // this line, and the `setBestScore`/`setTotalScore`/`setPullCount` trio below it,
+    // were all mirroring writes this one action already makes — including the
+    // prevResult-before-result rotation whose ordering it exists to own.
     dispatch({ type: ACTIONS.BANK_PULL, result: r, pullScore: pull });
+    // BANK_PULL writes bestScore/totalScore/pullCount itself, from the same three
+    // expressions. They are still computed here because `persistCareer` needs the new
+    // values NOW: reading them back off `session` would read this render's stale ones.
     const nextBest = Math.max(bestScore, pull);
     const nextTotal = totalScore + pull;
     const nextPulls = pullCount + 1;
-    setBestScore(nextBest); setTotalScore(nextTotal); setPullCount(nextPulls);
     persistCareer(nextBest, nextTotal, nextPulls);
     const total = r.points.length;
     let i = 0;
     revealTimer.current = setInterval(() => {
       i += Math.ceil(total / 30);
-      setRevealCount(Math.min(i, total));
-      if (i >= total) { clearInterval(revealTimer.current); setRunning(false); }
+      // `i` is the interval's own counter, not a read of `revealCount`, so there is no
+      // stale-closure hazard in carrying the value on the action.
+      dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'revealCount', value: Math.min(i, total) });
+      if (i >= total) { clearInterval(revealTimer.current); dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'running', value: false }); }
     }, 55);
   };
   useEffect(() => () => { if (revealTimer.current) clearInterval(revealTimer.current); }, []);
@@ -893,14 +894,30 @@ export function EcuLabApp() {
 
   // The engine runs continuously in the background at 20 Hz, integrating real
   // crankshaft dynamics and running one ECU control pass per step.
+  //
+  // The step itself happens in the REDUCER, not here. This interval is installed once
+  // and never re-created, so its callback closes over the `live` of the first render
+  // forever — computing `liveStep(live, ...)` here and dispatching the result would
+  // integrate from a permanently frozen engine-off state, and the readout would sit
+  // dead or jitter between two adjacent steps. That reads as a physics bug, not a
+  // state bug. The old `setLive((prev) => ...)` functional form has no action
+  // equivalent (actions must not carry functions), so LIVE_STEP carries only the two
+  // things the reducer cannot see — the driver input and the current tune — and
+  // resolves `prev` against the store. Both come from REFS, which are current at every
+  // tick, so nothing stale reaches the engine.
   useEffect(() => {
     liveTimer.current = setInterval(() => {
-      setLive((prev) => (prev.running || prev.cranking || prev.rpm > 1)
-        ? liveStep(prev, 0.05, { throttle: throttleRef.current, load: 0 }, liveCfgRef.current)
-        : prev);
+      dispatch({
+        type: ACTIONS.LIVE_STEP,
+        dt: 0.05,
+        input: { throttle: throttleRef.current, load: 0 },
+        cfg: liveCfgRef.current,
+      });
     }, 50);
     return () => clearInterval(liveTimer.current);
-  }, []);
+    // Stable for the life of the store, so the interval is still installed exactly once
+    // — re-creating it would restart the engine's 20 Hz clock on every render.
+  }, [dispatch]);
 
   // ---- Engine audio -------------------------------------------------------
   // Synthesised from the firing frequency: a 4-stroke fires cyl/2 times per
@@ -910,17 +927,17 @@ export function EcuLabApp() {
   const startEngine = () => {
     const a = ensureAudio();
     if (a && a.ctx.state === 'suspended') a.ctx.resume();
-    setLive((p) => ({ ...p, cranking: true }));
+    dispatch({ type: ACTIONS.LIVE_PATCH, patch: { cranking: true } });
   };
   const stopEngine = () => {
-    setThrottleInput(0); throttleRef.current = 0;
-    setLive((p) => ({ ...p, running: false, cranking: false }));
+    dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'throttleInput', value: 0 }); throttleRef.current = 0;
+    dispatch({ type: ACTIONS.LIVE_PATCH, patch: { running: false, cranking: false } });
   };
 
   // Safety net: if a pointerup/cancel is missed (scroll, app switch, lost focus)
   // the throttle must still close, or the engine would hang at redline.
   useEffect(() => {
-    const release = () => { setThrottleInput(0); throttleRef.current = 0; };
+    const release = () => { dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'throttleInput', value: 0 }); throttleRef.current = 0; };
     window.addEventListener('pointerup', release);
     window.addEventListener('pointercancel', release);
     window.addEventListener('blur', release);
@@ -931,7 +948,10 @@ export function EcuLabApp() {
       window.removeEventListener('blur', release);
       document.removeEventListener('visibilitychange', release);
     };
-  }, []);
+    // `dispatch` is stable for the life of the store (useReducer guarantees it), so
+    // this effect still installs its listeners exactly once — the dependency is here
+    // to satisfy exhaustive-deps honestly rather than to make the effect re-run.
+  }, [dispatch]);
 
   // Career stats persist across sessions so the high score is worth chasing.
   useEffect(() => {
@@ -939,10 +959,13 @@ export function EcuLabApp() {
     (async () => {
       const c = await loadCareer();
       if (cancelled) return;
-      setBestScore(c.best); setTotalScore(c.total); setPullCount(c.pulls);
+      dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'bestScore', value: c.best });
+      dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'totalScore', value: c.total });
+      dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'pullCount', value: c.pulls });
     })();
     return () => { cancelled = true; };
-  }, []);
+    // Stable for the life of the store, so this still loads career stats exactly once.
+  }, [dispatch]);
 
   const chartData = useMemo(() => {
     if (!result) return [];
@@ -976,7 +999,7 @@ export function EcuLabApp() {
       const err = ((p.afr / p.afrCommanded) - 1) * 100;
       cells[ri][ci].sum += err; cells[ri][ci].n += 1;
     });
-    setHistogram(cells.map((row) => row.map((c) => (c.n ? c.sum / c.n : null))));
+    dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'histogram', value: cells.map((row) => row.map((c) => (c.n ? c.sum / c.n : null))) });
   };
   const applyHistogram = () => {
     if (!histogram) return;
@@ -988,7 +1011,7 @@ export function EcuLabApp() {
       return e == null ? v : Number(clamp(v * (1 + e / 100), 10, 130).toFixed(1));
     }));
     dispatch({ type: ACTIONS.SET_TABLE, table: 've', value: nextVe });
-    setHistogram(null);
+    dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'histogram', value: null });
   };
 
   const currentRpm = result ? (result.points[Math.min(revealCount, result.points.length - 1)]?.rpm ?? 1500) : 1500;
@@ -1123,7 +1146,7 @@ export function EcuLabApp() {
     return (
       <TutorialScreen
         steps={TUTORIAL_STEPS}
-        onDone={() => { setAppView('app'); setTab('build'); setJourneyStep(0); }}
+        onDone={() => { setAppView('app'); setTab('build'); dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'journeyStep', value: 0 }); }}
       />
     );
   }
@@ -1163,7 +1186,7 @@ export function EcuLabApp() {
         {/* ---------- HOME: live engine, career stats, health, learning ---------- */}
         {tab === 'dash' && (
           <div style={{ padding: 16 }}>
-            {journeyStep === 2 && <JourneyBanner step={2} onAdvance={() => { setJourneyStep(3); changeTab('dyno'); }} onDismiss={() => setJourneyStep(99)} />}
+            {journeyStep === 2 && <JourneyBanner step={2} onAdvance={() => { dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'journeyStep', value: 3 }); changeTab('dyno'); }} onDismiss={() => dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'journeyStep', value: 99 })} />}
             <BuildSection
               active={dashSection === 'live'} onClick={() => setDashSection(dashSection === 'live' ? null : 'live')}
               icon={Activity} label="Live Engine"
@@ -1194,7 +1217,7 @@ export function EcuLabApp() {
                         background: live.running || live.cranking ? T.panel2 : T.ok, color: live.running || live.cranking ? T.ink : T.okBg,
                         borderWidth: 1, borderStyle: 'solid', borderColor: live.running || live.cranking ? T.line : T.ok,
                       }}>{live.running || live.cranking ? 'STOP' : 'START ENGINE'}</button>
-                      <button onClick={() => { if (!soundOn) ensureAudio()?.ctx.resume(); setSoundOn((v) => !v); }} title="Engine sound" style={{
+                      <button onClick={() => { if (!soundOn) ensureAudio()?.ctx.resume(); dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'soundOn', value: !soundOn }); }} title="Engine sound" style={{
                         width: 46, padding: '11px 0', borderRadius: 9, fontWeight: 800, fontSize: 13,
                         border: `1px solid ${soundOn ? T.acc : T.line}`, background: soundOn ? T.accBg : T.panel2,
                         color: soundOn ? T.accInk : T.ink3,
@@ -1204,9 +1227,9 @@ export function EcuLabApp() {
                 </div>
 
                 <div
-                  onPointerDown={(e) => { e.currentTarget.setPointerCapture?.(e.pointerId); setThrottleInput(100); throttleRef.current = 100; }}
-                  onPointerUp={() => { setThrottleInput(0); throttleRef.current = 0; }}
-                  onPointerCancel={() => { setThrottleInput(0); throttleRef.current = 0; }}
+                  onPointerDown={(e) => { e.currentTarget.setPointerCapture?.(e.pointerId); dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'throttleInput', value: 100 }); throttleRef.current = 100; }}
+                  onPointerUp={() => { dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'throttleInput', value: 0 }); throttleRef.current = 0; }}
+                  onPointerCancel={() => { dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'throttleInput', value: 0 }); throttleRef.current = 0; }}
                   style={{
                     position: 'relative', overflow: 'hidden',
                     marginTop: 12, padding: '18px 0', borderRadius: 12, textAlign: 'center', userSelect: 'none',
@@ -1426,7 +1449,7 @@ export function EcuLabApp() {
         {/* ---------- BUILD: engine architecture, parts, forced induction ---------- */}
         {tab === 'build' && (
           <div style={{ padding: 16 }}>
-            {journeyStep === 0 && <JourneyBanner step={0} onAdvance={() => { setJourneyStep(1); changeTab('tune'); }} onDismiss={() => setJourneyStep(99)} />}
+            {journeyStep === 0 && <JourneyBanner step={0} onAdvance={() => { dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'journeyStep', value: 1 }); changeTab('tune'); }} onDismiss={() => dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'journeyStep', value: 99 })} />}
             <Eyebrow icon={Settings}>Garage</Eyebrow>
             <p style={{ fontSize: 12.5, color: T.ink2, lineHeight: 1.6, marginTop: 0, marginBottom: 14 }}>
               Design the car before you tune it. Tap a section to open it — every choice inside changes real physics elsewhere in the sandbox.
@@ -1752,7 +1775,7 @@ export function EcuLabApp() {
 
         {tab === 'tune' && journeyStep === 1 && (
           <div style={{ padding: '14px 16px 0' }}>
-            <JourneyBanner step={1} onAdvance={() => { setJourneyStep(2); changeTab('dash'); }} onDismiss={() => setJourneyStep(99)} />
+            <JourneyBanner step={1} onAdvance={() => { dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'journeyStep', value: 2 }); changeTab('dash'); }} onDismiss={() => dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'journeyStep', value: 99 })} />
           </div>
         )}
 
@@ -1990,10 +2013,10 @@ export function EcuLabApp() {
         {/* ---------- DYNO: run a pull, then curves / log / datalog / score ---------- */}
         {tab === 'dyno' && (
           <div style={{ padding: 16 }}>
-            {journeyStep === 3 && <JourneyBanner step={3} onAdvance={() => setJourneyStep(99)} onDismiss={() => setJourneyStep(99)} />}
+            {journeyStep === 3 && <JourneyBanner step={3} onAdvance={() => dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'journeyStep', value: 99 })} onDismiss={() => dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'journeyStep', value: 99 })} />}
             <Eyebrow icon={Activity}>Dyno Cell</Eyebrow>
             <div style={{ fontSize: 12, color: T.ink2, marginBottom: 8, fontWeight: 600 }}>Manifold pressure for the pull (load)</div>
-            <Seg options={[100, 70, 40].map((l) => ({ label: `${l} kPa`, value: l }))} value={loadKpa} onChange={setLoadKpa} />
+            <Seg options={[100, 70, 40].map((l) => ({ label: `${l} kPa`, value: l }))} value={loadKpa} onChange={(v) => dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'loadKpa', value: v })} />
             <div style={{ fontSize: 10.5, color: T.ink3, marginTop: 4, marginBottom: 4 }}>
               ~100 kPa is wide-open throttle naturally aspirated. Boost adds on top and walks the tables into the higher-MAP rows automatically.
             </div>
@@ -2212,7 +2235,7 @@ export function EcuLabApp() {
                           <button onClick={applyHistogram} style={{ flex: 2, padding: '12px 0', borderRadius: 10, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 12.5 }}>
                             APPLY CORRECTIONS TO VE
                           </button>
-                          <button onClick={() => setHistogram(null)} style={{ flex: 1, padding: '12px 0', borderRadius: 10, border: `1px solid ${T.line}`, background: T.panel2, color: T.ink2, fontWeight: 700, fontSize: 12.5 }}>
+                          <button onClick={() => dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'histogram', value: null })} style={{ flex: 1, padding: '12px 0', borderRadius: 10, border: `1px solid ${T.line}`, background: T.panel2, color: T.ink2, fontWeight: 700, fontSize: 12.5 }}>
                             DISCARD
                           </button>
                         </div>

--- a/src/ui/state/StoreProvider.jsx
+++ b/src/ui/state/StoreProvider.jsx
@@ -1,0 +1,87 @@
+/**
+ * The store's React binding.
+ *
+ * One `useReducer`, one context carrying `[state, dispatch]`, and three hooks —
+ * `useBuild`, `useTune`, `useSession` — that each select their own slice. Consumers
+ * see the three-way split the design doc specifies; internally it stays one state
+ * tree, for the reasons in reducer.js's file header (cross-slice actions like
+ * SET_TABLE, and APPLY_PRESET/RESET_TO_STOCK to come, must land in a single pass).
+ */
+
+import React, { createContext, useContext, useReducer } from 'react';
+
+import { makeInitialState } from './initialState.js';
+import { reducer } from './reducer.js';
+
+/** @typedef {import('./initialState.js').StoreState} StoreState */
+/** @typedef {import('./initialState.js').BuildState} BuildState */
+/** @typedef {import('./initialState.js').TuneState} TuneState */
+/** @typedef {import('./initialState.js').SessionState} SessionState */
+/** @typedef {import('./reducer.js').StoreAction} StoreAction */
+
+/** @typedef {[StoreState, React.Dispatch<StoreAction>]} StoreContextValue */
+
+/** @type {React.Context<StoreContextValue|null>} */
+const StoreContext = createContext(null);
+
+/**
+ * Wraps its children in the store. Mount once, at the app root.
+ * @param {{children: React.ReactNode}} props
+ * @returns {React.ReactElement}
+ */
+export function StoreProvider({ children }) {
+  // The third argument makes this LAZY init: makeInitialState() runs once, on
+  // mount, rather than being recomputed (and thrown away) on every render.
+  const [state, dispatch] = useReducer(reducer, undefined, makeInitialState);
+  /** @type {StoreContextValue} */
+  const value = [state, dispatch];
+  return (
+    <StoreContext.Provider value={value}>
+      {children}
+    </StoreContext.Provider>
+  );
+}
+
+/**
+ * Reads the whole store. Throws outside a StoreProvider rather than silently handing
+ * back `undefined` — that failure needs to surface here, not as a crash three
+ * components away when something destructures a slice off `undefined`.
+ * @returns {StoreContextValue}
+ */
+function useStore() {
+  const ctx = useContext(StoreContext);
+  if (ctx === null) {
+    throw new Error(
+      'useStore (and useBuild/useTune/useSession) must be called from inside <StoreProvider>.',
+    );
+  }
+  return ctx;
+}
+
+/**
+ * The BUILD slice: hardware and ECU configuration.
+ * @returns {[BuildState, React.Dispatch<StoreAction>]}
+ */
+export function useBuild() {
+  const [state, dispatch] = useStore();
+  return [state.build, dispatch];
+}
+
+/**
+ * The TUNE slice: calibration tables and the unsaved-work flag.
+ * @returns {[TuneState, React.Dispatch<StoreAction>]}
+ */
+export function useTune() {
+  const [state, dispatch] = useStore();
+  return [state.tune, dispatch];
+}
+
+/**
+ * The SESSION slice: run results, scores, wear, the live-engine model and onboarding
+ * progress.
+ * @returns {[SessionState, React.Dispatch<StoreAction>]}
+ */
+export function useSession() {
+  const [state, dispatch] = useStore();
+  return [state.session, dispatch];
+}

--- a/src/ui/state/initialState.js
+++ b/src/ui/state/initialState.js
@@ -1,11 +1,11 @@
 /**
  * The store's starting values, sliced into `build`, `tune`, and `session`.
  *
- * Every default below is copied verbatim from EcuLab.jsx's `useState` initialisers
- * (src/ui/EcuLab.jsx, around lines 535-592) — this file changes nothing about what a
- * fresh session starts with, only where that starting value lives. See reducer.js for
- * why the three slices below are combined into ONE state tree rather than three
- * independent ones.
+ * Every default below began as a verbatim copy of an EcuLab.jsx `useState`
+ * initialiser. Those `useState` calls are gone, so this file is now the SOLE
+ * definition of what a fresh session starts with, not a second copy of one: change a
+ * default here and you have changed the app. See reducer.js for why the three slices
+ * below are combined into ONE state tree rather than three independent ones.
  *
  * `makeInitialState()` must return a fresh object graph on every call — a shared
  * initial state would let one test's mutation leak into the next, or one player's
@@ -77,7 +77,9 @@ import {
  * @property {{piston: number, bearing: number, valve: number}} health component wear, percent
  * @property {object|null} histogram the fuel-trim histogram from the last pull
  * @property {object} live the running live-engine model's state
- * @property {number} throttleInput the driver's current throttle input, 0..1
+ * @property {number} throttleInput the driver's current throttle input, PERCENT
+ *   (0..100), not a 0..1 fraction: the throttle pad writes 0 or 100 and `liveStep`
+ *   compares it against 3 and clamps it to 0..100 (`src/sim/live.js`)
  * @property {number} loadKpa the dyno sweep's fixed manifold load, kPa
  * @property {boolean} soundOn whether the engine-note synth is enabled
  * @property {number} journeyStep guided-onboarding progress: BUILD -> TUNE -> LIVE ->

--- a/src/ui/state/initialState.js
+++ b/src/ui/state/initialState.js
@@ -1,0 +1,144 @@
+/**
+ * The store's starting values, sliced into `build`, `tune`, and `session`.
+ *
+ * Every default below is copied verbatim from EcuLab.jsx's `useState` initialisers
+ * (src/ui/EcuLab.jsx, around lines 535-592) — this file changes nothing about what a
+ * fresh session starts with, only where that starting value lives. See reducer.js for
+ * why the three slices below are combined into ONE state tree rather than three
+ * independent ones.
+ *
+ * `makeInitialState()` must return a fresh object graph on every call — a shared
+ * initial state would let one test's mutation leak into the next, or one player's
+ * reset leak into their next build. The DEFAULT_* imports below are safe to reference
+ * directly without cloning: they are `Object.freeze`d at their definition in
+ * `src/sim/tables.js` and never written to. The calibration tables are NOT shared —
+ * `ve` comes from a fresh `computeHardwareVE` call and `timing`/`afr` are cloned with
+ * `clone2D` — because those get edited in place by table writes.
+ */
+
+import {
+  DEFAULT_AFR, DEFAULT_BOOST, DEFAULT_ENGINE_CONFIG, DEFAULT_MODS, DEFAULT_TIMING,
+  EXHAUST_DIA_OPTS, clone2D, computeHardwareVE, makeLiveState,
+} from '../../sim/index.js';
+
+/**
+ * Hardware and ECU configuration a factory preset owns. A hand edit to any field here
+ * clears `presetId` (the preset label), because it is no longer that preset's build.
+ * It does NOT by itself flag `tune.tablesDirty` — that flag means unsaved calibration
+ * work, and hardware edits alone don't touch the calibration tables.
+ *
+ * @typedef {object} BuildState
+ * @property {import('../../sim/index.js').EngineConfig} engineConfig short-block design
+ * @property {{intake: boolean, exhaust: boolean, headers: boolean, intercooler: boolean}} mods bolt-ons fitted
+ * @property {boolean} turboOn
+ * @property {number[]} boostCurve psi, indexed by RPM
+ * @property {number} octaneIdx index into OCTANE_OPTS
+ * @property {number} injIdx index into INJECTOR_OPTS
+ * @property {number} mafScalar ECU's MAF correction scalar
+ * @property {number} turbineIdx index into TURBINE_OPTS
+ * @property {number} turbineCount how many of that housing are fitted (only a preset sets this above 1)
+ * @property {number} compressorIdx index into COMPRESSOR_OPTS
+ * @property {number} exhaustDiaIdx index into EXHAUST_DIA_OPTS
+ * @property {number} ecuInjectorCc injector size the ECU is calibrated for, cc/min
+ * @property {string|null} presetId which factory preset (if any) is currently loaded stock
+ * @property {object|null} presetPrompt the preset pending an overwrite-confirmation prompt, or null
+ * @property {number} boostSel which RPM column the boost-curve editor has selected
+ */
+
+/**
+ * The calibration tables and the player's unsaved-work flag. `tablesDirty` — not pull
+ * count — is what the overwrite-confirmation prompt keys off: pull count is restored
+ * from career storage on load (so it would nag a returning player on an untouched
+ * default engine) and misses a player who edited every table but never pulled.
+ *
+ * @typedef {object} TuneState
+ * @property {number[][]} ve volumetric efficiency table, percent, indexed [LOAD][RPM]
+ * @property {number[][]} timing spark advance table, degrees, indexed [LOAD][RPM]
+ * @property {number[][]} afr target air/fuel ratio table, indexed [LOAD][RPM]
+ * @property {boolean} tablesDirty true once VE/spark/fuel has been hand-edited since
+ *   the last preset load or reset-to-stock
+ * @property {{type: 'cell'|'row'|'col', row?: number, col?: number}|null} selection
+ *   the currently selected calibration-grid cell, row or column, or null
+ */
+
+/**
+ * Everything about the current run and career progress that is NOT hardware or
+ * calibration: dyno results, scores, engine wear, the live-engine model, and
+ * onboarding progress.
+ *
+ * @typedef {object} SessionState
+ * @property {boolean} running true while a dyno pull is sweeping
+ * @property {object|null} result the most recent dyno pull's result
+ * @property {object|null} prevResult the dyno pull before that, for comparison
+ * @property {number} revealCount how much of the current result has been revealed
+ * @property {number} bestScore highest engineer score achieved this career
+ * @property {number} totalScore cumulative score across all pulls this career
+ * @property {number} pullCount how many dyno pulls have been logged this career
+ * @property {{piston: number, bearing: number, valve: number}} health component wear, percent
+ * @property {object|null} histogram the fuel-trim histogram from the last pull
+ * @property {object} live the running live-engine model's state
+ * @property {number} throttleInput the driver's current throttle input, 0..1
+ * @property {number} loadKpa the dyno sweep's fixed manifold load, kPa
+ * @property {boolean} soundOn whether the engine-note synth is enabled
+ * @property {number} journeyStep guided-onboarding progress: BUILD -> TUNE -> LIVE ->
+ *   DYNO, then free play (step 4). Survives navigation, so it lives here rather than
+ *   as view state.
+ */
+
+/**
+ * @typedef {object} StoreState
+ * @property {BuildState} build
+ * @property {TuneState} tune
+ * @property {SessionState} session
+ */
+
+/**
+ * Builds a fresh starting state for a new session.
+ * @returns {StoreState}
+ */
+export function makeInitialState() {
+  return {
+    build: {
+      engineConfig: DEFAULT_ENGINE_CONFIG,
+      mods: DEFAULT_MODS,
+      turboOn: false,
+      boostCurve: [...DEFAULT_BOOST],
+      octaneIdx: 0,
+      injIdx: 0,
+      mafScalar: 1.0,
+      turbineIdx: 1,
+      turbineCount: 1,
+      compressorIdx: 1,
+      // Pinned by diameter, not by position: adding sizes to the catalogue must not
+      // silently change which pipe a new build starts with.
+      exhaustDiaIdx: EXHAUST_DIA_OPTS.findIndex((o) => o.dia === 3.0),
+      ecuInjectorCc: 315,
+      presetId: null,
+      presetPrompt: null,
+      boostSel: 4,
+    },
+    tune: {
+      ve: computeHardwareVE(DEFAULT_ENGINE_CONFIG, DEFAULT_MODS),
+      timing: clone2D(DEFAULT_TIMING),
+      afr: clone2D(DEFAULT_AFR),
+      tablesDirty: false,
+      selection: null,
+    },
+    session: {
+      running: false,
+      result: null,
+      prevResult: null,
+      revealCount: 0,
+      bestScore: 0,
+      totalScore: 0,
+      pullCount: 0,
+      health: { piston: 100, bearing: 100, valve: 100 },
+      histogram: null,
+      live: makeLiveState(),
+      throttleInput: 0,
+      loadKpa: 100,
+      soundOn: true,
+      journeyStep: 0,
+    },
+  };
+}

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -36,6 +36,7 @@ import { clamp, clone2D, DEFAULT_AFR, DEFAULT_MODS, DEFAULT_TIMING } from '../..
  */
 export const ACTIONS = Object.freeze({
   SET_BUILD_FIELD: 'SET_BUILD_FIELD',
+  CLEAR_PRESET_ID: 'CLEAR_PRESET_ID',
   SET_TURBINE: 'SET_TURBINE',
   SET_TABLE: 'SET_TABLE',
   SET_SESSION_FIELD: 'SET_SESSION_FIELD',
@@ -56,6 +57,19 @@ export const ACTIONS = Object.freeze({
  * edits alone don't touch the calibration tables (see SET_TABLE for the write that
  * does).
  * @typedef {{type: 'SET_BUILD_FIELD', field: keyof BuildState, value: *}} SetBuildFieldAction
+ */
+
+/**
+ * Clears `presetId` alone, with NO other side effect — deliberately narrower than
+ * `SET_BUILD_FIELD`, which always pairs a field write with the same invalidation.
+ * Its one caller is the preset picker's "Custom build" option: choosing it disowns
+ * whatever preset is loaded without touching any other build field, so a generic
+ * `{type: SET_BUILD_FIELD, field: 'presetId', value: null}` would only have worked
+ * by coincidence — the reducer's own trailing `presetId: null` happens to overwrite
+ * whatever `action.value` said, so a future caller passing a non-null value would
+ * silently get `null` back with no error anywhere. This action can never carry a
+ * value that lies about what it does.
+ * @typedef {{type: 'CLEAR_PRESET_ID'}} ClearPresetIdAction
  */
 
 /**
@@ -181,7 +195,7 @@ export const ACTIONS = Object.freeze({
  * shape is assignable to `StoreAction` and the eleven specific typedefs above become
  * decorative — a typo'd payload key (`presset` instead of `preset`) would typecheck
  * clean. Without the catch-all, `tsc` must reject it.
- * @typedef {SetBuildFieldAction | SetTurbineAction | SetTableAction |
+ * @typedef {SetBuildFieldAction | ClearPresetIdAction | SetTurbineAction | SetTableAction |
  *   SetSessionFieldAction | SetTuneFieldAction | SetBoostSelAction |
  *   SetPresetPromptAction | SetEngineConfigPatchAction | ApplyPresetAction |
  *   ResetToStockAction | RepairEngineAction | BankPullAction
@@ -212,6 +226,12 @@ export function reducer(state, action) {
       return {
         ...state,
         build: { ...state.build, [action.field]: action.value, presetId: null },
+      };
+
+    case ACTIONS.CLEAR_PRESET_ID:
+      return {
+        ...state,
+        build: { ...state.build, presetId: null },
       };
 
     case ACTIONS.SET_TURBINE:

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -267,10 +267,23 @@ export const ACTIONS = Object.freeze({
  * normally cost is replay-safety — React re-runs a reducer over the same actions when
  * a render is double-invoked under StrictMode, or when an update is rebased behind a
  * higher-priority one — and here a replay re-integrates the SAME single step from the
- * SAME `prev`, so the engine never advances twice and the only thing that differs
+ * SAME `prev`; React never applies an action twice, it recomputes from base, so this
+ * is always a SINGLE-step replay. For that single step, the only thing that differs
  * between two runs is a fraction of a percent of simulated sensor noise, which is
- * random by design. No other case may call `Math.random()`; a second one would be a
- * reason to move the step out of the reducer, not a precedent.
+ * random by design. That framing does NOT generalise to a multi-step replay, and the
+ * reason is not cosmetic: the noise `sensorRead` writes into `sensedLambda`
+ * (live.js:253) is integrated into `stft` (live.js:239), `stft` into `ltft`
+ * (live.js:240), and `ltft` feeds back into `mafScalar` (live.js:192) — the airflow
+ * the engine actually runs on. Re-integrating several steps in sequence from divergent
+ * noise would be a bounded random walk through a learned fuel trim, not a rounding
+ * difference. Nothing in this reducer does that today — every replay React performs
+ * here is single-step — but it bounds what a FUTURE caller may safely do with this
+ * action: PR 4's undo log MUST exclude LIVE_STEP. It dispatches at 20 Hz, so one hour
+ * of idle alone is 72,000 entries, each pinning a `cfg` that references the full
+ * VE/timing/AFR tables — and even setting that cost aside, "undo the last 50 ms of
+ * engine idle" is not a thing a player wants. No other case may call `Math.random()`;
+ * a second one would be a reason to move the step out of the reducer, not a
+ * precedent.
  *
  * @param {StoreState} state
  * @param {StoreAction} action
@@ -436,11 +449,18 @@ export function reducer(state, action) {
 
     case ACTIONS.LIVE_STEP: {
       const prev = state.session.live;
-      // A stopped engine has nothing to integrate. Returning the SAME state object —
-      // not a fresh one holding an unchanged `live` — is what makes React bail out of
-      // the re-render: this action arrives 20 times a second for as long as the app is
-      // open, engine running or not, and every one of those ticks would otherwise
-      // re-render the entire app. This guard is `setLive`'s `: prev` branch, moved.
+      // A stopped engine has nothing to integrate. React 18's `dispatchReducerAction`
+      // DOES have an eager path: when the fiber has no pending lanes, it runs the
+      // reducer immediately outside of render and bails out on
+      // `Object.is(eagerState, currentState)` without scheduling a render at all. But
+      // that path is opportunistic, not guaranteed — it does not fire once a render is
+      // already in flight, which a dispatch arriving 20 times a second, racing every
+      // other UI action in the app, cannot rely on being clear of. Returning the SAME
+      // state object here is what GUARANTEES the bail-out on every tick regardless:
+      // even on the slow path, reconciliation compares the reducer's return value to
+      // the fiber's current state by `Object.is` and leaves `didReceiveUpdate` false
+      // when they match, so React still bails out of `StoreProvider`'s subtree and no
+      // consumer re-renders. This guard is `setLive`'s `: prev` branch, moved.
       if (!(prev.running || prev.cranking || prev.rpm > 1)) return state;
       return {
         ...state,

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -19,10 +19,13 @@
  * This file implements the SINGLE-slice actions (Task 2 of the state-extraction plan)
  * AND the cross-cutting actions that replace `applyEnginePreset`, `resetToStock`,
  * `repairEngine` and the score-tallying tail of `doRun` — APPLY_PRESET, RESET_TO_STOCK,
- * REPAIR_ENGINE, BANK_PULL (Task 3).
+ * REPAIR_ENGINE, BANK_PULL (Task 3). Task 6 adds the two live-engine actions,
+ * LIVE_STEP and LIVE_PATCH, for the same reason SET_ENGINE_CONFIG_PATCH exists: they
+ * replace functional `setState` updaters, which an action cannot carry, so the reducer
+ * resolves them against the `live` it already holds.
  */
 
-import { clamp, clone2D, DEFAULT_AFR, DEFAULT_MODS, DEFAULT_TIMING } from '../../sim/index.js';
+import { clamp, clone2D, DEFAULT_AFR, DEFAULT_MODS, DEFAULT_TIMING, liveStep } from '../../sim/index.js';
 
 /** @typedef {import('./initialState.js').StoreState} StoreState */
 /** @typedef {import('./initialState.js').BuildState} BuildState */
@@ -48,6 +51,8 @@ export const ACTIONS = Object.freeze({
   RESET_TO_STOCK: 'RESET_TO_STOCK',
   REPAIR_ENGINE: 'REPAIR_ENGINE',
   BANK_PULL: 'BANK_PULL',
+  LIVE_STEP: 'LIVE_STEP',
+  LIVE_PATCH: 'LIVE_PATCH',
 });
 
 /**
@@ -190,6 +195,46 @@ export const ACTIONS = Object.freeze({
  */
 
 /**
+ * Advances the live engine by ONE integration step, replacing `EcuLab.jsx`'s
+ * `setLive((prev) => liveStep(prev, ...))` inside a 50 ms `setInterval`.
+ *
+ * This exists because a `SET_SESSION_FIELD` carrying an already-computed value could
+ * not be made correct here. The interval is installed once, with `[]` deps, so its
+ * callback closes over the `live` from the FIRST render forever. Computing
+ * `liveStep(live, ...)` in that callback would integrate from a state that is frozen
+ * at engine-off — the readout would sit dead, or jitter between two adjacent steps,
+ * and it would look like a physics bug rather than a stale closure. The functional
+ * `setLive(prev => ...)` form has no reducer equivalent, because actions must not
+ * carry functions. So the step happens HERE, where `prev` comes from the store.
+ *
+ * `input` and `cfg` are read from refs at DISPATCH time and carried on the action.
+ * They are the only two things the step needs that the reducer does not hold:
+ * `cfg` is `liveCfgRef.current`, rebuilt from the build/tune slices on every render
+ * (a live table edit must reach the running engine without restarting the interval),
+ * and `input.throttle` is `throttleRef.current`. Neither is a function.
+ *
+ * The one caveat, recorded because it is real rather than because it matters: the old
+ * updater read both refs when React RAN it, this reads them when the interval
+ * dispatches. The gap between the two is one React render — sub-millisecond against a
+ * 50 ms tick, and refs only change from pointer handlers and render, so no step can
+ * land on different inputs than it would have before.
+ *
+ * @typedef {{type: 'LIVE_STEP', dt: number, input: {throttle: number, load: number}, cfg: object}} LiveStepAction
+ */
+
+/**
+ * Merges a patch into the live-engine state, for the two writes that are a COMMAND to
+ * the engine rather than a step of it: `startEngine` (`{cranking: true}`) and
+ * `stopEngine` (`{running: false, cranking: false}`). Both were
+ * `setLive((p) => ({ ...p, ... }))` — functional, because they must land on top of
+ * whatever the 20 Hz interval last wrote, not on the `live` the click handler's render
+ * happened to capture. A value-carrying `SET_SESSION_FIELD` would rewind the engine by
+ * up to one step (rpm, temperatures, trims) every time the player pressed START or
+ * STOP. The reducer holds the current `live`, so the merge happens here.
+ * @typedef {{type: 'LIVE_PATCH', patch: object}} LivePatchAction
+ */
+
+/**
  * The union of every action shape the reducer actually understands. Deliberately has
  * NO catch-all `{type: string, [key: string]: *}` member: with one, every object
  * shape is assignable to `StoreAction` and the eleven specific typedefs above become
@@ -198,7 +243,8 @@ export const ACTIONS = Object.freeze({
  * @typedef {SetBuildFieldAction | ClearPresetIdAction | SetTurbineAction | SetTableAction |
  *   SetSessionFieldAction | SetTuneFieldAction | SetBoostSelAction |
  *   SetPresetPromptAction | SetEngineConfigPatchAction | ApplyPresetAction |
- *   ResetToStockAction | RepairEngineAction | BankPullAction
+ *   ResetToStockAction | RepairEngineAction | BankPullAction | LiveStepAction |
+ *   LivePatchAction
  * } KnownStoreAction
  */
 
@@ -210,11 +256,21 @@ export const ACTIONS = Object.freeze({
  */
 
 /**
- * The root reducer. Pure: no `Date.now()`, no `Math.random()`, no mutation of `state`
- * or any of its slices — every case that changes a slice returns a NEW object for
- * that slice only, and every slice it does not touch keeps its existing reference
- * (so `React.memo`/`useMemo` consumers downstream can bail out on an unrelated
- * dispatch).
+ * The root reducer. No `Date.now()`, no mutation of `state` or any of its slices —
+ * every case that changes a slice returns a NEW object for that slice only, and every
+ * slice it does not touch keeps its existing reference (so `React.memo`/`useMemo`
+ * consumers downstream can bail out on an unrelated dispatch).
+ *
+ * ONE case is not a pure function of `(state, action)`: `LIVE_STEP` calls `liveStep`,
+ * which is itself pure apart from `sensorRead`'s `Math.random()` sensor noise (see
+ * src/sim/live.js). That is deliberate and it is contained. What impurity would
+ * normally cost is replay-safety — React re-runs a reducer over the same actions when
+ * a render is double-invoked under StrictMode, or when an update is rebased behind a
+ * higher-priority one — and here a replay re-integrates the SAME single step from the
+ * SAME `prev`, so the engine never advances twice and the only thing that differs
+ * between two runs is a fraction of a percent of simulated sensor noise, which is
+ * random by design. No other case may call `Math.random()`; a second one would be a
+ * reason to move the step out of the reducer, not a precedent.
  *
  * @param {StoreState} state
  * @param {StoreAction} action
@@ -376,6 +432,29 @@ export function reducer(state, action) {
           totalScore: state.session.totalScore + action.pullScore,
           pullCount: state.session.pullCount + 1,
         },
+      };
+
+    case ACTIONS.LIVE_STEP: {
+      const prev = state.session.live;
+      // A stopped engine has nothing to integrate. Returning the SAME state object —
+      // not a fresh one holding an unchanged `live` — is what makes React bail out of
+      // the re-render: this action arrives 20 times a second for as long as the app is
+      // open, engine running or not, and every one of those ticks would otherwise
+      // re-render the entire app. This guard is `setLive`'s `: prev` branch, moved.
+      if (!(prev.running || prev.cranking || prev.rpm > 1)) return state;
+      return {
+        ...state,
+        session: {
+          ...state.session,
+          live: liveStep(prev, action.dt, action.input, action.cfg),
+        },
+      };
+    }
+
+    case ACTIONS.LIVE_PATCH:
+      return {
+        ...state,
+        session: { ...state.session, live: { ...state.session.live, ...action.patch } },
       };
 
     default:

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -123,9 +123,9 @@ export const ACTIONS = Object.freeze({
  */
 
 /**
- * The reducer's equivalent of `setCfg` (`EcuLab.jsx:738`,
- * `setEngineConfigInvalidating((c) => ({ ...c, ...patch }))`). Actions cannot carry
- * functions, so the merge happens here: the reducer already holds the current
+ * The reducer's equivalent of `setCfg`, which EcuLab.jsx used to implement as a
+ * functional update over local state that also cleared `presetId`. Actions cannot
+ * carry functions, so the merge happens here: the reducer already holds the current
  * `engineConfig` and does the spread itself. Invalidates like every other hardware
  * write.
  *
@@ -183,9 +183,9 @@ export const ACTIONS = Object.freeze({
  * animation before and after an interval-driven timer runs; that is time-based UI
  * state with no atomicity hazard and stays as plain `SET_SESSION_FIELD` dispatches in
  * the component (Task 4). The part that DOES have an ordering hazard, and is what this
- * action removes: `doRun` calls `setPrevResult(result)` (the OLD result) before
- * `setResult(r)` (the new one) — reversing those two lines would silently make
- * `prevResult` equal the new result instead of the old one. `action.result` and
+ * action removes: `doRun` used to call `setPrevResult(result)` (the OLD result)
+ * before `setResult(r)` (the new one) — reversing those two lines would silently have
+ * made `prevResult` equal the new result instead of the old one. `action.result` and
  * `action.pullScore` are precomputed by the caller: `result` comes from
  * `simulateSweep`, and `pullScore` from `computePullScore`, which needs derived
  * hardware objects (`turbine`, `compressor`, `dutyPreview`, `exhaustDiaError`) that

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -110,12 +110,7 @@ export const ACTIONS = Object.freeze({
  * `engineConfig` and does the spread itself. Invalidates like every other hardware
  * write.
  *
- * `patch` is typed as a plain object rather than `Partial<EngineConfig>`: the caller
- * (a range/segment `onChange` handler in `EcuLab.jsx`) hands over whatever key it
- * owns, same as the untyped original, and a stricter type here would reject the
- * fixture patches this file's own tests use to prove the merge (not replace)
- * behaviour without also asserting anything about `EngineConfig`'s real shape.
- * @typedef {{type: 'SET_ENGINE_CONFIG_PATCH', patch: Object<string, *>}} SetEngineConfigPatchAction
+ * @typedef {{type: 'SET_ENGINE_CONFIG_PATCH', patch: Partial<import('../../sim/index.js').EngineConfig>}} SetEngineConfigPatchAction
  */
 
 /**
@@ -181,12 +176,23 @@ export const ACTIONS = Object.freeze({
  */
 
 /**
+ * The union of every action shape the reducer actually understands. Deliberately has
+ * NO catch-all `{type: string, [key: string]: *}` member: with one, every object
+ * shape is assignable to `StoreAction` and the eleven specific typedefs above become
+ * decorative — a typo'd payload key (`presset` instead of `preset`) would typecheck
+ * clean. Without the catch-all, `tsc` must reject it.
  * @typedef {SetBuildFieldAction | SetTurbineAction | SetTableAction |
  *   SetSessionFieldAction | SetTuneFieldAction | SetBoostSelAction |
  *   SetPresetPromptAction | SetEngineConfigPatchAction | ApplyPresetAction |
- *   ResetToStockAction | RepairEngineAction | BankPullAction |
- *   {type: string, [key: string]: *}
- * } StoreAction
+ *   ResetToStockAction | RepairEngineAction | BankPullAction
+ * } KnownStoreAction
+ */
+
+/**
+ * Kept as the public name `StoreAction` (re-exported via `StoreProvider.jsx`'s
+ * `@typedef {import('./reducer.js').StoreAction}`) so callers outside this file are
+ * unaffected — it is simply an alias for {@link KnownStoreAction}, not a looser type.
+ * @typedef {KnownStoreAction} StoreAction
  */
 
 /**

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -1,0 +1,141 @@
+/**
+ * The root reducer: one reducer over three slices, not three independent ones.
+ *
+ * `EcuLab.jsx`'s `applyEnginePreset` makes 23 sequential `setState` calls spanning
+ * hardware, calibration tables and run results — and its own comment warns that
+ * routing those writes through the invalidating setters "would make that order-
+ * dependent on React's batching instead of explicit". `resetToStock` makes six writes
+ * and documents that "the last call pins tablesDirty back to false". `withTableEdit`
+ * writes a TUNE table, then clears `presetId` (BUILD), then sets `tablesDirty` (TUNE)
+ * — one hand edit, two slices, and both must land together or the header lies about
+ * which preset (if any) is loaded.
+ *
+ * Three independent contexts cannot express any of that atomically — each cross-slice
+ * write would become choreography between providers, preserving the exact ordering
+ * hazards these comments warn about. One reducer computes the next state in a single
+ * pass instead: a case either changes a slice or it doesn't, there is no partial
+ * application to observe mid-write, and "order-dependent" stops being a possible bug.
+ *
+ * This file implements the SINGLE-slice actions only (Task 2 of the state-extraction
+ * plan). The cross-cutting actions that replace `applyEnginePreset` and
+ * `resetToStock` themselves — APPLY_PRESET, RESET_TO_STOCK, REPAIR_ENGINE, BANK_PULL —
+ * are added on top of this file in the next task.
+ */
+
+/** @typedef {import('./initialState.js').StoreState} StoreState */
+/** @typedef {import('./initialState.js').BuildState} BuildState */
+/** @typedef {import('./initialState.js').TuneState} TuneState */
+/** @typedef {import('./initialState.js').SessionState} SessionState */
+
+/**
+ * Every action type the reducer understands. Frozen so a typo in a dispatch call
+ * (`ACTIONS.SET_BULID_FIELD`) fails loudly as `undefined` rather than silently adding
+ * a new property.
+ */
+export const ACTIONS = Object.freeze({
+  SET_BUILD_FIELD: 'SET_BUILD_FIELD',
+  SET_TURBINE: 'SET_TURBINE',
+  SET_TABLE: 'SET_TABLE',
+  SET_SESSION_FIELD: 'SET_SESSION_FIELD',
+  SET_TUNE_FIELD: 'SET_TUNE_FIELD',
+});
+
+/**
+ * Sets one field on the BUILD slice and clears `presetId` — a hand edit to any single
+ * hardware/ECU field is no longer that preset's build. This is the reducer's
+ * equivalent of `withPresetField`. It does NOT touch `tune.tablesDirty`: hardware
+ * edits alone don't touch the calibration tables (see SET_TABLE for the write that
+ * does).
+ * @typedef {{type: 'SET_BUILD_FIELD', field: keyof BuildState, value: *}} SetBuildFieldAction
+ */
+
+/**
+ * Fits ONE of the chosen turbine housing. A twin-turbo `turbineCount` belongs to a
+ * preset, not a hand pick from the turbine list, so this always resets it to 1
+ * alongside the new housing — and, like any hardware edit, clears `presetId`.
+ * @typedef {{type: 'SET_TURBINE', value: number}} SetTurbineAction
+ */
+
+/**
+ * Writes a calibration table (`ve`, `timing` or `afr`) and, in the SAME pass, clears
+ * `presetId` (BUILD) and sets `tablesDirty` (TUNE). This is the reducer's equivalent
+ * of `withTableEdit` — the one write that must cross the build/tune boundary
+ * atomically, which is the whole reason this is one reducer and not two.
+ * @typedef {{type: 'SET_TABLE', table: 've'|'timing'|'afr', value: number[][]}} SetTableAction
+ */
+
+/**
+ * Sets one field on the SESSION slice. No cross-slice effects — session is run/career
+ * bookkeeping, not hardware or calibration.
+ * @typedef {{type: 'SET_SESSION_FIELD', field: keyof SessionState, value: *}} SetSessionFieldAction
+ */
+
+/**
+ * Sets one field on the TUNE slice WITHOUT the SET_TABLE side effects. This is for
+ * tune-slice writes that are not a calibration edit — `selection`, for instance, which
+ * changes what grid cell is highlighted and must not clear the preset label or flag
+ * unsaved work.
+ * @typedef {{type: 'SET_TUNE_FIELD', field: keyof TuneState, value: *}} SetTuneFieldAction
+ */
+
+/**
+ * @typedef {SetBuildFieldAction | SetTurbineAction | SetTableAction |
+ *   SetSessionFieldAction | SetTuneFieldAction | {type: string, [key: string]: *}
+ * } StoreAction
+ */
+
+/**
+ * The root reducer. Pure: no `Date.now()`, no `Math.random()`, no mutation of `state`
+ * or any of its slices — every case that changes a slice returns a NEW object for
+ * that slice only, and every slice it does not touch keeps its existing reference
+ * (so `React.memo`/`useMemo` consumers downstream can bail out on an unrelated
+ * dispatch).
+ *
+ * @param {StoreState} state
+ * @param {StoreAction} action
+ * @returns {StoreState}
+ */
+export function reducer(state, action) {
+  switch (action.type) {
+    case ACTIONS.SET_BUILD_FIELD:
+      return {
+        ...state,
+        build: { ...state.build, [action.field]: action.value, presetId: null },
+      };
+
+    case ACTIONS.SET_TURBINE:
+      return {
+        ...state,
+        build: {
+          ...state.build,
+          turbineIdx: action.value,
+          turbineCount: 1,
+          presetId: null,
+        },
+      };
+
+    case ACTIONS.SET_TABLE:
+      return {
+        ...state,
+        build: { ...state.build, presetId: null },
+        tune: { ...state.tune, [action.table]: action.value, tablesDirty: true },
+      };
+
+    case ACTIONS.SET_SESSION_FIELD:
+      return {
+        ...state,
+        session: { ...state.session, [action.field]: action.value },
+      };
+
+    case ACTIONS.SET_TUNE_FIELD:
+      return {
+        ...state,
+        tune: { ...state.tune, [action.field]: action.value },
+      };
+
+    default:
+      // Unknown action: return the SAME object by reference so React's useReducer
+      // bails out of the re-render instead of scheduling one for a no-op.
+      return state;
+  }
+}

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -1,7 +1,7 @@
 /**
  * The root reducer: one reducer over three slices, not three independent ones.
  *
- * `EcuLab.jsx`'s `applyEnginePreset` makes 23 sequential `setState` calls spanning
+ * `EcuLab.jsx`'s `applyEnginePreset` makes 21 sequential `setState` calls spanning
  * hardware, calibration tables and run results — and its own comment warns that
  * routing those writes through the invalidating setters "would make that order-
  * dependent on React's batching instead of explicit". `resetToStock` makes six writes
@@ -16,11 +16,13 @@
  * pass instead: a case either changes a slice or it doesn't, there is no partial
  * application to observe mid-write, and "order-dependent" stops being a possible bug.
  *
- * This file implements the SINGLE-slice actions only (Task 2 of the state-extraction
- * plan). The cross-cutting actions that replace `applyEnginePreset` and
- * `resetToStock` themselves — APPLY_PRESET, RESET_TO_STOCK, REPAIR_ENGINE, BANK_PULL —
- * are added on top of this file in the next task.
+ * This file implements the SINGLE-slice actions (Task 2 of the state-extraction plan)
+ * AND the cross-cutting actions that replace `applyEnginePreset`, `resetToStock`,
+ * `repairEngine` and the score-tallying tail of `doRun` — APPLY_PRESET, RESET_TO_STOCK,
+ * REPAIR_ENGINE, BANK_PULL (Task 3).
  */
+
+import { clamp, clone2D, DEFAULT_AFR, DEFAULT_MODS, DEFAULT_TIMING } from '../../sim/index.js';
 
 /** @typedef {import('./initialState.js').StoreState} StoreState */
 /** @typedef {import('./initialState.js').BuildState} BuildState */
@@ -38,6 +40,13 @@ export const ACTIONS = Object.freeze({
   SET_TABLE: 'SET_TABLE',
   SET_SESSION_FIELD: 'SET_SESSION_FIELD',
   SET_TUNE_FIELD: 'SET_TUNE_FIELD',
+  SET_BOOST_SEL: 'SET_BOOST_SEL',
+  SET_PRESET_PROMPT: 'SET_PRESET_PROMPT',
+  SET_ENGINE_CONFIG_PATCH: 'SET_ENGINE_CONFIG_PATCH',
+  APPLY_PRESET: 'APPLY_PRESET',
+  RESET_TO_STOCK: 'RESET_TO_STOCK',
+  REPAIR_ENGINE: 'REPAIR_ENGINE',
+  BANK_PULL: 'BANK_PULL',
 });
 
 /**
@@ -79,8 +88,104 @@ export const ACTIONS = Object.freeze({
  */
 
 /**
+ * Moves the boost-curve editor's selected RPM column. A cursor, not hardware — the
+ * build-side analogue of `tune.selection` — so unlike `SET_BUILD_FIELD` it must NOT
+ * clear `presetId`. See the Task 3 amendment: a generic non-invalidating build setter
+ * would be an escape hatch a future caller could reach for on an actual hardware
+ * field, silently reintroducing the stale-preset bug `withPresetField` exists to
+ * prevent, so this is deliberately its own narrow action rather than a general one.
+ * @typedef {{type: 'SET_BOOST_SEL', value: number}} SetBoostSelAction
+ */
+
+/**
+ * Opens or dismisses the overwrite-confirmation prompt. Also a cursor/UI-state field,
+ * not hardware, so — like `SET_BOOST_SEL` — it must NOT clear `presetId`.
+ * @typedef {{type: 'SET_PRESET_PROMPT', value: object|null}} SetPresetPromptAction
+ */
+
+/**
+ * The reducer's equivalent of `setCfg` (`EcuLab.jsx:738`,
+ * `setEngineConfigInvalidating((c) => ({ ...c, ...patch }))`). Actions cannot carry
+ * functions, so the merge happens here: the reducer already holds the current
+ * `engineConfig` and does the spread itself. Invalidates like every other hardware
+ * write.
+ *
+ * `patch` is typed as a plain object rather than `Partial<EngineConfig>`: the caller
+ * (a range/segment `onChange` handler in `EcuLab.jsx`) hands over whatever key it
+ * owns, same as the untyped original, and a stricter type here would reject the
+ * fixture patches this file's own tests use to prove the merge (not replace)
+ * behaviour without also asserting anything about `EngineConfig`'s real shape.
+ * @typedef {{type: 'SET_ENGINE_CONFIG_PATCH', patch: Object<string, *>}} SetEngineConfigPatchAction
+ */
+
+/**
+ * Loads a factory preset's complete patch — build, tune AND session — in one pass.
+ * `action.preset` is the ALREADY-COMPUTED patch object `applyPreset(rawPreset)`
+ * returns (`src/sim/presets.js`), not the raw catalogue entry: computing it needs no
+ * hardware the reducer doesn't already have in scope, unlike `RESET_TO_STOCK`'s `ve`,
+ * but it is still the caller's job to produce it, the same way `SET_TABLE`'s caller
+ * produces the table it hands over. `EcuLab.jsx`'s `applyEnginePreset` made 21
+ * sequential raw `setState` calls across all three slices to land this and its own
+ * comment warns that routing them through the invalidating setters "would make that
+ * order-dependent" — deliberately bypassing `withPresetField`/`withTableEdit` because
+ * IT needs `presetId` to end up SET, the opposite of every other write. One reducer
+ * case removes the ordering hazard instead of documenting it: every field lands in the
+ * same object-literal pass, so there is no "last call" to get right.
+ * @typedef {{type: 'APPLY_PRESET', preset: {
+ *   presetId: string, engineConfig: import('../../sim/index.js').EngineConfig,
+ *   mods: BuildState['mods'], turboOn: boolean, boostCurve: number[],
+ *   turbineIdx: number, turbineCount: number, compressorIdx: number, injIdx: number,
+ *   ecuInjectorCc: number, octaneIdx: number, exhaustDiaIdx: number,
+ *   ve: number[][], timing: number[][], afr: number[][],
+ * }}} ApplyPresetAction
+ */
+
+/**
+ * Wipes the calibration back to a generic stock baseline and drops any preset label,
+ * mirroring `resetToStock` (`EcuLab.jsx:726`). `action.ve` is the recomputed stock VE
+ * table: producing it needs `computeHardwareVE` fed the CURRENT hardware
+ * (`engineConfig`, `turboOn`, `exhaustDiaIdx`, `boostCurve`, fuel, turbine) mixed with
+ * a hypothetical DEFAULT_MODS, which is exactly the kind of hardware-shaped lookup the
+ * reducer should not be reaching for itself — so the caller computes it, the same
+ * reasoning as `SET_TABLE`. `timing`/`afr`/`mods`/`mafScalar` reset to fixed constants
+ * that need no such lookup, so the reducer sets those itself. The original made six
+ * `setState` calls and documented that "the last call pins tablesDirty back to false"
+ * — three of the five earlier calls set it true via `withTableEdit`/`withPresetField`,
+ * so the LAST write had to win. One action has no "last write" to get right: it is
+ * simply false in the object literal below.
+ * @typedef {{type: 'RESET_TO_STOCK', ve: number[][]}} ResetToStockAction
+ */
+
+/**
+ * Restores every worn engine component to full health, mirroring `repairEngine`
+ * (`EcuLab.jsx:737`).
+ * @typedef {{type: 'REPAIR_ENGINE'}} RepairEngineAction
+ */
+
+/**
+ * Finalises a completed dyno pull: banks the score, wears the engine, and rotates
+ * `result` into `prevResult`. Mirrors the tail of `doRun` (`EcuLab.jsx:868-896`) —
+ * NOT the whole function, which also flips `running`/`revealCount` for the reveal
+ * animation before and after an interval-driven timer runs; that is time-based UI
+ * state with no atomicity hazard and stays as plain `SET_SESSION_FIELD` dispatches in
+ * the component (Task 4). The part that DOES have an ordering hazard, and is what this
+ * action removes: `doRun` calls `setPrevResult(result)` (the OLD result) before
+ * `setResult(r)` (the new one) — reversing those two lines would silently make
+ * `prevResult` equal the new result instead of the old one. `action.result` and
+ * `action.pullScore` are precomputed by the caller: `result` comes from
+ * `simulateSweep`, and `pullScore` from `computePullScore`, which needs derived
+ * hardware objects (`turbine`, `compressor`, `dutyPreview`, `exhaustDiaError`) that
+ * are `useMemo` values in the component, not raw state the reducer holds — the same
+ * "caller computes, reducer applies" split as `RESET_TO_STOCK`'s `ve`.
+ * @typedef {{type: 'BANK_PULL', result: object, pullScore: number}} BankPullAction
+ */
+
+/**
  * @typedef {SetBuildFieldAction | SetTurbineAction | SetTableAction |
- *   SetSessionFieldAction | SetTuneFieldAction | {type: string, [key: string]: *}
+ *   SetSessionFieldAction | SetTuneFieldAction | SetBoostSelAction |
+ *   SetPresetPromptAction | SetEngineConfigPatchAction | ApplyPresetAction |
+ *   ResetToStockAction | RepairEngineAction | BankPullAction |
+ *   {type: string, [key: string]: *}
  * } StoreAction
  */
 
@@ -131,6 +236,120 @@ export function reducer(state, action) {
       return {
         ...state,
         tune: { ...state.tune, [action.field]: action.value },
+      };
+
+    case ACTIONS.SET_BOOST_SEL:
+      return {
+        ...state,
+        build: { ...state.build, boostSel: action.value },
+      };
+
+    case ACTIONS.SET_PRESET_PROMPT:
+      return {
+        ...state,
+        build: { ...state.build, presetPrompt: action.value },
+      };
+
+    case ACTIONS.SET_ENGINE_CONFIG_PATCH:
+      return {
+        ...state,
+        build: {
+          ...state.build,
+          engineConfig: { ...state.build.engineConfig, ...action.patch },
+          presetId: null,
+        },
+      };
+
+    case ACTIONS.APPLY_PRESET: {
+      const p = action.preset;
+      return {
+        ...state,
+        build: {
+          ...state.build,
+          engineConfig: p.engineConfig,
+          mods: p.mods,
+          turboOn: p.turboOn,
+          boostCurve: p.boostCurve,
+          turbineIdx: p.turbineIdx,
+          turbineCount: p.turbineCount,
+          compressorIdx: p.compressorIdx,
+          injIdx: p.injIdx,
+          ecuInjectorCc: p.ecuInjectorCc,
+          octaneIdx: p.octaneIdx,
+          exhaustDiaIdx: p.exhaustDiaIdx,
+          // A preset's AFR table already bakes in a correction for the MAF error its
+          // mod set implies (factoryCalibration, src/sim/presets.js) — valid only at
+          // the neutral scalar, so loading a preset must pin this back to 1.0.
+          mafScalar: 1.0,
+          presetId: p.presetId,
+          presetPrompt: null,
+        },
+        tune: {
+          ...state.tune,
+          ve: p.ve,
+          timing: p.timing,
+          afr: p.afr,
+          // Fresh factory calibration is not unsaved player work.
+          tablesDirty: false,
+          selection: null,
+        },
+        session: {
+          ...state.session,
+          // A factory rating from the newly loaded engine must never sit next to a
+          // pull logged on whatever was running before it.
+          result: null,
+          prevResult: null,
+        },
+      };
+    }
+
+    case ACTIONS.RESET_TO_STOCK:
+      return {
+        ...state,
+        build: {
+          ...state.build,
+          mods: DEFAULT_MODS,
+          mafScalar: 1.0,
+          presetId: null,
+        },
+        tune: {
+          ...state.tune,
+          ve: action.ve,
+          timing: clone2D(DEFAULT_TIMING),
+          afr: clone2D(DEFAULT_AFR),
+          // A reset baseline is not unsaved player work — no "last call" needed to
+          // pin this false, it is simply false in this same pass.
+          tablesDirty: false,
+        },
+      };
+
+    case ACTIONS.REPAIR_ENGINE:
+      return {
+        ...state,
+        session: {
+          ...state.session,
+          health: { piston: 100, bearing: 100, valve: 100 },
+        },
+      };
+
+    case ACTIONS.BANK_PULL:
+      return {
+        ...state,
+        session: {
+          ...state.session,
+          // The OLD result becomes prevResult BEFORE the new one overwrites `result` —
+          // reversing this order would silently make prevResult equal the new result.
+          prevResult: state.session.result,
+          result: action.result,
+          health: {
+            piston: clamp(state.session.health.piston - action.result.wear.piston, 0, 100),
+            bearing: clamp(state.session.health.bearing - action.result.wear.bearing, 0, 100),
+            valve: clamp(state.session.health.valve - action.result.wear.valve, 0, 100),
+          },
+          bestScore: Math.max(state.session.bestScore, action.pullScore),
+          totalScore: state.session.totalScore + action.pullScore,
+          pullCount: state.session.pullCount + 1,
+        },
       };
 
     default:

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -15,7 +15,6 @@ const T = {
   panel: tokens.panel,
   panel2: tokens.panel2,
   panel3: tokens.panel3,
-  panelHi: tokens.panel3,
   line: tokens.line,
   lineHi: tokens.lineHi,
 

--- a/tests/ui/build-store.test.jsx
+++ b/tests/ui/build-store.test.jsx
@@ -18,17 +18,35 @@
  * These tests close that gap: they drive the real controls and read the real header.
  */
 
-import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
 
 import {
   DEFAULT_ENGINE_CONFIG, DEFAULT_MODS, ENGINE_PRESETS, OCTANE_OPTS, TURBINE_OPTS,
   applyPreset, computeHardwareVE, turbineWithCount,
 } from '../../src/sim/index.js';
+import { LOAD, RPM } from '../../src/sim/tables.js';
 import EcuLab, { EcuLabApp } from '../../src/ui/EcuLab.jsx';
 import { StoreProvider, useBuild, useTune } from '../../src/ui/state/StoreProvider.jsx';
 import { ACTIONS } from '../../src/ui/state/reducer.js';
+
+// jsdom has no ResizeObserver. recharts' <ResponsiveContainer> (used on the DYNO
+// results panel) needs one to mount at all, so any test that reaches a rendered
+// dyno result throws an uncaught ReferenceError from inside react-dom's commit
+// phase without this stub. Same approach as characterisation.test.jsx.
+// observe/unobserve/disconnect are no-ops: the tests below never depend on a
+// resize callback firing, only on the chart mounting.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+const hadResizeObserver = 'ResizeObserver' in window;
+if (!hadResizeObserver) window.ResizeObserver = ResizeObserverStub;
+afterAll(() => {
+  if (!hadResizeObserver) delete window.ResizeObserver;
+});
 
 afterEach(cleanup);
 
@@ -89,6 +107,54 @@ describe('moving the boost-curve cursor', () => {
       return selectedRpm() !== before;
     });
     expect(moved).toBe(true);
+
+    expect(headerEngineName()).toBe(preset);
+  });
+});
+
+describe('moving the tune-grid cursor', () => {
+  it('does not stop the header claiming the factory preset', () => {
+    // The twin of the boost-cursor test above: `setSelection` on the TUNE grid
+    // dispatches SET_TUNE_FIELD (a cursor move), not SET_TABLE (a calibration edit
+    // that clears presetId and flags tablesDirty). Selecting a grid cell must not
+    // disown a loaded preset or trip the overwrite-confirmation prompt.
+    launch();
+    const preset = loadFirstPreset();
+    // Guard the setup rather than trusting it: if loading the preset silently failed,
+    // presetId would be null before the click and the assertion below would pass for
+    // the wrong reason.
+    expect(preset).not.toMatch(/^\d\.\dL /);
+
+    fireEvent.click(screen.getByRole('button', { name: /TUNE/ }));
+    const grid = within(screen.getByTestId('tuning-grid'));
+    // TuningGrid renders, in DOM order: RPM.length column-header buttons (each
+    // itself a numeric label, so a text-pattern filter can't tell them apart from
+    // data cells), then one row per LOAD entry — a numeric row-header button
+    // followed by RPM.length data-cell buttons. Slicing by that known layout is
+    // what actually isolates the data cells; text content alone can collide (a VE
+    // cell can legitimately read "100", same as a LOAD header).
+    const allButtons = grid.getAllByRole('button');
+    const dataCells = [];
+    let idx = RPM.length;
+    for (let row = 0; row < LOAD.length; row += 1) {
+      idx += 1; // row-header button
+      for (let col = 0; col < RPM.length; col += 1) { dataCells.push(allButtons[idx]); idx += 1; }
+    }
+
+    // Selecting a grid cell mounts the SelectionDock, whose readout line names the
+    // selected cell's coordinates: "<rpm> RPM · <map> kPa MAP". Reading it after two
+    // DIFFERENT cell clicks and confirming it changed proves the clicks actually
+    // MOVED the cursor — without that, a click that hit nothing (or landed on the
+    // same cell twice) would leave the header intact and the test would pass while
+    // proving nothing.
+    const cellLabel = () => within(screen.getByTestId('selection-dock'))
+      .getByText(/^\d+ RPM · \d+ kPa MAP$/).textContent;
+
+    fireEvent.click(dataCells[0]);
+    const first = cellLabel();
+    fireEvent.click(dataCells[dataCells.length - 1]);
+    const second = cellLabel();
+    expect(second).not.toBe(first);
 
     expect(headerEngineName()).toBe(preset);
   });
@@ -273,5 +339,108 @@ describe('resetting the calibration to stock', () => {
     const stock = computeHardwareVE(DEFAULT_ENGINE_CONFIG, DEFAULT_MODS, hw);
     const modded = computeHardwareVE(DEFAULT_ENGINE_CONFIG, { ...DEFAULT_MODS, intake: true }, hw);
     expect(modded).not.toEqual(stock);
+  });
+});
+
+describe('accepting a re-logged VE table', () => {
+  it('rewrites the VE table on ACCEPT RE-LOGGED VALUES', () => {
+    // recalcVE (EcuLab.jsx:663) is the ACCEPT RE-LOGGED VALUES button's dispatch.
+    // Stub it out and the button silently does nothing — the player is told their
+    // hardware and calibration are out of sync and handed a button that claims to
+    // fix it, and nothing happens.
+    /** @type {*} */
+    let tune;
+    render(
+      <StoreProvider>
+        <TuneProbe onTune={(t) => { tune = t; }} />
+        <EcuLabApp />
+      </StoreProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'START' }));
+
+    // Drift the hardware away from the stock VE table the store starts with, so
+    // veAdvice.inSync goes false and the ACCEPT button actually renders.
+    fireEvent.click(screen.getByText('Forced Induction'));
+    fireEvent.click(toggleFor('Turbo kit'));
+    fireEvent.click(screen.getByText('Bolt-On Parts'));
+    fireEvent.click(screen.getByRole('button', { name: /Intake/ }));
+
+    fireEvent.click(screen.getByRole('button', { name: /TUNE/ }));
+
+    // Guard: the button only renders when the advisor actually sees a gap. If the
+    // toggles above hadn't moved computeHardwareVE, this query would throw instead
+    // of silently finding nothing, and the assertion below could never run for the
+    // right reason.
+    const acceptBtn = screen.getByRole('button', { name: 'ACCEPT RE-LOGGED VALUES' });
+    const veBefore = tune.ve;
+
+    fireEvent.click(acceptBtn);
+
+    expect(tune.ve).not.toEqual(veBefore);
+  });
+});
+
+describe('applying a fuel-trim histogram', () => {
+  it('rewrites the VE table on APPLY CORRECTIONS TO VE', async () => {
+    // applyHistogram (EcuLab.jsx:990) is the APPLY CORRECTIONS TO VE button's
+    // dispatch. tests/regressions.test.js re-implements the histogram math directly
+    // and never touches this button, so it LOOKS like coverage of this path and is
+    // not. This drives the real control instead: fit hardware the stock VE table
+    // doesn't match, run a dyno pull (the ECU fuels from the stale table while the
+    // engine actually breathes the true one, so the pull logs a real mismatch),
+    // build a histogram from it, and apply it.
+    /** @type {*} */
+    let tune;
+    render(
+      <StoreProvider>
+        <TuneProbe onTune={(t) => { tune = t; }} />
+        <EcuLabApp />
+      </StoreProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'START' }));
+
+    fireEvent.click(screen.getByText('Forced Induction'));
+    fireEvent.click(toggleFor('Turbo kit'));
+    fireEvent.click(screen.getByText('Bolt-On Parts'));
+    fireEvent.click(screen.getByRole('button', { name: /Intake/ }));
+
+    fireEvent.click(screen.getByRole('button', { name: /DYNO/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'RUN DYNO PULL' }));
+    // The reveal is a setInterval that ends by setting running false, which is what
+    // uncovers the CURVES/PULL LOG/DATALOG/SCORE sub-tabs. Real timers + waitFor,
+    // same approach as characterisation.test.jsx's dyno-pull test.
+    await waitFor(
+      () => expect(screen.getByRole('button', { name: 'RUN DYNO PULL' })).toBeTruthy(),
+      { timeout: 10000 },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'DATALOG' }));
+    fireEvent.click(screen.getByRole('button', { name: 'BUILD HISTOGRAM FROM THIS PULL' }));
+
+    // Guard: BUILD HISTOGRAM swaps its own button for an APPLY/DISCARD pair only once
+    // `histogram` is actually set. If that click's handler were missing, this query
+    // would throw instead of silently finding nothing.
+    const applyBtn = screen.getByRole('button', { name: 'APPLY CORRECTIONS TO VE' });
+    const veBefore = tune.ve;
+
+    fireEvent.click(applyBtn);
+
+    expect(tune.ve).not.toEqual(veBefore);
+  });
+});
+
+describe('choosing Custom build from the preset picker', () => {
+  it('stops the header claiming the preset', () => {
+    // clearPresetId (EcuLab.jsx:600) is CLEAR_PRESET_ID's only call site, reached by
+    // choosing "Custom build" from the preset picker. The reducer case is tested;
+    // this call site was not — stub the dispatch and choosing "Custom build" leaves
+    // the header still naming the preset the player just disowned.
+    launch();
+    const preset = loadFirstPreset();
+    expect(preset).not.toMatch(/^\d\.\dL /);
+
+    fireEvent.change(presetPicker(), { target: { value: '__custom__' } });
+
+    expect(headerEngineName()).toMatch(/^\d\.\dL /);
   });
 });

--- a/tests/ui/build-store.test.jsx
+++ b/tests/ui/build-store.test.jsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+
+/**
+ * The two BUILD-slice fields that are cursors, not hardware.
+ *
+ * Thirteen of the fifteen fields in the build slice are hardware or ECU configuration:
+ * a hand edit to any of them means the build is no longer the factory preset it was
+ * loaded from, so `SET_BUILD_FIELD` clears `presetId` and the header stops naming that
+ * preset. `boostSel` (which RPM column the boost editor has selected) and
+ * `presetPrompt` (whether the overwrite-confirmation dialog is open) live in the same
+ * slice but are NOT that — they are a cursor and a piece of dialog state. Routing
+ * either through `SET_BUILD_FIELD` would make the header stop claiming the factory
+ * preset because the player tapped an RPM column or opened a dialog.
+ *
+ * That is invisible to the characterisation tests, which never touch either control,
+ * and it is invisible to the reducer tests, which prove SET_BOOST_SEL/SET_PRESET_PROMPT
+ * preserve `presetId` but say nothing about which action EcuLab actually dispatches.
+ * These tests close that gap: they drive the real controls and read the real header.
+ */
+
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ENGINE_PRESETS, applyPreset } from '../../src/sim/index.js';
+import EcuLab, { EcuLabApp } from '../../src/ui/EcuLab.jsx';
+import { StoreProvider, useBuild } from '../../src/ui/state/StoreProvider.jsx';
+import { ACTIONS } from '../../src/ui/state/reducer.js';
+
+afterEach(cleanup);
+
+/**
+ * The preset picker is the only select with optgroups.
+ * @returns {HTMLSelectElement}
+ */
+function presetPicker() {
+  return /** @type {HTMLSelectElement[]} */ (screen.getAllByRole('combobox'))
+    .find((el) => el.querySelector('optgroup'));
+}
+
+/**
+ * The header line is `${engineName} · ${turbo} · ${octane} oct · ...`, where
+ * `engineName` is the loaded preset's name if one is loaded and a derived "3.0L I6"
+ * form if not. Its leading segment is therefore exactly the thing `presetId` drives.
+ * @returns {string}
+ */
+function headerEngineName() {
+  return screen.getByText(/oct/).textContent.split('·')[0].trim();
+}
+
+/** Renders the app and clicks past the start screen. */
+function launch() {
+  const view = render(<EcuLab />);
+  fireEvent.click(screen.getByRole('button', { name: 'START' }));
+  return view;
+}
+
+/** Loads the first preset the picker offers and returns the header name it produced. */
+function loadFirstPreset() {
+  const picker = presetPicker();
+  const target = [...picker.querySelectorAll('option')]
+    .map((o) => o.value)
+    .find((v) => v && v !== picker.value);
+  fireEvent.change(picker, { target: { value: target } });
+  return headerEngineName();
+}
+
+describe('moving the boost-curve cursor', () => {
+  it('does not stop the header claiming the factory preset', () => {
+    launch();
+    const preset = loadFirstPreset();
+    // Guard the setup rather than trusting it: if loading the preset silently failed,
+    // presetId would be null before the click and the assertion below would pass for
+    // the wrong reason.
+    expect(preset).not.toMatch(/^\d\.\dL /);
+
+    const columns = within(screen.getByTestId('boost-columns')).getAllByRole('button');
+    // The selected RPM appears in the editor's readout under the bars. Reading it
+    // before and after proves the click actually MOVED the cursor — without that, a
+    // click that hit nothing would leave the header intact and the test would pass
+    // while proving nothing.
+    const selectedRpm = () => screen.getByText(/^\d+ RPM$/).textContent;
+    const before = selectedRpm();
+    const moved = columns.some((col) => {
+      fireEvent.click(col);
+      return selectedRpm() !== before;
+    });
+    expect(moved).toBe(true);
+
+    expect(headerEngineName()).toBe(preset);
+  });
+});
+
+/**
+ * A probe that hands the store's dispatch back to the test, so it can put the build
+ * into a state the UI's own guards cannot reach (see below).
+ * @param {{onReady: (dispatch: React.Dispatch<*>) => void}} props
+ * @returns {null}
+ */
+function DispatchProbe({ onReady }) {
+  const [, dispatch] = useBuild();
+  onReady(dispatch);
+  return null;
+}
+
+describe('opening and dismissing the overwrite prompt', () => {
+  it('does not stop the header claiming the factory preset', () => {
+    // `presetId` set AND unsaved calibration work pending is unreachable through the
+    // UI alone: every path that flags `tablesDirty` also clears `presetId`, so the
+    // prompt only ever opens on a build the header already shows as custom. The
+    // combination is still worth pinning — it is one guard away from reachable, and
+    // it is the state in which routing `presetPrompt` through SET_BUILD_FIELD does
+    // visible damage. So mount the app body inside a store this test owns, and seed
+    // that half of the state directly.
+    /** @type {React.Dispatch<*>} */
+    let dispatch;
+    render(
+      <StoreProvider>
+        <DispatchProbe onReady={(d) => { dispatch = d; }} />
+        <EcuLabApp />
+      </StoreProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'START' }));
+
+    // Hand-edit a calibration table: this is what sets `tablesDirty`, which is what
+    // makes choosePreset offer the prompt instead of loading straight away.
+    fireEvent.click(screen.getByRole('button', { name: /TUNE/ }));
+    const grid = within(screen.getByTestId('tuning-grid'));
+    const cells = grid.getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent));
+    fireEvent.click(cells[Math.floor(cells.length / 2)]);
+    fireEvent.click(within(screen.getByTestId('selection-dock')).getByRole('button', { name: '+1' }));
+    fireEvent.click(screen.getByRole('button', { name: /BUILD/ }));
+
+    // Now put a preset label back on the build without touching `tablesDirty`, which
+    // is still EcuLab's own useState until Task 5.
+    const seed = ENGINE_PRESETS[0];
+    act(() => dispatch({ type: ACTIONS.APPLY_PRESET, preset: applyPreset(seed) }));
+    expect(headerEngineName()).toBe(seed.name);
+
+    // Choosing a different preset with work pending opens the prompt rather than
+    // loading. The prompt is dialog state, not a hardware edit: the build has not
+    // changed, so the header must still name the preset it is running.
+    const picker = presetPicker();
+    const other = [...picker.querySelectorAll('option')]
+      .map((o) => o.value)
+      .find((v) => v && v !== seed.id && v !== '__custom__');
+    fireEvent.change(picker, { target: { value: other } });
+    expect(screen.getByRole('button', { name: /^LOAD / })).toBeTruthy();
+    expect(headerEngineName()).toBe(seed.name);
+
+    // Backing out of the prompt is not a hardware edit either.
+    fireEvent.click(screen.getByRole('button', { name: 'CANCEL' }));
+    expect(screen.queryByRole('button', { name: /^LOAD / })).toBeNull();
+    expect(headerEngineName()).toBe(seed.name);
+  });
+});

--- a/tests/ui/build-store.test.jsx
+++ b/tests/ui/build-store.test.jsx
@@ -136,10 +136,19 @@ describe('opening and dismissing the overwrite prompt', () => {
     fireEvent.click(within(screen.getByTestId('selection-dock')).getByRole('button', { name: '+1' }));
     fireEvent.click(screen.getByRole('button', { name: /BUILD/ }));
 
-    // Now put a preset label back on the build without touching `tablesDirty`, which
-    // is still EcuLab's own useState until Task 5.
+    // Now put a preset label back on the build. APPLY_PRESET also clears the store's
+    // `tune.tablesDirty` (it moved into the store in Task 5, along with the rest of the
+    // tune slice) — a fresh factory calibration is not unsaved player work. That is
+    // correct behaviour, but it undoes this test's setup: the hand edit above no longer
+    // leaves any unsaved work behind once a preset is loaded on top of it. So re-flag
+    // `tablesDirty` directly afterwards, via the one action built for exactly this seam:
+    // `SET_TUNE_FIELD` deliberately does NOT clear `presetId` (unlike SET_TABLE), so it
+    // can put the store back into "preset loaded, unsaved work pending" — the combination
+    // this test exists to pin — without going through another hand edit that would just
+    // clear the preset label again.
     const seed = ENGINE_PRESETS[0];
     act(() => dispatch({ type: ACTIONS.APPLY_PRESET, preset: applyPreset(seed) }));
+    act(() => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'tablesDirty', value: true }));
     expect(headerEngineName()).toBe(seed.name);
 
     // Choosing a different preset with work pending opens the prompt rather than

--- a/tests/ui/build-store.test.jsx
+++ b/tests/ui/build-store.test.jsx
@@ -22,9 +22,12 @@ import { act, cleanup, fireEvent, render, screen, within } from '@testing-librar
 import React from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { ENGINE_PRESETS, applyPreset } from '../../src/sim/index.js';
+import {
+  DEFAULT_ENGINE_CONFIG, DEFAULT_MODS, ENGINE_PRESETS, OCTANE_OPTS, TURBINE_OPTS,
+  applyPreset, computeHardwareVE, turbineWithCount,
+} from '../../src/sim/index.js';
 import EcuLab, { EcuLabApp } from '../../src/ui/EcuLab.jsx';
-import { StoreProvider, useBuild } from '../../src/ui/state/StoreProvider.jsx';
+import { StoreProvider, useBuild, useTune } from '../../src/ui/state/StoreProvider.jsx';
 import { ACTIONS } from '../../src/ui/state/reducer.js';
 
 afterEach(cleanup);
@@ -99,7 +102,9 @@ describe('moving the boost-curve cursor', () => {
  */
 function DispatchProbe({ onReady }) {
   const [, dispatch] = useBuild();
-  onReady(dispatch);
+  // In an effect, not in render: a render-phase callback fires on every render and
+  // twice under StrictMode.
+  React.useEffect(() => { onReady(dispatch); }, [onReady, dispatch]);
   return null;
 }
 
@@ -152,5 +157,112 @@ describe('opening and dismissing the overwrite prompt', () => {
     fireEvent.click(screen.getByRole('button', { name: 'CANCEL' }));
     expect(screen.queryByRole('button', { name: /^LOAD / })).toBeNull();
     expect(headerEngineName()).toBe(seed.name);
+  });
+});
+
+
+/**
+ * ToggleRow renders its switch as an unlabelled button beside the label text, so it
+ * has to be reached through the row rather than by name.
+ * @param {string} label
+ * @returns {HTMLButtonElement}
+ */
+function toggleFor(label) {
+  return screen.getByText(label).parentElement.parentElement.querySelector('button');
+}
+
+/**
+ * Reports the store's `tune` slice to the test on every change.
+ * @param {{onTune: (tune: *) => void}} props
+ * @returns {null}
+ */
+function TuneProbe({ onTune }) {
+  const [tune] = useTune();
+  React.useEffect(() => { onTune(tune); }, [onTune, tune]);
+  return null;
+}
+
+describe('choosing a turbine', () => {
+  it('drops the twin-turbo count the preset installed', () => {
+    // SET_TURBINE resets `turbineCount` to 1 as well as setting `turbineIdx`, because
+    // the count belongs to the preset's induction layout, not to the housing you just
+    // picked. Route this control through SET_BUILD_FIELD and the count survives: a
+    // twin count against a turbine chosen as a single, silently doubling the airflow
+    // the sim is handed. Nothing else in the suite covers that.
+    launch();
+    const picker = presetPicker();
+    const twin = ENGINE_PRESETS.find((p) => applyPreset(p).turbineCount > 1);
+    expect(twin).toBeTruthy();
+    fireEvent.change(picker, { target: { value: twin.id } });
+
+    // The Forced Induction summary is where the count is legible: it reads "Twin
+    // <housing> turbine" above 1 and the bare housing name at 1.
+    const inductionSummary = () => screen.getByText(/turbine · peak/).textContent;
+    expect(inductionSummary()).toMatch(/Twin/);
+
+    fireEvent.click(screen.getByText('Forced Induction'));
+    const current = TURBINE_OPTS[applyPreset(twin).turbineIdx].label;
+    const other = TURBINE_OPTS.map((o) => o.label).find((l) => l !== current);
+    fireEvent.click(screen.getByRole('button', { name: new RegExp(`^${other}`) }));
+
+    expect(inductionSummary()).not.toMatch(/Twin/);
+  });
+});
+
+describe('resetting the calibration to stock', () => {
+  /**
+   * Runs the app to a reset and reports the VE table the store received.
+   * @param {boolean} withIntake whether to fit the intake first
+   * @returns {number[][]}
+   */
+  function veAfterReset(withIntake) {
+    /** @type {*} */
+    let tune;
+    render(
+      <StoreProvider>
+        <TuneProbe onTune={(t) => { tune = t; }} />
+        <EcuLabApp />
+      </StoreProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'START' }));
+    // Turbo on in BOTH runs, so the hardware half of the VE calculation is identical
+    // and the only difference between them is the mod set.
+    fireEvent.click(screen.getByText('Forced Induction'));
+    fireEvent.click(toggleFor('Turbo kit'));
+    if (withIntake) {
+      fireEvent.click(screen.getByText('Bolt-On Parts'));
+      fireEvent.click(screen.getByRole('button', { name: /Intake/ }));
+    }
+    fireEvent.click(screen.getByRole('button', { name: /RESET ALL TO STOCK/ }));
+    cleanup();
+    return tune.ve;
+  }
+
+  it('rebuilds the VE table from STOCK mods, not the ones still bolted on', () => {
+    // resetToStock passes computeHardwareVE(engineConfig, DEFAULT_MODS, hwForVe) —
+    // DEFAULT_MODS for the mods argument, but the CURRENT hwForVe for hardware.
+    // Wiping a calibration is not un-installing the turbo, and it is not un-bolting
+    // the intake either: reset means "give me the stock BASELINE for this hardware",
+    // so the table must come out the same whether or not parts are fitted.
+    //
+    // Change that DEFAULT_MODS to `mods` and the player gets a table calibrated for
+    // bolt-ons the reset just told them it had discarded. The whole suite passes.
+    expect(veAfterReset(true)).toEqual(veAfterReset(false));
+  });
+
+  it('can tell the two apart — the mods argument changes the table', () => {
+    // Guards the test above. If mods made no difference to computeHardwareVE, the
+    // equality assertion would hold no matter which argument the call site passed,
+    // and would be proving nothing at all.
+    const hw = {
+      turboOn: true,
+      turbine: turbineWithCount(TURBINE_OPTS[1], 1),
+      exhaustDia: 3.0,
+      fuel: OCTANE_OPTS[0],
+      peakBoostPsi: 8,
+    };
+    const stock = computeHardwareVE(DEFAULT_ENGINE_CONFIG, DEFAULT_MODS, hw);
+    const modded = computeHardwareVE(DEFAULT_ENGINE_CONFIG, { ...DEFAULT_MODS, intake: true }, hw);
+    expect(modded).not.toEqual(stock);
   });
 });

--- a/tests/ui/characterisation.test.jsx
+++ b/tests/ui/characterisation.test.jsx
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+
+/**
+ * Characterisation tests: what the app DOES today, pinned before its state moves.
+ *
+ * PR 2 is a pure refactor — 34 pieces of state leave EcuLab.jsx for a store, and by
+ * definition nothing observable should change. The problem is that a refactor with no
+ * behavioural tests is unverifiable: a setter wired to the wrong slice still compiles,
+ * still typechecks, still builds, and still passes 408 tests about physics and buttons.
+ *
+ * These do not describe what the app SHOULD do. They describe what it does now, so the
+ * refactor has something to preserve. If one of these fails after the extraction, the
+ * extraction is wrong — do not edit the test to match the new behaviour.
+ */
+
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+// EcuLab.jsx is loaded with a dynamic import behind a runtime-built specifier rather
+// than `import EcuLab from '../../src/ui/EcuLab.jsx'`. tsconfig.json deliberately
+// excludes EcuLab.jsx from typechecking ("still one large untyped component... stays
+// excluded until the screen split") — but that exclusion only controls root-file
+// discovery. tsc still type-checks any file a *statically resolvable* import pulls in
+// transitively, so a normal import here would, for the first time, run ~26 pre-existing
+// and unrelated type errors in EcuLab.jsx through `npm run typecheck` and fail the
+// gate. Because the specifier is a variable, tsc cannot resolve the module and leaves
+// it alone, which is what the exclusion already intends.
+let EcuLab;
+
+beforeAll(async () => {
+  const modulePath = '../../src/ui/EcuLab.jsx';
+  ({ default: EcuLab } = await import(/* @vite-ignore */ modulePath));
+});
+
+// jsdom has no ResizeObserver. recharts' <ResponsiveContainer> (used on the DYNO
+// results panel) needs one to mount at all, so without this stub any test that
+// reaches a rendered result panel throws an uncaught ReferenceError from inside
+// react-dom's commit phase. observe/unobserve/disconnect are no-ops: the tests
+// below never depend on a resize callback firing, only on the chart mounting.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+const hadResizeObserver = 'ResizeObserver' in window;
+if (!hadResizeObserver) window.ResizeObserver = ResizeObserverStub;
+afterAll(() => {
+  if (!hadResizeObserver) delete window.ResizeObserver;
+});
+
+afterEach(cleanup);
+
+/** Renders the app and clicks past the start screen into the build tab. */
+function launch() {
+  const view = render(<EcuLab />);
+  fireEvent.click(screen.getByRole('button', { name: 'START' }));
+  return view;
+}
+
+/**
+ * The preset picker is the only select with optgroups.
+ * @returns {HTMLSelectElement | undefined}
+ */
+function presetPicker() {
+  return /** @type {HTMLSelectElement[]} */ (screen.getAllByRole('combobox'))
+    .find((el) => el.querySelector('optgroup'));
+}
+
+describe('entry', () => {
+  it('opens on the start screen', () => {
+    render(<EcuLab />);
+    expect(screen.getByRole('button', { name: 'START' })).toBeTruthy();
+  });
+
+  it('enters the app on START and lands on BUILD', () => {
+    launch();
+    expect(screen.getByRole('button', { name: /BUILD/ })).toBeTruthy();
+  });
+
+  it('opens the tutorial and comes back', () => {
+    render(<EcuLab />);
+    fireEvent.click(screen.getByRole('button', { name: 'TUTORIAL' }));
+    expect(screen.getByText(/TUTORIAL · 1\//)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'SKIP' }));
+    expect(screen.getByRole('button', { name: /BUILD/ })).toBeTruthy();
+  });
+});
+
+describe('navigation', () => {
+  it('moves between the four tabs', () => {
+    launch();
+    // The bottom-nav buttons (HOME/BUILD/TUNE/DYNO) are rendered unconditionally —
+    // only their active styling changes — so re-querying for the clicked button by
+    // name proves nothing about whether the click actually switched tabs; it would
+    // pass even if the tab body never moved. Assert on a marker that only exists
+    // while that tab's body is mounted instead.
+    const marker = {
+      TUNE: () => screen.getByRole('button', { name: 'AIR' }), // TUNE_VIEWS sub-tab
+      DYNO: () => screen.getByRole('button', { name: 'RUN DYNO PULL' }),
+      HOME: () => screen.getByText('Live Engine'),
+      BUILD: () => screen.getByText('Garage'),
+    };
+    for (const tab of ['TUNE', 'DYNO', 'HOME', 'BUILD']) {
+      fireEvent.click(screen.getByRole('button', { name: tab }));
+      expect(marker[tab]()).toBeTruthy();
+    }
+  });
+});
+
+describe('the header reflects the build', () => {
+  it('names the current engine and fuel', () => {
+    launch();
+    // The header line is `${engineName} · ${turbo} · ${octane} oct · ${injector} · ${version}`.
+    // Pin that it renders at all and carries an octane figure; the exact preset name is
+    // not the point.
+    expect(screen.getByText(/oct/)).toBeTruthy();
+  });
+});
+
+describe('loading a preset', () => {
+  it('rewrites the header to name that preset', () => {
+    // Exercises applyEnginePreset's 23 writes across all three slices in one go.
+    launch();
+    const picker = presetPicker();
+    expect(picker).toBeTruthy();
+    const target = [...picker.querySelectorAll('option')]
+      .map((o) => o.value)
+      .find((v) => v && v !== picker.value);
+    fireEvent.change(picker, { target: { value: target } });
+    // With a preset loaded the header shows its NAME, not the "3.0L I6" fallback.
+    expect(screen.getByText(/oct/).textContent).not.toMatch(/^\d\.\dL /);
+  });
+});
+
+describe('editing a calibration table', () => {
+  it('stops the header claiming the factory preset', () => {
+    // The single most important behaviour in this PR: withTableEdit crosses the
+    // build/tune boundary, clearing presetId (build) and setting tablesDirty (tune).
+    // If the extraction drops that link, the header goes on claiming a factory
+    // calibration the player has just edited away from.
+    launch();
+    const picker = presetPicker();
+    const target = [...picker.querySelectorAll('option')]
+      .map((o) => o.value)
+      .find((v) => v && v !== picker.value);
+    fireEvent.change(picker, { target: { value: target } });
+
+    fireEvent.click(screen.getByRole('button', { name: /TUNE/ }));
+    // Any grid cell; the first numeric-labelled button inside the grid will do.
+    const cells = screen.getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent));
+    fireEvent.click(cells[Math.floor(cells.length / 2)]);
+    fireEvent.click(screen.getByRole('button', { name: '+1' }));
+
+    // Header falls back to the derived "3.0L I6" form once the preset is invalidated.
+    expect(screen.getByText(/oct/).textContent).toMatch(/^\d\.\dL /);
+  });
+});
+
+describe('running a dyno pull', () => {
+  it('produces a result', async () => {
+    launch();
+    fireEvent.click(screen.getByRole('button', { name: /DYNO/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'RUN DYNO PULL' }));
+    // The reveal is a setInterval that ends by setting running false, so the button
+    // returns to its idle label. Real timers + waitFor is less brittle here than fake
+    // timers, which would need act() wrapping around every tick.
+    await waitFor(
+      () => expect(screen.getByRole('button', { name: 'RUN DYNO PULL' })).toBeTruthy(),
+      { timeout: 10000 },
+    );
+  });
+});

--- a/tests/ui/characterisation.test.jsx
+++ b/tests/ui/characterisation.test.jsx
@@ -13,7 +13,7 @@
  * extraction is wrong — do not edit the test to match the new behaviour.
  */
 
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
 import { afterAll, afterEach, describe, expect, it } from 'vitest';
 
@@ -133,10 +133,22 @@ describe('editing a calibration table', () => {
     fireEvent.change(picker, { target: { value: target } });
 
     fireEvent.click(screen.getByRole('button', { name: /TUNE/ }));
+    // Scope to the tuning grid itself: unscoped queries also match the BUILD tab's
+    // boost-curve editor, so if tab navigation broke and the app never left BUILD,
+    // an unscoped query would still find cells there and the test would pass for
+    // the wrong reason. Querying inside the grid means this can only pass by
+    // actually landing on TUNE and editing a real calibration table cell.
+    const grid = within(screen.getByTestId('tuning-grid'));
     // Any grid cell; the first numeric-labelled button inside the grid will do.
-    const cells = screen.getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent));
+    const cells = grid.getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent));
     fireEvent.click(cells[Math.floor(cells.length / 2)]);
-    fireEvent.click(screen.getByRole('button', { name: '+1' }));
+    // Selecting a grid cell mounts the SelectionDock (the sticky editor at the
+    // bottom of the tuning tab). The BUILD tab's boost-curve editor has its own
+    // unrelated '+1' button, so scope to the dock rather than querying the whole
+    // document — otherwise a broken tab switch that left the boost editor visible
+    // could satisfy this query too.
+    const dock = within(screen.getByTestId('selection-dock'));
+    fireEvent.click(dock.getByRole('button', { name: '+1' }));
 
     // Header falls back to the derived "3.0L I6" form once the preset is invalidated.
     expect(screen.getByText(/oct/).textContent).toMatch(/^\d\.\dL /);
@@ -148,6 +160,12 @@ describe('running a dyno pull', () => {
     launch();
     fireEvent.click(screen.getByRole('button', { name: /DYNO/ }));
     fireEvent.click(screen.getByRole('button', { name: 'RUN DYNO PULL' }));
+    // doRun() calls setResult(r) synchronously (before the reveal interval even
+    // starts), so the PEAK WHP tile mounts immediately — no need to wait for the
+    // sweep to finish. This is the actual point of the test: if setResult were
+    // wired to the wrong slice (or dropped entirely), this tile never appears,
+    // regardless of what the button label does.
+    expect(screen.getByText('PEAK WHP')).toBeTruthy();
     // The reveal is a setInterval that ends by setting running false, so the button
     // returns to its idle label. Real timers + waitFor is less brittle here than fake
     // timers, which would need act() wrapping around every tick.

--- a/tests/ui/characterisation.test.jsx
+++ b/tests/ui/characterisation.test.jsx
@@ -15,23 +15,9 @@
 
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
 
-// EcuLab.jsx is loaded with a dynamic import behind a runtime-built specifier rather
-// than `import EcuLab from '../../src/ui/EcuLab.jsx'`. tsconfig.json deliberately
-// excludes EcuLab.jsx from typechecking ("still one large untyped component... stays
-// excluded until the screen split") — but that exclusion only controls root-file
-// discovery. tsc still type-checks any file a *statically resolvable* import pulls in
-// transitively, so a normal import here would, for the first time, run ~26 pre-existing
-// and unrelated type errors in EcuLab.jsx through `npm run typecheck` and fail the
-// gate. Because the specifier is a variable, tsc cannot resolve the module and leaves
-// it alone, which is what the exclusion already intends.
-let EcuLab;
-
-beforeAll(async () => {
-  const modulePath = '../../src/ui/EcuLab.jsx';
-  ({ default: EcuLab } = await import(/* @vite-ignore */ modulePath));
-});
+import EcuLab from '../../src/ui/EcuLab.jsx';
 
 // jsdom has no ResizeObserver. recharts' <ResponsiveContainer> (used on the DYNO
 // results panel) needs one to mount at all, so without this stub any test that

--- a/tests/ui/session-store.test.jsx
+++ b/tests/ui/session-store.test.jsx
@@ -26,6 +26,7 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import React from 'react';
 import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { loadCareer } from '../../src/storage.js';
 import EcuLab, { EcuLabApp } from '../../src/ui/EcuLab.jsx';
 import { StoreProvider, useSession } from '../../src/ui/state/StoreProvider.jsx';
 import { ACTIONS } from '../../src/ui/state/reducer.js';
@@ -383,6 +384,41 @@ describe('the guided first run', () => {
     fireEvent.click(screen.getByRole('button', { name: 'SKIP GUIDE' }));
 
     expect(screen.queryByText('STEP 1 · BUILD THE ENGINE')).toBeNull();
+  });
+});
+
+describe('banking a pull', () => {
+  it('writes the career through to storage, not just to the store', async () => {
+    // `BANK_PULL` updates bestScore/totalScore/pullCount in the store; `persistCareer`
+    // (EcuLab.jsx:873) is a SEPARATE synchronous call that writes them through to the
+    // storage adapter. It is deliberately not in the reducer — reducers do no I/O — and
+    // deliberately not in a useEffect keyed on the score fields, because the restore
+    // effect is async and a score-watching effect would fire with 0,0,0 on mount,
+    // BEFORE loadCareer() resolves, and overwrite a real save with zeroes.
+    //
+    // That left the call itself pinned by nothing. Deleting the persistCareer line
+    // passes all 169 other tests: the session plays perfectly, the HOME panel shows the
+    // right figures from the store, and the career is simply gone at the next refresh.
+    // A whole-branch break sweep found this; every earlier review confirmed the call
+    // site was CORRECT without checking a regression would be caught.
+    launch();
+    fireEvent.click(screen.getByRole('button', { name: 'DYNO' }));
+    // Guard the setup: nothing is saved before a pull is banked, so if the pull below
+    // silently failed to run, the assertion afterwards would be comparing zero to zero.
+    expect(localStorage.getItem('career')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'RUN DYNO PULL' }));
+    await waitFor(
+      () => expect(screen.getByRole('button', { name: 'RUN DYNO PULL' })).toBeTruthy(),
+      { timeout: 10000 },
+    );
+
+    // Read it back through the adapter rather than parsing the raw string, so this
+    // pins the round trip a returning player actually depends on.
+    const saved = await loadCareer();
+    expect(saved.pulls).toBe(1);
+    expect(saved.total).toBeGreaterThan(0);
+    expect(saved.best).toBe(saved.total);
   });
 });
 

--- a/tests/ui/session-store.test.jsx
+++ b/tests/ui/session-store.test.jsx
@@ -276,6 +276,41 @@ describe('running a dyno pull', () => {
     expect(screen.queryByRole('button', { name: 'APPLY CORRECTIONS TO VE' })).toBeNull();
     expect(screen.getByRole('button', { name: 'BUILD HISTOGRAM FROM THIS PULL' })).toBeTruthy();
   });
+
+  it('resets the tach to the start of the sweep when a second pull begins', async () => {
+    // `doRun` (EcuLab.jsx:846) dispatches `revealCount: 0` before the reveal interval
+    // starts. Task 6's report justified leaving that dispatch untested by calling it
+    // "a reset to a value the field is usually already at" with "no readout that could
+    // distinguish" it. Both halves are false: after ANY completed pull revealCount ===
+    // points.length, never 0, and the tach (EcuLab.jsx:1017) reads it back directly.
+    // Drop the dispatch and every pull after the first opens with the tach still
+    // pinned at the PREVIOUS pull's peak RPM and the chart fully drawn, then snaps
+    // back to the sweep's first point and re-animates a beat later — a visible flash
+    // on a core screen, every time a player runs back-to-back pulls.
+    launch();
+    fireEvent.click(screen.getByRole('button', { name: 'DYNO' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'RUN DYNO PULL' }));
+    await waitFor(
+      () => expect(screen.getByRole('button', { name: 'RUN DYNO PULL' })).toBeTruthy(),
+      { timeout: 10000 },
+    );
+    const afterFirstPull = tachReading();
+    // Guard the setup, not just the outcome: if the reveal had not actually run to the
+    // end of the sweep, this would already read the sweep's first point, and the real
+    // assertion below would pass whether or not the second pull's reset dispatch fired
+    // — for the wrong reason. Same figure the "sweeps the tach to the top of the run"
+    // test above already establishes is reachable.
+    expect(afterFirstPull).toBeGreaterThan(1500);
+
+    fireEvent.click(screen.getByRole('button', { name: 'RUN DYNO PULL' }));
+    // Deliberately no `waitFor` here: `doRun` dispatches SET_SESSION_FIELD/revealCount
+    // and BANK_PULL synchronously, inside this very click, before the reveal interval
+    // has ticked even once. The whole failure this test exists to catch is the FIRST
+    // frame of the second pull — waiting for anything would let the 55 ms interval
+    // catch up and paper over exactly the flash a player would see.
+    expect(tachReading()).toBeLessThan(afterFirstPull);
+  });
 });
 
 /**

--- a/tests/ui/session-store.test.jsx
+++ b/tests/ui/session-store.test.jsx
@@ -1,0 +1,400 @@
+// @vitest-environment jsdom
+
+/**
+ * The SESSION-slice call sites nothing else watches.
+ *
+ * `tests/ui/state/reducer.test.js` proves what each action DOES to the state tree. It
+ * says nothing about which action `EcuLab` dispatches, or whether it dispatches one at
+ * all — and the session slice is where that gap is widest, because two of its actions
+ * had no caller before this task and three of its writes are invisible to every other
+ * test in the suite:
+ *
+ * - REPAIR_ENGINE existed in the reducer, fully tested, dispatched from NOWHERE. The
+ *   REPAIR button wrote a local `health` the store never saw. Deleting that setter
+ *   without adding the dispatch leaves the button inert with no error anywhere.
+ * - LIVE_STEP integrates the running engine. Its whole reason to exist is that the
+ *   50 ms interval must not read `live` from the render scope — get that wrong and the
+ *   engine readout freezes, which presents as a physics bug, not a state bug.
+ * - LIVE_PATCH is START/STOP. `live.running` gates the throttle pad, so a broken patch
+ *   locks the player out of revving the engine.
+ *
+ * Every test below drives a real control and reads a real readout, so none of them can
+ * pass with the dispatch stubbed out.
+ */
+
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import EcuLab, { EcuLabApp } from '../../src/ui/EcuLab.jsx';
+import { StoreProvider, useSession } from '../../src/ui/state/StoreProvider.jsx';
+import { ACTIONS } from '../../src/ui/state/reducer.js';
+
+// jsdom has no ResizeObserver. recharts' <ResponsiveContainer> (used on the DYNO
+// results panel) needs one to mount at all, so any test that reaches a rendered dyno
+// result throws an uncaught ReferenceError from inside react-dom's commit phase
+// without this stub. Same approach as characterisation.test.jsx.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+const hadResizeObserver = 'ResizeObserver' in window;
+if (!hadResizeObserver) window.ResizeObserver = ResizeObserverStub;
+afterAll(() => {
+  if (!hadResizeObserver) delete window.ResizeObserver;
+});
+
+afterEach(cleanup);
+
+// The dyno tests below bank a pull, and banking persists career stats through the
+// storage adapter — which in jsdom is localStorage. Left in place that would leak into
+// the career-restore test, which asserts on exactly those figures.
+beforeEach(() => localStorage.clear());
+afterEach(() => localStorage.clear());
+
+/** Renders the app and clicks past the start screen. Lands on BUILD. */
+function launch() {
+  const view = render(<EcuLab />);
+  fireEvent.click(screen.getByRole('button', { name: 'START' }));
+  return view;
+}
+
+/** Renders the app and clicks past the start screen onto HOME. */
+function launchOnHome() {
+  const view = launch();
+  fireEvent.click(screen.getByRole('button', { name: 'HOME' }));
+  return view;
+}
+
+/**
+ * A probe that hands the store's dispatch back to the test, so it can seed session
+ * state the UI's own controls cannot produce on demand. Same shape as the one in
+ * build-store.test.jsx.
+ * @param {{onReady: (dispatch: React.Dispatch<*>) => void}} props
+ * @returns {null}
+ */
+function DispatchProbe({ onReady }) {
+  const [, dispatch] = useSession();
+  // In an effect, not in render: a render-phase callback fires on every render and
+  // twice under StrictMode.
+  React.useEffect(() => { onReady(dispatch); }, [onReady, dispatch]);
+  return null;
+}
+
+/** The Engine Health accordion's subtitle, which reads "<n>% overall" while collapsed. */
+function overallHealth() {
+  return Number(screen.getByText(/% overall$/).textContent.match(/^(\d+)%/)[1]);
+}
+
+describe('the REPAIR button', () => {
+  it('puts every worn component back to full health', () => {
+    // REPAIR_ENGINE's reducer case has been tested since Task 3; its CALL SITE has
+    // never been. Before this task `repairEngine` set a local `health` the store could
+    // not see, so removing the setter and forgetting the dispatch would leave the
+    // wrench button doing nothing at all — no error, no failing test, and a player
+    // staring at a damaged engine they were told they could fix.
+    /** @type {React.Dispatch<*>} */
+    let dispatch;
+    render(
+      <StoreProvider>
+        <DispatchProbe onReady={(d) => { dispatch = d; }} />
+        <EcuLabApp />
+      </StoreProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'START' }));
+    fireEvent.click(screen.getByRole('button', { name: 'HOME' }));
+
+    // Wear the engine directly rather than by running pulls: how much damage a given
+    // build takes is the sim's business and would make this test a physics test.
+    // `overallHealth` is the MINIMUM of the three, so the readout below is the 42.
+    act(() => dispatch({
+      type: ACTIONS.SET_SESSION_FIELD,
+      field: 'health',
+      value: { piston: 42, bearing: 71, valve: 88 },
+    }));
+    // Guard the setup rather than trusting it: if the seed silently failed, health
+    // would already be 100 and the assertion after the click would pass for the wrong
+    // reason.
+    expect(overallHealth()).toBe(42);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Repair engine' }));
+
+    expect(overallHealth()).toBe(100);
+  });
+});
+
+describe('the live engine', () => {
+  it('cranks, catches and runs off the store', async () => {
+    // The hardest conversion in the PR, and the one with the least margin for error.
+    // The 20 Hz interval is installed once with a stable dependency, so anything it
+    // reads from the render scope is frozen at mount — an engine-off `live` forever.
+    // LIVE_STEP therefore resolves `prev` inside the reducer. If it did not, the guard
+    // (`running || cranking || rpm > 1`) would evaluate against that frozen state and
+    // this engine would never leave 0 RPM, no matter how many times START was pressed.
+    launchOnHome();
+
+    // The Live Engine panel's subtitle is the engine's own state machine: "Off",
+    // "Cranking…", or "Running · <n> RPM · <n>°C".
+    expect(screen.getByText('Off')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'START ENGINE' }));
+
+    // liveStep catches on the third 50 ms step from cold (tests/live.test.js covers the
+    // physics), so this is ~150 ms of real time. Real timers rather than fake ones, for
+    // the same reason as characterisation.test.jsx's dyno pull: fake timers would need
+    // act() around every tick.
+    await waitFor(
+      () => expect(screen.getByText(/^Running · \d+ RPM · \d+°C$/)).toBeTruthy(),
+      { timeout: 5000 },
+    );
+    // Not just "the flag flipped": the engine is actually turning, which only happens
+    // if the reducer integrated real steps from the store's own `live`.
+    const rpm = Number(screen.getByText(/^Running · \d+ RPM/).textContent.match(/(\d+) RPM/)[1]);
+    expect(rpm).toBeGreaterThan(300);
+  });
+
+  it('opens and closes the throttle while it runs', async () => {
+    // `throttleInput` is a session field written from three pointer handlers, and the
+    // throttle pad's own label is the only thing that reads it back. Stub those
+    // dispatches and the pad silently stops acknowledging the press.
+    launchOnHome();
+    fireEvent.click(screen.getByRole('button', { name: 'START ENGINE' }));
+    await waitFor(
+      () => expect(screen.getByText(/^Running · /)).toBeTruthy(),
+      { timeout: 5000 },
+    );
+
+    const pad = screen.getByText('PRESS AND HOLD TO REV');
+    fireEvent.pointerDown(pad.parentElement);
+    expect(screen.getByText('WIDE OPEN THROTTLE')).toBeTruthy();
+
+    fireEvent.pointerUp(screen.getByText('WIDE OPEN THROTTLE').parentElement);
+    expect(screen.getByText('PRESS AND HOLD TO REV')).toBeTruthy();
+  });
+
+  it('shuts down on STOP', async () => {
+    // STOP is the other LIVE_PATCH. It has to land on top of whatever the 20 Hz
+    // interval last wrote — the interval is still ticking underneath it — so if this
+    // regressed to a value-carrying write of a captured `live`, the engine would come
+    // straight back to life on the next step.
+    launchOnHome();
+    fireEvent.click(screen.getByRole('button', { name: 'START ENGINE' }));
+    await waitFor(
+      () => expect(screen.getByText(/^Running · /)).toBeTruthy(),
+      { timeout: 5000 },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'STOP' }));
+
+    // Wait past several more interval ticks: a STOP that the next step overwrites
+    // would show as the engine still running here.
+    await act(async () => { await new Promise((r) => { setTimeout(r, 400); }); });
+    expect(screen.getByText('Off')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'START ENGINE' })).toBeTruthy();
+  });
+
+  it('does not re-render the app while it is stopped', async () => {
+    // LIVE_STEP's early return hands back the SAME state object, which is what makes
+    // React bail out. Return a fresh state holding an unchanged `live` instead and
+    // nothing breaks, nothing fails — the entire app just re-renders twenty times a
+    // second, forever, on a dead engine. Nothing else in the suite would notice.
+    let renders = 0;
+    /** @returns {null} */
+    function RenderCounter() {
+      useSession();
+      renders += 1;
+      return null;
+    }
+    render(
+      <StoreProvider>
+        <RenderCounter />
+        <EcuLabApp />
+      </StoreProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'START' }));
+
+    // Let the mount settle first — the career-restore effect resolves asynchronously
+    // and dispatches three writes of its own, which are legitimate re-renders.
+    await act(async () => { await new Promise((r) => { setTimeout(r, 300); }); });
+    const settled = renders;
+
+    // Four separate waits rather than one long one: a single `act` would flush every
+    // tick's re-render into one commit, so a broken bail-out would show up as ONE
+    // extra render instead of one per tick and the signal would be a hair from noise.
+    for (let i = 0; i < 4; i += 1) {
+      await act(async () => { await new Promise((r) => { setTimeout(r, 120); }); });
+    }
+
+    expect(renders).toBe(settled);
+  });
+});
+
+describe('running a dyno pull', () => {
+  it('flips the button to SWEEPING… and sweeps the tach to the top of the run', async () => {
+    // Two session writes nothing else pins. `running` is only legible as the RUN
+    // button's label while the sweep is live — characterisation.test.jsx waits for the
+    // idle label to come BACK, which a permanently-idle button satisfies immediately.
+    // `revealCount` is only legible through the tach, which reads points[revealCount]:
+    // stub that dispatch and the needle sits at the sweep's first point (1500 RPM) for
+    // the whole pull and forever afterwards.
+    launch();
+    fireEvent.click(screen.getByRole('button', { name: 'DYNO' }));
+    expect(tachReading()).toBe(1500);
+
+    fireEvent.click(screen.getByRole('button', { name: 'RUN DYNO PULL' }));
+    expect(screen.getByRole('button', { name: 'SWEEPING…' })).toBeTruthy();
+
+    await waitFor(
+      () => expect(screen.getByRole('button', { name: 'RUN DYNO PULL' })).toBeTruthy(),
+      { timeout: 10000 },
+    );
+    // The reveal ran to the end of the sweep, so the needle is up at the last logged
+    // point rather than still on the first one.
+    expect(tachReading()).toBeGreaterThan(1500);
+  });
+
+  it('puts the histogram controls away once the correction is applied', async () => {
+    // `applyHistogram` clears `histogram` after writing the VE table. Drop that write
+    // and the APPLY/DISCARD pair stays on screen, inviting the player to apply the same
+    // correction to the same table over and over. build-store.test.jsx covers the VE
+    // write itself but stops before the clear.
+    launch();
+    fireEvent.click(screen.getByRole('button', { name: 'DYNO' }));
+    fireEvent.click(screen.getByRole('button', { name: 'RUN DYNO PULL' }));
+    await waitFor(
+      () => expect(screen.getByRole('button', { name: 'RUN DYNO PULL' })).toBeTruthy(),
+      { timeout: 10000 },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'DATALOG' }));
+    fireEvent.click(screen.getByRole('button', { name: 'BUILD HISTOGRAM FROM THIS PULL' }));
+    // Guard: the APPLY/DISCARD pair only exists while `histogram` is set, so this also
+    // proves the build-side write landed before the clear is asserted below.
+    fireEvent.click(screen.getByRole('button', { name: 'APPLY CORRECTIONS TO VE' }));
+
+    expect(screen.queryByRole('button', { name: 'APPLY CORRECTIONS TO VE' })).toBeNull();
+    expect(screen.getByRole('button', { name: 'BUILD HISTOGRAM FROM THIS PULL' })).toBeTruthy();
+  });
+});
+
+/**
+ * The dyno tab's tach renders its RPM figure as a bare integer directly above a "RPM"
+ * caption. recharts also labels an axis "RPM", so match on the pairing rather than on
+ * the caption alone.
+ * @returns {number}
+ */
+function tachReading() {
+  const readings = screen.getAllByText('RPM')
+    .map((el) => el.previousElementSibling)
+    .filter((el) => el && /^\d+$/.test(el.textContent))
+    .map((el) => Number(el.textContent));
+  expect(readings).toHaveLength(1);
+  return readings[0];
+}
+
+describe('the dyno load selector', () => {
+  it('moves the selection to the load the player picked', () => {
+    // `loadKpa` decides which manifold-pressure column the sweep is run at. It is fed
+    // straight into simulateSweep, so a dropped write is only visible as a pull that
+    // quietly measured the wrong thing — but the Seg's own highlight reads the value
+    // back out of the store, which makes the round trip testable in one click.
+    launch();
+    fireEvent.click(screen.getByRole('button', { name: 'DYNO' }));
+    expect(selectedLoad()).toBe('100 kPa');
+
+    fireEvent.click(screen.getByRole('button', { name: '40 kPa' }));
+
+    expect(selectedLoad()).toBe('40 kPa');
+  });
+});
+
+/**
+ * Seg marks its selected option by giving that one button a different background from
+ * the rest, so the selected label is the odd one out of the three.
+ * @returns {string}
+ */
+function selectedLoad() {
+  const buttons = ['100 kPa', '70 kPa', '40 kPa']
+    .map((name) => screen.getByRole('button', { name }));
+  const tally = {};
+  buttons.forEach((b) => { tally[b.style.background] = (tally[b.style.background] || 0) + 1; });
+  const odd = buttons.filter((b) => tally[b.style.background] === 1);
+  expect(odd).toHaveLength(1);
+  return odd[0].textContent;
+}
+
+describe('the guided first run', () => {
+  it('advances to the next step when the banner is followed', () => {
+    // `journeyStep` is onboarding progress, and the banner is the only thing that
+    // reads it. A dropped write leaves a new player stuck on step 1 of 4, being told
+    // to do something they have already done.
+    launch();
+    expect(screen.getByText('STEP 1 · BUILD THE ENGINE')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Done building — go tune it' }));
+
+    // The banner's onAdvance both bumps the step and changes tab, so the step-2 banner
+    // is what proves the store took the write — the tab change alone would not.
+    expect(screen.getByText('STEP 2 · CALIBRATE IT')).toBeTruthy();
+  });
+
+  it('dismisses for good on SKIP GUIDE', () => {
+    // The dismissal writes 99, a step the JOURNEY table has no entry for, so
+    // JourneyBanner renders null. Drop the write and the banner is unclosable.
+    launch();
+    expect(screen.getByText('STEP 1 · BUILD THE ENGINE')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'SKIP GUIDE' }));
+
+    expect(screen.queryByText('STEP 1 · BUILD THE ENGINE')).toBeNull();
+  });
+});
+
+describe('career stats saved from a previous session', () => {
+  it('are restored into the store on mount', async () => {
+    // The career-restore effect writes bestScore, totalScore and pullCount. Drop those
+    // writes and a returning player's high score reads back as zero — and then the
+    // next pull's `persistCareer` OVERWRITES the real save with that zeroed career, so
+    // the failure is not just cosmetic, it destroys the data. tests/storage.test.js
+    // covers the adapter and never touches this wiring.
+    localStorage.setItem('career', JSON.stringify({ best: 812, total: 3405, pulls: 7 }));
+    launchOnHome();
+
+    // The load is async, so the first paint legitimately shows a zeroed career.
+    await waitFor(() => expect(screen.getByText('7 pulls logged')).toBeTruthy());
+
+    // Open the panel for the other two figures: the collapsed subtitle only names the
+    // pull count while no pull has been run this session.
+    fireEvent.click(screen.getByText('Career & Last Pull'));
+    expect(statTile('BEST PULL')).toBe('812');
+    expect(statTile('CAREER TOTAL')).toBe('3405');
+  });
+});
+
+/**
+ * StatTile renders its caption and its figure as sibling divs.
+ * @param {string} label
+ * @returns {string}
+ */
+function statTile(label) {
+  return screen.getByText(label).nextElementSibling.firstChild.textContent;
+}
+
+describe('the engine-sound toggle', () => {
+  it('switches the button between on and off', () => {
+    // `soundOn` gates the audio synth's master gain, which jsdom has no way to hear.
+    // The button's own glyph is the readable half of that write.
+    launchOnHome();
+    // By title, not by name: the button's only content is the glyph this test is
+    // asserting on, and that glyph IS its accessible name.
+    const toggle = () => screen.getByTitle('Engine sound');
+    expect(toggle().textContent).toBe('♪');
+
+    fireEvent.click(toggle());
+    expect(toggle().textContent).toBe('✕');
+
+    fireEvent.click(toggle());
+    expect(toggle().textContent).toBe('♪');
+  });
+});

--- a/tests/ui/state/StoreProvider.test.jsx
+++ b/tests/ui/state/StoreProvider.test.jsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+/**
+ * StoreProvider / hook tests.
+ *
+ * Not pinned by the plan's verbatim test listing (that only specifies
+ * reducer.test.js), but the provider and its three hooks are a produced interface
+ * later tasks depend on by exact name, so they get their own coverage: each hook must
+ * return its own slice, dispatch must route through the real reducer, and using a
+ * hook outside the provider must throw instead of silently handing back `undefined`.
+ */
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { ACTIONS } from '../../../src/ui/state/reducer.js';
+import { StoreProvider, useBuild, useSession, useTune } from '../../../src/ui/state/StoreProvider.jsx';
+
+afterEach(cleanup);
+
+function BuildProbe() {
+  const [build, dispatch] = useBuild();
+  return (
+    <div>
+      <span data-testid="turboOn">{String(build.turboOn)}</span>
+      <button onClick={() => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: true })}>
+        flip
+      </button>
+    </div>
+  );
+}
+
+function TuneProbe() {
+  const [tune] = useTune();
+  return <span data-testid="tablesDirty">{String(tune.tablesDirty)}</span>;
+}
+
+function SessionProbe() {
+  const [session] = useSession();
+  return <span data-testid="pullCount">{session.pullCount}</span>;
+}
+
+describe('useBuild / useTune / useSession outside a provider', () => {
+  it('throws a clear error rather than returning undefined', () => {
+    // Rendered with no <StoreProvider> ancestor. A silent `undefined` here would
+    // surface as a confusing crash three components away instead of at the source.
+    const Bare = () => { useBuild(); return null; };
+    // React logs the thrown error to the console during a failed render; that noise
+    // is expected and not something this test needs to assert on.
+    const spy = () => {};
+    const originalError = console.error;
+    console.error = spy;
+    try {
+      expect(() => render(<Bare />)).toThrow(/StoreProvider/);
+    } finally {
+      console.error = originalError;
+    }
+  });
+});
+
+describe('StoreProvider', () => {
+  it('gives each hook its own slice of one shared store', () => {
+    render(
+      <StoreProvider>
+        <BuildProbe />
+        <TuneProbe />
+        <SessionProbe />
+      </StoreProvider>,
+    );
+    expect(screen.getByTestId('turboOn').textContent).toBe('false');
+    expect(screen.getByTestId('tablesDirty').textContent).toBe('false');
+    expect(screen.getByTestId('pullCount').textContent).toBe('0');
+  });
+
+  it('dispatch from useBuild goes through the real reducer and re-renders the slice', () => {
+    render(
+      <StoreProvider>
+        <BuildProbe />
+      </StoreProvider>,
+    );
+    expect(screen.getByTestId('turboOn').textContent).toBe('false');
+    fireEvent.click(screen.getByRole('button', { name: 'flip' }));
+    expect(screen.getByTestId('turboOn').textContent).toBe('true');
+  });
+
+  it('gives two mounted providers independent state', () => {
+    // Regression guard against a module-scoped store: each <StoreProvider> must own
+    // its own useReducer instance.
+    const { unmount } = render(
+      <StoreProvider>
+        <BuildProbe />
+      </StoreProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'flip' }));
+    expect(screen.getByTestId('turboOn').textContent).toBe('true');
+    unmount();
+
+    render(
+      <StoreProvider>
+        <BuildProbe />
+      </StoreProvider>,
+    );
+    expect(screen.getByTestId('turboOn').textContent).toBe('false');
+  });
+});

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -142,6 +142,46 @@ describe('SET_BUILD_FIELD', () => {
   });
 });
 
+describe('CLEAR_PRESET_ID', () => {
+  it('clears the preset label', () => {
+    const loaded = { ...makeInitialState() };
+    loaded.build = { ...loaded.build, presetId: 'n54' };
+    const s = reducer(loaded, { type: ACTIONS.CLEAR_PRESET_ID });
+    expect(s.build.presetId).toBeNull();
+  });
+
+  it('does not flag the calibration tables as dirty', () => {
+    // Unlike SET_TABLE, choosing "Custom build" is not itself a calibration edit.
+    const s = reducer(makeInitialState(), { type: ACTIONS.CLEAR_PRESET_ID });
+    expect(s.tune.tablesDirty).toBe(false);
+  });
+
+  it('touches ONLY presetId — a value the action cannot even carry proves the point', () => {
+    // The bug this action exists to fix: the old call site dispatched
+    // `{type: SET_BUILD_FIELD, field: 'presetId', value: null}`, which only worked
+    // because the reducer's OWN trailing `presetId: null` clobbered whatever value the
+    // action carried — so a hypothetical caller passing a non-null value would have
+    // silently gotten null back anyway. CLEAR_PRESET_ID has no `value` field in its
+    // shape at all, so there is no payload for a future caller to get wrong here; this
+    // test instead pins that every OTHER build field survives the dispatch untouched,
+    // which is the property SET_BUILD_FIELD could never have offered (it invalidates
+    // every write, by design).
+    const loaded = { ...makeInitialState() };
+    loaded.build = { ...loaded.build, presetId: 'n54', turboOn: true, mafScalar: 0.9 };
+    const s = reducer(loaded, { type: ACTIONS.CLEAR_PRESET_ID });
+    expect(s.build.presetId).toBeNull();
+    expect(s.build.turboOn).toBe(true);
+    expect(s.build.mafScalar).toBe(0.9);
+  });
+
+  it('leaves the other slices untouched by reference', () => {
+    const before = makeInitialState();
+    const after = reducer(before, { type: ACTIONS.CLEAR_PRESET_ID });
+    expect(after.tune).toBe(before.tune);
+    expect(after.session).toBe(before.session);
+  });
+});
+
 describe('SET_TURBINE', () => {
   it('fits one of the chosen housing, because a twin-turbo count belongs to a preset', () => {
     const twin = { ...makeInitialState() };

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -159,3 +159,232 @@ describe('SET_TUNE_FIELD', () => {
     expect(after.session).toBe(before.session);
   });
 });
+
+describe('every write produces a fresh slice reference', () => {
+  it('SET_SESSION_FIELD replaces the changed slice rather than mutating it', () => {
+    const before = makeInitialState();
+    const after = reducer(before, { type: ACTIONS.SET_SESSION_FIELD, field: 'pullCount', value: 3 });
+    expect(after.session).not.toBe(before.session);
+    expect(before.session.pullCount).toBe(0); // the input state is untouched
+  });
+
+  it('SET_BUILD_FIELD replaces the changed slice rather than mutating it', () => {
+    const before = makeInitialState();
+    const after = reducer(before, { type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: true });
+    expect(after.build).not.toBe(before.build);
+    expect(before.build.turboOn).toBe(false); // the input state is untouched
+  });
+
+  it('SET_TUNE_FIELD replaces the changed slice rather than mutating it', () => {
+    const before = makeInitialState();
+    const after = reducer(before, {
+      type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value: { type: 'cell', row: 0, col: 0 },
+    });
+    expect(after.tune).not.toBe(before.tune);
+    expect(before.tune.selection).toBeNull(); // the input state is untouched
+  });
+});
+
+describe('non-invalidating build writes', () => {
+  it('moving the boost-curve cursor does not disown the preset', () => {
+    const loaded = makeInitialState();
+    loaded.build = { ...loaded.build, presetId: 'n54' };
+    const s = reducer(loaded, { type: ACTIONS.SET_BOOST_SEL, value: 6 });
+    expect(s.build.boostSel).toBe(6);
+    expect(s.build.presetId).toBe('n54');
+  });
+
+  it('opening the overwrite prompt does not disown the preset', () => {
+    const loaded = makeInitialState();
+    loaded.build = { ...loaded.build, presetId: 'n54' };
+    const s = reducer(loaded, { type: ACTIONS.SET_PRESET_PROMPT, value: { presetId: 'k20' } });
+    expect(s.build.presetPrompt).toEqual({ presetId: 'k20' });
+    expect(s.build.presetId).toBe('n54');
+  });
+});
+
+describe('SET_ENGINE_CONFIG_PATCH', () => {
+  it('patching the engine config merges and invalidates', () => {
+    const loaded = makeInitialState();
+    loaded.build = { ...loaded.build, presetId: 'n54' };
+    const s = reducer(loaded, { type: ACTIONS.SET_ENGINE_CONFIG_PATCH, patch: { cylinders: 8 } });
+    // `cylinders` is not a real EngineConfig field (it's `configuration`, e.g. 'V6') —
+    // deliberately used here per the plan's verbatim test code, to prove the merge
+    // lands whatever key the patch carries rather than asserting anything about
+    // EngineConfig's real shape.
+    // @ts-expect-error intentionally patching a non-EngineConfig key, see above
+    expect(s.build.engineConfig.cylinders).toBe(8);
+    expect(s.build.presetId).toBeNull();
+  });
+
+  it('preserves the config fields the patch does not mention', () => {
+    // A patch that REPLACES rather than merges would silently drop bore, stroke and
+    // every other untouched field — the app would still render, just wrongly.
+    const loaded = makeInitialState();
+    const boreBefore = loaded.build.engineConfig.bore;
+    const s = reducer(loaded, { type: ACTIONS.SET_ENGINE_CONFIG_PATCH, patch: { cylinders: 8 } });
+    expect(s.build.engineConfig.bore).toBe(boreBefore);
+  });
+});
+
+describe('APPLY_PRESET', () => {
+  const preset = {
+    presetId: 'n54', engineConfig: { cylinders: 6 }, mods: { intake: true },
+    turboOn: true, boostCurve: [8, 8, 8, 8, 8, 8, 8, 8], turbineIdx: 1,
+    turbineCount: 2, compressorIdx: 1, injIdx: 2, ecuInjectorCc: 440,
+    octaneIdx: 1, exhaustDiaIdx: 2, ve: [[80]], timing: [[20]], afr: [[12]],
+  };
+
+  it('ends with the preset LOADED, not invalidated', () => {
+    // The ordering hazard this whole design removes: applying a preset writes the same
+    // fields a hand edit would, and a hand edit clears presetId. Done as 21 separate
+    // setState calls that is order-dependent; done as one action it cannot race.
+    const s = reducer(makeInitialState(), { type: ACTIONS.APPLY_PRESET, preset });
+    expect(s.build.presetId).toBe('n54');
+  });
+
+  it('loads the preset\'s own calibration, not a recomputed one', () => {
+    const s = reducer(makeInitialState(), { type: ACTIONS.APPLY_PRESET, preset });
+    expect(s.tune.timing).toEqual([[20]]);
+  });
+
+  it('leaves the tables clean — a freshly loaded preset is not unsaved work', () => {
+    const dirty = { ...makeInitialState() };
+    dirty.tune = { ...dirty.tune, tablesDirty: true };
+    const s = reducer(dirty, { type: ACTIONS.APPLY_PRESET, preset });
+    expect(s.tune.tablesDirty).toBe(false);
+  });
+
+  it('clears the previous run, which measured a different engine', () => {
+    const ran = { ...makeInitialState() };
+    ran.session = { ...ran.session, result: { peakHp: 400 }, prevResult: { peakHp: 380 } };
+    const s = reducer(ran, { type: ACTIONS.APPLY_PRESET, preset });
+    expect(s.session.result).toBeNull();
+    expect(s.session.prevResult).toBeNull();
+  });
+
+  it('carries the twin-turbo count a preset owns', () => {
+    const s = reducer(makeInitialState(), { type: ACTIONS.APPLY_PRESET, preset });
+    expect(s.build.turbineCount).toBe(2);
+  });
+
+  it('clears any pending overwrite prompt and cell selection', () => {
+    const s = reducer(makeInitialState(), { type: ACTIONS.APPLY_PRESET, preset });
+    expect(s.build.presetPrompt).toBeNull();
+    expect(s.tune.selection).toBeNull();
+  });
+
+  it('pins the MAF scalar back to neutral, because the preset\'s AFR already bakes in its own correction', () => {
+    const dragged = { ...makeInitialState() };
+    dragged.build = { ...dragged.build, mafScalar: 0.8 };
+    const s = reducer(dragged, { type: ACTIONS.APPLY_PRESET, preset });
+    expect(s.build.mafScalar).toBe(1.0);
+  });
+});
+
+describe('RESET_TO_STOCK', () => {
+  it('clears the preset label, because a reset is not that preset\'s calibration', () => {
+    const loaded = { ...makeInitialState() };
+    loaded.build = { ...loaded.build, presetId: 'n54' };
+    const s = reducer(loaded, { type: ACTIONS.RESET_TO_STOCK, ve: [[70]] });
+    expect(s.build.presetId).toBeNull();
+  });
+
+  it('ends with the tables CLEAN — a reset baseline is not unsaved player work', () => {
+    // The old code achieved this by ordering setTablesDirty(false) last, after three
+    // invalidating setters that each set it true. As one action there is no order to get
+    // wrong.
+    const dirty = { ...makeInitialState() };
+    dirty.tune = { ...dirty.tune, tablesDirty: true };
+    const s = reducer(dirty, { type: ACTIONS.RESET_TO_STOCK, ve: [[70]] });
+    expect(s.tune.tablesDirty).toBe(false);
+  });
+
+  it('uses the caller-supplied VE rather than recomputing one', () => {
+    const s = reducer(makeInitialState(), { type: ACTIONS.RESET_TO_STOCK, ve: [[70]] });
+    expect(s.tune.ve).toEqual([[70]]);
+  });
+
+  it('strips mods and MAF trim back to stock', () => {
+    const modded = { ...makeInitialState() };
+    modded.build = { ...modded.build, mods: { intake: true, exhaust: true, headers: false, intercooler: false }, mafScalar: 0.85 };
+    const s = reducer(modded, { type: ACTIONS.RESET_TO_STOCK, ve: [[70]] });
+    expect(s.build.mods).toEqual({ intake: false, exhaust: false, headers: false, intercooler: false });
+    expect(s.build.mafScalar).toBe(1.0);
+  });
+
+  it('leaves session untouched by reference — a reset is not a dyno result', () => {
+    const before = makeInitialState();
+    const after = reducer(before, { type: ACTIONS.RESET_TO_STOCK, ve: [[70]] });
+    expect(after.session).toBe(before.session);
+  });
+});
+
+describe('REPAIR_ENGINE', () => {
+  it('restores every component to full health', () => {
+    const worn = { ...makeInitialState() };
+    worn.session = { ...worn.session, health: { piston: 40, bearing: 55, valve: 70 } };
+    const s = reducer(worn, { type: ACTIONS.REPAIR_ENGINE });
+    expect(s.session.health).toEqual({ piston: 100, bearing: 100, valve: 100 });
+  });
+
+  it('leaves build and tune untouched by reference', () => {
+    const before = makeInitialState();
+    const after = reducer(before, { type: ACTIONS.REPAIR_ENGINE });
+    expect(after.build).toBe(before.build);
+    expect(after.tune).toBe(before.tune);
+  });
+});
+
+describe('BANK_PULL', () => {
+  // Mirrors the tail of doRun (EcuLab.jsx:868-896): a completed dyno pull's result
+  // rotates into prevResult, the engine wears by the pull's own wear figures, and the
+  // career score/pull count advance — all in one pass instead of six ordered setState
+  // calls where getting `setPrevResult(result)` before `setResult(r)` backwards would
+  // silently corrupt prevResult.
+  const result = { peakHp: 410, wear: { piston: 3, bearing: 2, valve: 1 } };
+
+  it('rotates the previous result into prevResult and installs the new one', () => {
+    const ran = { ...makeInitialState() };
+    ran.session = { ...ran.session, result: { peakHp: 380 } };
+    const s = reducer(ran, { type: ACTIONS.BANK_PULL, result, pullScore: 50 });
+    expect(s.session.prevResult).toEqual({ peakHp: 380 });
+    expect(s.session.result).toBe(result);
+  });
+
+  it('wears the engine by the pull\'s own wear figures', () => {
+    const s = reducer(makeInitialState(), { type: ACTIONS.BANK_PULL, result, pullScore: 50 });
+    expect(s.session.health).toEqual({ piston: 97, bearing: 98, valve: 99 });
+  });
+
+  it('does not wear health below zero', () => {
+    const worn = { ...makeInitialState() };
+    worn.session = { ...worn.session, health: { piston: 2, bearing: 100, valve: 100 } };
+    const s = reducer(worn, { type: ACTIONS.BANK_PULL, result, pullScore: 50 });
+    expect(s.session.health.piston).toBe(0);
+  });
+
+  it('raises bestScore only when the new pull beats it', () => {
+    const withBest = { ...makeInitialState() };
+    withBest.session = { ...withBest.session, bestScore: 80 };
+    const lower = reducer(withBest, { type: ACTIONS.BANK_PULL, result, pullScore: 50 });
+    expect(lower.session.bestScore).toBe(80);
+    const higher = reducer(withBest, { type: ACTIONS.BANK_PULL, result, pullScore: 95 });
+    expect(higher.session.bestScore).toBe(95);
+  });
+
+  it('accumulates totalScore and increments pullCount', () => {
+    const withHistory = { ...makeInitialState() };
+    withHistory.session = { ...withHistory.session, totalScore: 100, pullCount: 2 };
+    const s = reducer(withHistory, { type: ACTIONS.BANK_PULL, result, pullScore: 50 });
+    expect(s.session.totalScore).toBe(150);
+    expect(s.session.pullCount).toBe(3);
+  });
+
+  it('leaves build and tune untouched by reference', () => {
+    const before = makeInitialState();
+    const after = reducer(before, { type: ACTIONS.BANK_PULL, result, pullScore: 50 });
+    expect(after.build).toBe(before.build);
+    expect(after.tune).toBe(before.tune);
+  });
+});

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -10,8 +10,58 @@
 import { describe, expect, it } from 'vitest';
 
 import { DEFAULT_AFR, DEFAULT_MODS, DEFAULT_TIMING } from '../../../src/sim/index.js';
+import { applyPreset, ENGINE_PRESETS } from '../../../src/sim/presets.js';
 import { makeInitialState } from '../../../src/ui/state/initialState.js';
 import { ACTIONS, reducer } from '../../../src/ui/state/reducer.js';
+
+/**
+ * A state where EVERY field of EVERY slice holds a value no real APPLY_PRESET write
+ * could ever produce: a string built from the field's own `slice.field` name. The
+ * field list comes from `makeInitialState()`'s own output keys, not a hand-maintained
+ * list, so a field added to a slice in a later PR is swept automatically.
+ *
+ * Because each sentinel is a fresh string unique to its own field, no real preset
+ * value — a number, an array, a plain object, `null`, a boolean, ANY type the 21 real
+ * writes use — can ever equal it. That makes a single strict `!==` check exact for
+ * "did the reducer touch this field", for every field type in play, with no deep-
+ * equality helper needed: the starting value is never deep-equal to a real written
+ * value by construction, and a field the reducer does not touch keeps the identical
+ * string reference through the object spread, so `!==` cannot false-positive either.
+ * @returns {any} an object shaped like StoreState, but not typed as one — every field
+ *   deliberately holds a sentinel string instead of a value of its real type.
+ */
+function makeSentinelState() {
+  const init = makeInitialState();
+  const state = /** @type {any} */ ({});
+  for (const slice of Object.keys(init)) {
+    const sliceState = /** @type {any} */ ({});
+    for (const field of Object.keys(/** @type {any} */ (init)[slice])) {
+      sliceState[field] = `SENTINEL::${slice}.${field}`;
+    }
+    state[slice] = sliceState;
+  }
+  return state;
+}
+
+/**
+ * The `slice.field` keys whose value differs between two sentinel-seeded state trees,
+ * via strict `!==`. See {@link makeSentinelState} for why reference/value inequality
+ * alone is exact here for every field type.
+ * @param {any} before
+ * @param {any} after
+ * @returns {Set<string>}
+ */
+function changedFieldKeys(before, after) {
+  const changed = new Set();
+  for (const slice of Object.keys(before)) {
+    for (const field of Object.keys(before[slice])) {
+      if (before[slice][field] !== after[slice][field]) {
+        changed.add(`${slice}.${field}`);
+      }
+    }
+  }
+  return changed;
+}
 
 /**
  * A complete, real engineConfig (BMW N54 figures — src/sim/presets.js) so this file's
@@ -379,6 +429,68 @@ describe('APPLY_PRESET', () => {
     dragged.build = { ...dragged.build, mafScalar: 0.8 };
     const s = reducer(dragged, { type: ACTIONS.APPLY_PRESET, preset });
     expect(s.build.mafScalar).toBe(1.0);
+  });
+});
+
+describe('APPLY_PRESET — exact write surface (catches drift in both directions)', () => {
+  // Round 1 found 14/21 fields deletable with the suite green; round 2's hardcoded
+  // `boostSel: 3` sailed through the table-driven fix at 65/65. Both survived because
+  // the old test only compared a hand-built map against the local fixture's own key
+  // set — never against what the reducer actually writes. This test instead seeds
+  // EVERY field of EVERY slice with a sentinel a real write can never produce, dispatches
+  // for real, and asserts the walked set of changed fields against the 21-field
+  // contract this action documents: a stray write grows the changed set past 21, a
+  // dropped write shrinks it below 21, and the failure message names the field either
+  // way.
+  it('changes exactly the 21 documented fields — no more, no fewer', () => {
+    const before = makeSentinelState();
+    const after = reducer(before, { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
+    const changed = changedFieldKeys(before, after);
+
+    const expected = [
+      'build.engineConfig', 'build.mods', 'build.turboOn', 'build.boostCurve',
+      'build.turbineIdx', 'build.turbineCount', 'build.compressorIdx', 'build.injIdx',
+      'build.ecuInjectorCc', 'build.octaneIdx', 'build.exhaustDiaIdx', 'build.mafScalar',
+      'build.presetId', 'build.presetPrompt',
+      'tune.ve', 'tune.timing', 'tune.afr', 'tune.tablesDirty', 'tune.selection',
+      'session.result', 'session.prevResult',
+    ];
+
+    expect([...changed].sort()).toEqual([...expected].sort());
+  });
+});
+
+describe('APPLY_PRESET — payload contract stays in sync with sim/presets.js', () => {
+  // The 15 payload-carried fields must be read from applyPreset()'s REAL return value,
+  // not the local fixture: if presets.js grows a 16th field tomorrow and the reducer
+  // is not updated to copy it into the store, nothing before this test would notice —
+  // the fixture and the map would happily agree with each other while both silently
+  // ignore the new field.
+  it('copies every key the real applyPreset() returns into the store', () => {
+    const rawPreset = ENGINE_PRESETS[0];
+    const payload = applyPreset(rawPreset);
+    const payloadKeys = Object.keys(payload);
+    // Sanity: fail loudly (not with a vacuous pass) if applyPreset()'s shape ever
+    // collapses to nothing.
+    expect(payloadKeys.length).toBeGreaterThan(0);
+
+    const before = makeSentinelState();
+    const after = reducer(before, {
+      type: ACTIONS.APPLY_PRESET, preset: /** @type {any} */ (payload),
+    });
+
+    // A key is "copied" if it landed, BY THE SAME NAME, in whichever slice actually
+    // received it — we don't hardcode which slice each key belongs to, we just look
+    // for the exact value applyPreset() produced. Starting from an all-sentinel state
+    // means there is no way for this to pass by coincidence: a field the reducer
+    // doesn't copy is still sitting at its sentinel, which can never equal a real
+    // payload value.
+    const missing = payloadKeys.filter((key) => (
+      after.build[key] !== /** @type {any} */ (payload)[key]
+      && after.tune[key] !== /** @type {any} */ (payload)[key]
+    ));
+
+    expect(missing).toEqual([]);
   });
 });
 

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -9,7 +9,11 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { DEFAULT_AFR, DEFAULT_MODS, DEFAULT_TIMING } from '../../../src/sim/index.js';
+import {
+  clone2D, COMPRESSOR_OPTS, computeHardwareVE, DEFAULT_AFR, DEFAULT_BOOST,
+  DEFAULT_ENGINE_CONFIG, DEFAULT_MODS, DEFAULT_TIMING, deriveEngine, INJECTOR_OPTS,
+  OCTANE_OPTS,
+} from '../../../src/sim/index.js';
 import { applyPreset, ENGINE_PRESETS } from '../../../src/sim/presets.js';
 import { makeInitialState } from '../../../src/ui/state/initialState.js';
 import { ACTIONS, reducer } from '../../../src/ui/state/reducer.js';
@@ -634,6 +638,90 @@ describe('REPAIR_ENGINE', () => {
     const after = reducer(before, { type: ACTIONS.REPAIR_ENGINE });
     expect(after.build).toBe(before.build);
     expect(after.tune).toBe(before.tune);
+  });
+});
+
+describe('LIVE_STEP and LIVE_PATCH', () => {
+  // These were the only two actions with no reducer-level tests. `session-store.test.jsx`
+  // covers them through the running engine, which is the coverage that matters most, but
+  // it cannot express the reference-identity contract precisely — and that contract is
+  // the whole reason LIVE_STEP has an early return.
+
+  /** @returns {*} a state whose engine is running, so LIVE_STEP has something to do */
+  function running() {
+    const s = makeInitialState();
+    s.session = { ...s.session, live: { ...s.session.live, running: true, rpm: 900 } };
+    return s;
+  }
+
+  /**
+   * The live config the app feeds the loop, built from the same sim exports EcuLab
+   * uses. Assembled from real values rather than stubbed: `liveStep` destructures
+   * fourteen fields off it and asserts the boost curve's shape, so a hand-made stub
+   * would be testing a shape the app never passes.
+   * @returns {*}
+   */
+  function liveCfg() {
+    const cfg = DEFAULT_ENGINE_CONFIG;
+    const derived = deriveEngine(cfg);
+    const ve = computeHardwareVE(cfg, DEFAULT_MODS);
+    return {
+      ve, veTruth: ve, timing: clone2D(DEFAULT_TIMING), afr: clone2D(DEFAULT_AFR),
+      derived, fuel: OCTANE_OPTS[0], injectorCc: INJECTOR_OPTS[0].cc,
+      ecuInjectorCc: INJECTOR_OPTS[0].cc, mods: DEFAULT_MODS, mafScalar: 1.0,
+      mafErrorBase: 1.0, turboOn: false, boostCurve: [...DEFAULT_BOOST],
+      octaneBonus: 0, turbine: null, compressor: COMPRESSOR_OPTS[0],
+      exhaustDiaError: 0,
+    };
+  }
+
+  const step = {
+    type: ACTIONS.LIVE_STEP, dt: 0.05,
+    input: { throttle: 0, load: 0 }, cfg: liveCfg(),
+  };
+
+  it('returns the IDENTICAL state object when the engine is stopped', () => {
+    // Not "an equal object" — the same one. This action arrives 20 times a second for
+    // as long as the app is open, engine running or not. Object.is equality is what
+    // makes React bail out of the whole StoreProvider subtree; return a fresh object
+    // and every one of those ticks re-renders the entire app for nothing.
+    const before = makeInitialState();
+    expect(reducer(before, step)).toBe(before);
+  });
+
+  it('integrates the engine when it is running', () => {
+    const before = running();
+    const after = reducer(before, step);
+    expect(after.session.live).not.toBe(before.session.live);
+    expect(after.session.live.elapsed).toBeGreaterThan(before.session.live.elapsed);
+  });
+
+  it('leaves build and tune untouched while integrating', () => {
+    // The live engine reads the calibration but must never write it.
+    const before = running();
+    const after = reducer(before, step);
+    expect(after.build).toBe(before.build);
+    expect(after.tune).toBe(before.tune);
+  });
+
+  it('LIVE_PATCH merges rather than replacing', () => {
+    // START/STOP were `setLive((p) => ({ ...p, running: X }))`. Carrying a whole new
+    // live object instead would rewind every field the patch omits — coolant, trims,
+    // knock count — back to whatever the caller happened to capture.
+    const before = running();
+    const after = reducer(before, { type: ACTIONS.LIVE_PATCH, patch: { running: false } });
+    expect(after.session.live.running).toBe(false);
+    expect(after.session.live.rpm).toBe(before.session.live.rpm);
+    expect(after.session.live.coolantC).toBe(before.session.live.coolantC);
+  });
+
+  it('neither action disowns a loaded preset', () => {
+    // Running the engine is not a build edit.
+    const before = running();
+    before.build = { ...before.build, presetId: 'n54' };
+    expect(reducer(before, step).build.presetId).toBe('n54');
+    expect(reducer(before, { type: ACTIONS.LIVE_PATCH, patch: { running: false } })
+      .build.presetId).toBe('n54');
   });
 });
 

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -2,15 +2,38 @@
  * Reducer tests — pure, no DOM.
  *
  * The reducer exists so that operations spanning several slices happen in ONE pass.
- * EcuLab's applyEnginePreset makes 23 sequential setState calls and its own comment
+ * EcuLab's applyEnginePreset makes 21 sequential setState calls and its own comment
  * warns the order matters; resetToStock documents that "the last call pins tablesDirty
  * back to false". Those hazards are what this file exists to make impossible.
  */
 
 import { describe, expect, it } from 'vitest';
 
+import { DEFAULT_AFR, DEFAULT_MODS, DEFAULT_TIMING } from '../../../src/sim/index.js';
 import { makeInitialState } from '../../../src/ui/state/initialState.js';
 import { ACTIONS, reducer } from '../../../src/ui/state/reducer.js';
+
+/**
+ * A complete, real engineConfig (BMW N54 figures — src/sim/presets.js) so this file's
+ * APPLY_PRESET fixtures typecheck as a genuine EngineConfig, not just a configuration
+ * stub. Declared with an explicit type annotation below (not an "as" cast) so
+ * `configuration` narrows to the engine-layout literal union instead of widening to
+ * plain string.
+ * @type {import('../../../src/sim/index.js').EngineConfig}
+ */
+const N54_ENGINE_CONFIG = {
+  configuration: 'I6', bore: 84.0, stroke: 89.6, compression: 10.2,
+  blockMaterial: 'Aluminum', headMaterial: 'Aluminum',
+};
+
+/** Shared APPLY_PRESET fixture: every field the action's `preset` payload carries. */
+const N54_PRESET = {
+  presetId: 'n54', engineConfig: N54_ENGINE_CONFIG,
+  mods: { intake: false, exhaust: false, headers: false, intercooler: true },
+  turboOn: true, boostCurve: [8, 8, 8, 8, 8, 8, 8, 8], turbineIdx: 1,
+  turbineCount: 2, compressorIdx: 1, injIdx: 2, ecuInjectorCc: 440,
+  octaneIdx: 1, exhaustDiaIdx: 2, ve: [[80]], timing: [[20]], afr: [[12]],
+};
 
 describe('makeInitialState', () => {
   it('returns the three slices', () => {
@@ -104,7 +127,12 @@ describe('SET_TABLE', () => {
 describe('unknown actions', () => {
   it('returns the same state object, so React skips the re-render', () => {
     const before = makeInitialState();
-    expect(reducer(before, { type: 'NOT_A_REAL_ACTION' })).toBe(before);
+    // Deliberately outside the known-action union (see the StoreAction JSDoc in
+    // reducer.js) — this test exercises the default branch's fallback for an action
+    // shape the reducer does not recognize, so the cast is intentional, not a leak of
+    // the removed catch-all.
+    const bogus = /** @type {any} */ ({ type: 'NOT_A_REAL_ACTION' });
+    expect(reducer(before, bogus)).toBe(before);
   });
 });
 
@@ -183,6 +211,41 @@ describe('every write produces a fresh slice reference', () => {
     expect(after.tune).not.toBe(before.tune);
     expect(before.tune.selection).toBeNull(); // the input state is untouched
   });
+
+  // Finding 7: the tests above only ever assert `toBe` on slices an action LEAVES
+  // ALONE — the inverse property. None of the cross-cutting actions asserted a fresh
+  // reference for the slice(s) they actually WRITE, so an action that mutated a slice
+  // in place instead of replacing it would pass every existing test here.
+  it('APPLY_PRESET replaces build, tune AND session rather than mutating them', () => {
+    const before = makeInitialState();
+    const after = reducer(before, { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
+    expect(after.build).not.toBe(before.build);
+    expect(after.tune).not.toBe(before.tune);
+    expect(after.session).not.toBe(before.session);
+  });
+
+  it('RESET_TO_STOCK replaces build and tune rather than mutating them', () => {
+    const before = makeInitialState();
+    const after = reducer(before, { type: ACTIONS.RESET_TO_STOCK, ve: [[70]] });
+    expect(after.build).not.toBe(before.build);
+    expect(after.tune).not.toBe(before.tune);
+  });
+
+  it('REPAIR_ENGINE replaces session rather than mutating it', () => {
+    const before = makeInitialState();
+    const after = reducer(before, { type: ACTIONS.REPAIR_ENGINE });
+    expect(after.session).not.toBe(before.session);
+  });
+
+  it('BANK_PULL replaces session rather than mutating it', () => {
+    const before = makeInitialState();
+    const after = reducer(before, {
+      type: ACTIONS.BANK_PULL,
+      result: { peakHp: 410, wear: { piston: 3, bearing: 2, valve: 1 } },
+      pullScore: 50,
+    });
+    expect(after.session).not.toBe(before.session);
+  });
 });
 
 describe('non-invalidating build writes', () => {
@@ -227,12 +290,43 @@ describe('SET_ENGINE_CONFIG_PATCH', () => {
 });
 
 describe('APPLY_PRESET', () => {
-  const preset = {
-    presetId: 'n54', engineConfig: { configuration: 'I6' }, mods: { intake: true },
-    turboOn: true, boostCurve: [8, 8, 8, 8, 8, 8, 8, 8], turbineIdx: 1,
-    turbineCount: 2, compressorIdx: 1, injIdx: 2, ecuInjectorCc: 440,
-    octaneIdx: 1, exhaustDiaIdx: 2, ve: [[80]], timing: [[20]], afr: [[12]],
+  const preset = N54_PRESET;
+
+  // Finding 1: every field the preset carries must land in the RIGHT slice. Deleting
+  // any one of these from the reducer's APPLY_PRESET case must fail this test by
+  // naming the missing field — that is the point of iterating rather than spot-
+  // checking a handful of fields. The key-set assertion at the end means a 22nd field
+  // added to the fixture without a matching map entry fails LOUDLY too, so this table
+  // cannot silently drift out of date the way the hand-picked assertions above did.
+  const presetFieldSlice = {
+    presetId: 'build',
+    engineConfig: 'build',
+    mods: 'build',
+    turboOn: 'build',
+    boostCurve: 'build',
+    turbineIdx: 'build',
+    turbineCount: 'build',
+    compressorIdx: 'build',
+    injIdx: 'build',
+    ecuInjectorCc: 'build',
+    octaneIdx: 'build',
+    exhaustDiaIdx: 'build',
+    ve: 'tune',
+    timing: 'tune',
+    afr: 'tune',
   };
+
+  it('maps every fixture field to a slice — the map cannot drift out of date', () => {
+    expect(Object.keys(presetFieldSlice).sort()).toEqual(Object.keys(preset).sort());
+  });
+
+  it.each(Object.entries(presetFieldSlice))(
+    'lands preset field %s in the %s slice',
+    (field, slice) => {
+      const s = reducer(makeInitialState(), { type: ACTIONS.APPLY_PRESET, preset });
+      expect(s[slice][field]).toEqual(preset[field]);
+    },
+  );
 
   it('ends with the preset LOADED, not invalidated', () => {
     // The ordering hazard this whole design removes: applying a preset writes the same
@@ -268,7 +362,14 @@ describe('APPLY_PRESET', () => {
   });
 
   it('clears any pending overwrite prompt and cell selection', () => {
-    const s = reducer(makeInitialState(), { type: ACTIONS.APPLY_PRESET, preset });
+    // Finding 2: makeInitialState() already starts with both fields null, so
+    // dispatching against a bare initial state proves nothing — the reducer could
+    // drop these two writes entirely and this would still pass. Seed non-null
+    // starting values so the assertions below have something to actually clear.
+    const seeded = { ...makeInitialState() };
+    seeded.build = { ...seeded.build, presetPrompt: { id: 'k20' } };
+    seeded.tune = { ...seeded.tune, selection: { type: 'cell', row: 0, col: 0 } };
+    const s = reducer(seeded, { type: ACTIONS.APPLY_PRESET, preset });
     expect(s.build.presetPrompt).toBeNull();
     expect(s.tune.selection).toBeNull();
   });
@@ -316,6 +417,55 @@ describe('RESET_TO_STOCK', () => {
     const before = makeInitialState();
     const after = reducer(before, { type: ACTIONS.RESET_TO_STOCK, ve: [[70]] });
     expect(after.session).toBe(before.session);
+  });
+
+  // Finding 3: DEFAULT_TIMING/DEFAULT_AFR are NOT Object.freeze'd (unlike DEFAULT_MODS
+  // and DEFAULT_ENGINE_CONFIG — see src/sim/tables.js). clone2D is load-bearing here:
+  // handing back the module-level constant directly would let any future in-place
+  // table edit corrupt the shared default for the rest of the session, and every later
+  // reset would then return the already-corrupted table. toEqual alone cannot catch
+  // that regression because a bare DEFAULT_TIMING is also toEqual DEFAULT_TIMING.
+  it('clones timing and afr rather than returning the shared module-level defaults', () => {
+    const s = reducer(makeInitialState(), { type: ACTIONS.RESET_TO_STOCK, ve: [[70]] });
+    expect(s.tune.timing).toEqual(DEFAULT_TIMING);
+    expect(s.tune.timing).not.toBe(DEFAULT_TIMING);
+    expect(s.tune.afr).toEqual(DEFAULT_AFR);
+    expect(s.tune.afr).not.toBe(DEFAULT_AFR);
+  });
+
+  // Finding 1's table-driven approach applied here too: the reviewer found that
+  // deleting `timing`/`afr` from this case entirely still left the suite green,
+  // because no test started from a value that differed from the reset target. Every
+  // field below is seeded to a WRONG value first, same fix as Finding 2's
+  // presetPrompt/selection seeding — RESET_TO_STOCK does not touch presetPrompt or
+  // selection at all (only EcuLab's hand-edit setters do), so there is nothing
+  // "equivalent" to clear there; this is the field-coverage analogue instead. One
+  // seeded starting state, one assertion per field RESET_TO_STOCK owns — deleting any
+  // one of these from the reducer case leaves that field at its seeded WRONG value and
+  // fails this test by naming it.
+  it('resets every field it owns, starting from values that all differ from the target', () => {
+    const dirty = { ...makeInitialState() };
+    dirty.build = {
+      ...dirty.build,
+      mods: { intake: true, exhaust: true, headers: true, intercooler: true },
+      mafScalar: 0.7,
+      presetId: 'n54',
+    };
+    dirty.tune = {
+      ...dirty.tune,
+      ve: [[999]],
+      timing: [[999]],
+      afr: [[999]],
+      tablesDirty: true,
+    };
+    const s = reducer(dirty, { type: ACTIONS.RESET_TO_STOCK, ve: [[70]] });
+    expect(s.build.mods).toEqual(DEFAULT_MODS);
+    expect(s.build.mafScalar).toBe(1.0);
+    expect(s.build.presetId).toBeNull();
+    expect(s.tune.ve).toEqual([[70]]);
+    expect(s.tune.timing).toEqual(DEFAULT_TIMING);
+    expect(s.tune.afr).toEqual(DEFAULT_AFR);
+    expect(s.tune.tablesDirty).toBe(false);
   });
 });
 

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -207,13 +207,8 @@ describe('SET_ENGINE_CONFIG_PATCH', () => {
   it('patching the engine config merges and invalidates', () => {
     const loaded = makeInitialState();
     loaded.build = { ...loaded.build, presetId: 'n54' };
-    const s = reducer(loaded, { type: ACTIONS.SET_ENGINE_CONFIG_PATCH, patch: { cylinders: 8 } });
-    // `cylinders` is not a real EngineConfig field (it's `configuration`, e.g. 'V6') —
-    // deliberately used here per the plan's verbatim test code, to prove the merge
-    // lands whatever key the patch carries rather than asserting anything about
-    // EngineConfig's real shape.
-    // @ts-expect-error intentionally patching a non-EngineConfig key, see above
-    expect(s.build.engineConfig.cylinders).toBe(8);
+    const s = reducer(loaded, { type: ACTIONS.SET_ENGINE_CONFIG_PATCH, patch: { compression: 11.5 } });
+    expect(s.build.engineConfig.compression).toBe(11.5);
     expect(s.build.presetId).toBeNull();
   });
 
@@ -221,15 +216,19 @@ describe('SET_ENGINE_CONFIG_PATCH', () => {
     // A patch that REPLACES rather than merges would silently drop bore, stroke and
     // every other untouched field — the app would still render, just wrongly.
     const loaded = makeInitialState();
-    const boreBefore = loaded.build.engineConfig.bore;
-    const s = reducer(loaded, { type: ACTIONS.SET_ENGINE_CONFIG_PATCH, patch: { cylinders: 8 } });
-    expect(s.build.engineConfig.bore).toBe(boreBefore);
+    const before = loaded.build.engineConfig;
+    const s = reducer(loaded, { type: ACTIONS.SET_ENGINE_CONFIG_PATCH, patch: { compression: 11.5 } });
+    const after = s.build.engineConfig;
+    expect(after.bore).toBe(before.bore);
+    expect(after.stroke).toBe(before.stroke);
+    expect(after.configuration).toBe(before.configuration);
+    expect(after.redline).toBe(before.redline);
   });
 });
 
 describe('APPLY_PRESET', () => {
   const preset = {
-    presetId: 'n54', engineConfig: { cylinders: 6 }, mods: { intake: true },
+    presetId: 'n54', engineConfig: { configuration: 'I6' }, mods: { intake: true },
     turboOn: true, boostCurve: [8, 8, 8, 8, 8, 8, 8, 8], turbineIdx: 1,
     turbineCount: 2, compressorIdx: 1, injIdx: 2, ecuInjectorCc: 440,
     octaneIdx: 1, exhaustDiaIdx: 2, ve: [[80]], timing: [[20]], afr: [[12]],

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -1,0 +1,161 @@
+/**
+ * Reducer tests — pure, no DOM.
+ *
+ * The reducer exists so that operations spanning several slices happen in ONE pass.
+ * EcuLab's applyEnginePreset makes 23 sequential setState calls and its own comment
+ * warns the order matters; resetToStock documents that "the last call pins tablesDirty
+ * back to false". Those hazards are what this file exists to make impossible.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { makeInitialState } from '../../../src/ui/state/initialState.js';
+import { ACTIONS, reducer } from '../../../src/ui/state/reducer.js';
+
+describe('makeInitialState', () => {
+  it('returns the three slices', () => {
+    const s = makeInitialState();
+    expect(Object.keys(s).sort()).toEqual(['build', 'session', 'tune']);
+  });
+
+  it('starts with no preset loaded and clean tables', () => {
+    const s = makeInitialState();
+    expect(s.build.presetId).toBeNull();
+    expect(s.tune.tablesDirty).toBe(false);
+  });
+
+  it('returns a fresh object each call, not a shared reference', () => {
+    // A shared initial state would let one test's mutation leak into the next, and
+    // one player's reset leak into their next build.
+    const a = makeInitialState();
+    const b = makeInitialState();
+    expect(a).not.toBe(b);
+    expect(a.tune.ve).not.toBe(b.tune.ve);
+  });
+});
+
+describe('SET_BUILD_FIELD', () => {
+  it('sets the field', () => {
+    const s = reducer(makeInitialState(), {
+      type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: true,
+    });
+    expect(s.build.turboOn).toBe(true);
+  });
+
+  it('clears the preset label, because a hand edit is no longer that preset', () => {
+    const loaded = { ...makeInitialState() };
+    loaded.build = { ...loaded.build, presetId: 'n54' };
+    const s = reducer(loaded, {
+      type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: true,
+    });
+    expect(s.build.presetId).toBeNull();
+  });
+
+  it('does not flag the calibration tables as dirty', () => {
+    // Hardware edits invalidate the preset LABEL only. tablesDirty means unsaved
+    // player work on the calibration, and is what the overwrite prompt keys off.
+    const s = reducer(makeInitialState(), {
+      type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: true,
+    });
+    expect(s.tune.tablesDirty).toBe(false);
+  });
+
+  it('leaves the other slices untouched by reference', () => {
+    const before = makeInitialState();
+    const after = reducer(before, {
+      type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: true,
+    });
+    expect(after.session).toBe(before.session);
+  });
+});
+
+describe('SET_TURBINE', () => {
+  it('fits one of the chosen housing, because a twin-turbo count belongs to a preset', () => {
+    const twin = { ...makeInitialState() };
+    twin.build = { ...twin.build, turbineIdx: 2, turbineCount: 2 };
+    const s = reducer(twin, { type: ACTIONS.SET_TURBINE, value: 1 });
+    expect(s.build.turbineIdx).toBe(1);
+    expect(s.build.turbineCount).toBe(1);
+  });
+});
+
+describe('SET_TABLE', () => {
+  it('sets the table', () => {
+    const next = [[1, 2], [3, 4]];
+    const s = reducer(makeInitialState(), {
+      type: ACTIONS.SET_TABLE, table: 'timing', value: next,
+    });
+    expect(s.tune.timing).toBe(next);
+  });
+
+  it('clears the preset AND flags the tables dirty, in one pass', () => {
+    // This is the cross-slice write that three independent contexts could not express
+    // atomically: a table edit invalidates a BUILD field and a TUNE field together.
+    const loaded = { ...makeInitialState() };
+    loaded.build = { ...loaded.build, presetId: 'n54' };
+    const s = reducer(loaded, {
+      type: ACTIONS.SET_TABLE, table: 'timing', value: [[1]],
+    });
+    expect(s.build.presetId).toBeNull();
+    expect(s.tune.tablesDirty).toBe(true);
+  });
+});
+
+describe('unknown actions', () => {
+  it('returns the same state object, so React skips the re-render', () => {
+    const before = makeInitialState();
+    expect(reducer(before, { type: 'NOT_A_REAL_ACTION' })).toBe(before);
+  });
+});
+
+// The two cases below are not in the plan's verbatim test listing, but SET_SESSION_FIELD
+// and SET_TUNE_FIELD are both part of the "implement at minimum" set for this task and
+// need their own coverage — a test suite that only exercises three of five action types
+// would not catch a broken fourth.
+describe('SET_SESSION_FIELD', () => {
+  it('sets the field', () => {
+    const s = reducer(makeInitialState(), {
+      type: ACTIONS.SET_SESSION_FIELD, field: 'running', value: true,
+    });
+    expect(s.session.running).toBe(true);
+  });
+
+  it('leaves build and tune untouched by reference', () => {
+    const before = makeInitialState();
+    const after = reducer(before, {
+      type: ACTIONS.SET_SESSION_FIELD, field: 'running', value: true,
+    });
+    expect(after.build).toBe(before.build);
+    expect(after.tune).toBe(before.tune);
+  });
+});
+
+describe('SET_TUNE_FIELD', () => {
+  it('sets the field', () => {
+    const s = reducer(makeInitialState(), {
+      type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value: { type: 'cell', row: 1, col: 2 },
+    });
+    expect(s.tune.selection).toEqual({ type: 'cell', row: 1, col: 2 });
+  });
+
+  it('does NOT clear the preset or flag the tables dirty', () => {
+    // Unlike SET_TABLE, a plain tune-slice write (e.g. changing which cell is
+    // selected) is not a calibration edit and must not invalidate anything.
+    const loaded = { ...makeInitialState() };
+    loaded.build = { ...loaded.build, presetId: 'n54' };
+    const s = reducer(loaded, {
+      type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value: { type: 'row', row: 0 },
+    });
+    expect(s.build.presetId).toBe('n54');
+    expect(s.tune.tablesDirty).toBe(false);
+  });
+
+  it('leaves the other slices untouched by reference', () => {
+    const before = makeInitialState();
+    const after = reducer(before, {
+      type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value: null,
+    });
+    expect(after.build).toBe(before.build);
+    expect(after.session).toBe(before.session);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,5 +30,6 @@
     "tests",
     "scripts"
   ],
-  "exclude": ["node_modules", "dist", "ECULab.jsx"]
+  "//exclude": "`exclude` only filters `include` — it does not stop tsc following an import. EcuLab.jsx is kept out of typechecking by a `@ts-nocheck` directive at the top of the file itself, not from here.",
+  "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
     "src/ui/theme.js",
     "src/ui/primitives",
     "src/ui/screens",
+    "src/ui/state",
     "src/storage.js",
     "src/version.js",
     "src/globals.d.ts",


### PR DESCRIPTION
PR 2 of the UI overhaul. Moves 34 pieces of domain state out of `src/ui/EcuLab.jsx` into a reducer-backed store so that PR 3 can split the component into screens. **Nothing observable changes.**

`useState` in `EcuLab.jsx`: **41 → 7**.

Closes #58. Part of #6.

## Why this exists

`EcuLab.jsx` is one 2,300-line component holding all of the app's state. Nothing can be lifted out of it until that state has somewhere else to live, so this blocks PR 3. The render is deliberately untouched — splitting screens *and* moving state in one diff produces something nobody can review.

## What moved

A single reducer over one state tree, sliced three ways, in `src/ui/state/`:

| Slice | Fields | What it owns |
|---|---|---|
| `build` | 15 | Hardware and ECU config a factory preset owns |
| `tune` | 5 | VE / spark / fuel tables, `tablesDirty`, grid selection |
| `session` | 14 | Dyno results, career score, wear, live engine, onboarding |

Consumed through `useBuild()`, `useTune()`, `useSession()` from `StoreProvider.jsx`, mounted at the module boundary inside `EcuLab.jsx` so `<EcuLab />` stays self-contained and a test renders the same single store the browser does.

Fifteen actions, each with a typedef: `SET_BUILD_FIELD`, `CLEAR_PRESET_ID`, `SET_TURBINE`, `SET_TABLE`, `SET_SESSION_FIELD`, `SET_TUNE_FIELD`, `SET_BOOST_SEL`, `SET_PRESET_PROMPT`, `SET_ENGINE_CONFIG_PATCH`, `APPLY_PRESET`, `RESET_TO_STOCK`, `REPAIR_ENGINE`, `BANK_PULL`, `LIVE_STEP`, `LIVE_PATCH`.

**Deviation from the issue, on purpose.** #58 proposed three separate contexts. This is one reducer with three slices and three hooks. Three independent contexts cannot express the cross-slice writes atomically — `APPLY_PRESET` writes build, tune *and* session in one pass, and doing that across three providers reintroduces exactly the ordering hazard described below. The consumer-facing API is the three hooks the issue asked for.

## What deliberately did not move

The **7 remaining `useState`** are all view state: `appView`, `tab`, `buildSection`, `tuneView`, `dynoView`, `dashSection`, plus `open` inside `ExpandableInfo`. PR 3 absorbs these into routing, so extracting them now is work PR 3 would immediately undo.

## The ordering hazard this removes

`applyEnginePreset` was **21 consecutive local setter calls** that had to run in a specific order, with a comment explaining that it must bypass the invalidating wrappers because "routing its own writes through `setPresetId(null)` would make that order-dependent on React's batching". That is not a bug that was documented — it is a bug that is now *impossible*: `APPLY_PRESET` is one reducer pass producing one next state. Same for `RESET_TO_STOCK`, `BANK_PULL` (which rotated `result` into `prevResult` across two setters), and the `clearPresetId`-then-`setTablesDirty` pair that every table edit used to make by hand and is now the single `SET_TABLE` action.

`withPresetField` and `withTableEdit` — wrappers each new field had to remember to be threaded through — are gone; the reducer invalidates.

## Why you can believe it preserves behaviour

**The characterisation tests were written first and never edited.** They landed in Task 1, *before* any state moved, pinning the real flows through the real component. They stayed green through all six state-moving tasks, and the file is byte-identical to its post-review Task 1 state:

```
$ git rev-parse 663197c:tests/ui/characterisation.test.jsx   # Task 1, final
47131efd0d975662bbf2223a69138bf70e044aff
$ git rev-parse HEAD:tests/ui/characterisation.test.jsx
47131efd0d975662bbf2223a69138bf70e044aff
```

**The physics never moved.** No file under `src/sim/`, `tests/fixtures/` or `tests/fingerprint.test.js` is touched:

```
$ git diff origin/main --stat -- tests/fixtures/ tests/fingerprint.test.js src/sim/
(no output)
```

The fingerprint test is green on this branch, unregenerated.

**No dependency changed.**

```
$ git diff origin/main -- package.json
(no output)
```

**The render is unchanged.** Extracting the JSX element sequence from `EcuLab.jsx` before and after and diffing it yields exactly one addition: the `<StoreProvider><EcuLabApp /></StoreProvider>` shell. No element added, removed or reordered anywhere else. What changed inside the elements is the callbacks: local setters became dispatches.

**522 tests passing**, 105 of them new across five files: 71 reducer unit tests, 13 session-store, 9 build-store, 8 characterisation, 4 provider.

`src/ui/state/` is added to `tsconfig.json`'s `include`, so the store and its action typedefs are typechecked. `KnownStoreAction` deliberately omits a catch-all member, so a typo'd payload key fails `tsc` instead of silently no-op'ing at runtime. `EcuLab.jsx` itself keeps its pre-existing `@ts-nocheck`.

## Verification

Run on Node v22.23.2. Every command exited 0.

```
$ npm test
 Test Files  21 passed (21)
      Tests  528 passed (528)

$ npm run lint       # eslint .            → 0
$ npm run typecheck  # tsc --noEmit        → 0
$ npm run build      # vite build          → 0, built in 3.75s
```

Rebased onto `origin/main` (`e01f2a7`) — already the merge-base, nothing to replay, no conflicts.

## Also in this PR

A small sweep of comment-only findings deferred during the work: `initialState.js`'s header no longer claims its defaults are "copied verbatim" from `useState` initialisers that no longer exist; two `reducer.js` typedefs no longer name `setEngineConfigInvalidating` / `setPrevResult` / `setResult` as if they were live code; `throttleInput` is documented as percent rather than `0..1` (every call site writes 0 or 100 and `liveStep` clamps to `0..100` — the comment was the wrong half); and `T.panelHi`, a dead alias for `tokens.panel3` deferred from PR 1, is deleted.

## A final break sweep, after every task review had passed

With all seven tasks reviewed and green, I went back and deleted things at random to see what the suite would notice. It caught the BANK_PULL ordering hazard, a cursor action wrongly disowning a preset, LIVE_PATCH overwriting instead of merging, and the LIVE_STEP bailout. It did **not** catch this:

**Deleting the `persistCareer()` call from `doRun` left all 169 UI tests green.** The session plays perfectly, HOME shows the right figures straight from the store — and the player's career is gone at the next refresh. That call had been flagged as a hazard twice during this PR and confirmed correct both times. Nobody checked that a regression would be caught. Verifying that code is correct is not the same as verifying it is pinned.

It now has a test that runs a real pull and reads the career back through the storage adapter, guarding its setup so a pull that silently failed to run cannot let it pass on zeroes.

Also added: reducer-level tests for `LIVE_STEP` and `LIVE_PATCH`, the only two actions that had none. They are well covered through the running engine, but that cannot express the contract precisely — `LIVE_STEP` must return the **identical** state object when the engine is stopped, not merely an equal one, because `Object.is` is what makes React bail out of the whole provider subtree 20 times a second.

Writing those caught a mistake of mine: I passed `input: 0` where the action carries `{throttle, load}`. `KnownStoreAction` rejected it — the catch-all removal doing exactly what it was added for.

## Known gaps — please read before approving

**1. No single test spans hand-edit → `tablesDirty` → overwrite prompt end to end.** Moving `tablesDirty` into the store made a one-test version of that impossible. It is now covered in three pieces across two files: characterisation test 2 proves a real UI table edit reaches `SET_TABLE`; a reducer test proves `SET_TABLE` sets the flag; `build-store.test.jsx` proves the flag opens the prompt. The chain is complete but no longer proven by a single execution. The now-inert hand-edit block in that test's setup is what keeps its preconditions realistic — please do not tidy it away.

**2. Everything here is jsdom.** The live engine, the audio synth, the animations and the reveal timer are exercised only as far as the suites reach. **Nobody has loaded this in a real browser during this PR.** A manual smoke test before merge is worth the five minutes.

**3. Left undone deliberately: `LivePatchAction.patch` and `LiveStepAction.cfg` are still typed `object`,** as is `SessionState.live`. So `dispatch({type: LIVE_PATCH, patch: {crankign: true}})` typechecks and the reducer spreads the typo into `live`. A real `LiveState` typedef would close all three, and I judged it too big to do well here: the shape's authority is `src/sim/live.js`, which this PR may not touch, so the typedef would have to be mirrored in the UI layer and would drift. It is also not a flat 21-field record — `liveStep` adds four more fields (`prevRpm`, `effThrottle`, `closedLoop`, `lope`) that a fresh state does not have, so it needs optionality decisions plus `Partial<>` on the patch, and it bottoms out in `s.live = pt`, an `evaluatePoint` result that would need its own typedef or reintroduce the same hole one level down. The right fix is a `LiveState` typedef exported from `src/sim/live.js` in its own change. `KnownStoreAction`'s value is weakened by this, not defeated — the other fourteen action shapes are fully typed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd

