### PR TITLE
Release v1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ecu-lab",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ecu-lab",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "lucide-react": "^0.460.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecu-lab",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "An engine management and tuning simulator. Design an engine, edit the same three calibration tables a real tuner edits, run a dyno pull, and read a log that explains what went right or wrong.",
   "keywords": [
     "engine",

--- a/src/version.js
+++ b/src/version.js
@@ -5,4 +5,4 @@
  * GENERATED — do not edit by hand. Run `npm version <patch|minor|major>`, which
  * rewrites this file from package.json via scripts/sync-version.js.
  */
-export const BUILD_VERSION = 'v1.4.0';
+export const BUILD_VERSION = 'v1.5.0';


### PR DESCRIPTION
Cuts **v1.5.0**. The branch itself is a single commit — a version bump across
`package.json`, `package-lock.json` and `src/version.js`. Everything else in this release
is already on `main`.

Closes #72.

## What the tag will actually capture

Issue #72's changelog was generated when this branch was cut, **before PR #71 merged**, so
it lists 26 commits and describes the design system alone. That undersells it. The tag
goes on the merge commit on `main`, and `main` now carries PR #71 as well:

- **PR 1 — the design system** (#57): the azure token layer as one source of truth, nine
  UI primitives, every colour in the UI routed through tokens, and the first responsive
  breakpoints.
- **PR 2 — the state refactor** (#71): 34 pieces of domain state moved out of
  `EcuLab.jsx` into a reducer-backed store. No observable behaviour change.
- Shared-stewardship docs (#56), and two release-workflow fixes (#51, #52).

**59 commits since v1.4.0**, of which 31 landed after this branch was cut.

## Verification

Merged into current `main` on a scratch branch and run there, so this is the tree the tag
would point at — not the release branch in isolation.

```
$ node --version      → v22.23.2
$ npm test            → 21 files, 528 tests passed
                        (tests/fingerprint.test.js green, never regenerated)
$ npm run lint        → 0
$ npm run typecheck   → 0
$ npm run build       → 0, built in 3.66s
```

- Merges into `main` with **no conflicts**.
- `scripts/sync-version.js` reports `src/version.js` already correct — the three version
  files agree.
- The built bundle carries `v1.5.0`, so the start screen and header will report the build
  a tester is actually running.
- `v1.4.0` is the current latest tag, so `v1.5.0` is the correct next one.

## After merging

The merge publishes nothing. The tag is what deploys — `.github/workflows/deploy.yml`
fires on `push: tags: ['v*']`.

```bash
git checkout main && git pull
git tag v1.5.0 && git push origin v1.5.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd
