### PR TITLE
Adopt the design system EcuLab still ignores (#74)

### DIFF
--- a/docs/superpowers/plans/2026-08-21-adopt-design-system.md
+++ b/docs/superpowers/plans/2026-08-21-adopt-design-system.md
@@ -233,12 +233,18 @@ git commit -m "Use the Panel primitive, dropping styles that restated its own lo
 **Two defects in the primitive itself, found while planning. Fix these FIRST — migrating
 before you do would ship an accessibility regression on ten tiles.**
 
-Measured against `panel2` (`#1a2130`), the surface every StatTile sits on:
+**Correction to an earlier draft of this section:** I first measured these against
+`panel2`, the *local copy's* background. The primitive's `.tile` is `var(--panel)`
+(`#131824`), so those are the numbers that matter. The conclusion is unchanged — the label
+still fails AA — but the figures below are the correct ones.
 
-| Element | Local copy | Primitive | Ratio | Needs |
+| Element | Local copy (on panel2) | Primitive (on **panel**) | Verdict | Needs |
 |---|---|---|---|---|
-| `.label` (~9.5px, **small text**) | `T.ink2` 5.14:1 | `--ink3` **2.87:1** | **FAILS AA** | 4.5:1 |
-| `.acc .value` (24px, large text) | `T.accInk` 8.69:1 | `--acc` 5.86:1 | passes | 3:1 |
+| `.label` (~9.5px, **small text**) | `T.ink2` 5.14:1 | `--ink3` **3.17:1** | **FAILS AA** | 4.5:1 |
+| `.acc .value` (large text) | `T.accInk` 8.69:1 | `--acc` 6.46:1 | passes | 3:1 |
+
+With `.label` on `--ink2` the primitive measures 5.67:1, and `.acc .value` on `--acc-ink`
+measures 9.57:1.
 
 1. **`.label` must not use `--ink3`.** At 2.87:1 it fails WCAG AA for small text; the copy
    it replaces passed at 5.14:1. Change `.label` to `var(--ink2)`. This is the same class

--- a/docs/superpowers/plans/2026-08-21-adopt-design-system.md
+++ b/docs/superpowers/plans/2026-08-21-adopt-design-system.md
@@ -746,6 +746,58 @@ animation: running ? `cylpulse ${dur}s ${i * (0.5 / cylinders)}s ease-in-out inf
 Confirm the console warning is gone afterwards. This is pre-existing, not something this PR
 introduced — say so in the PR body rather than implying otherwise.
 
+- [ ] **Step 2c: Finish the `T.ok` sweep — and tell the two kinds apart**
+
+Task 7 removed `T.ok` from START ENGINE because green there was decoration: the button
+reads START precisely when the engine is **off**, so the status colour reported the
+opposite of the state. That same judgement was not applied to the steppers, and the
+review caught the inconsistency.
+
+`grep` finds five sites. **They are not all the same thing, and the difference is the
+whole point of the rule:**
+
+| Line | Expression | Verdict |
+|---|---|---|
+| `:374` | `d < 0 ? T.accInk : T.ok` | **decoration** — a pending edit's sign |
+| `:1618` | `d < 0 ? T.accInk : T.ok` | **decoration** — same, boost editor |
+| `:1992` | `dHp > 0 ? T.ok : T.dangerInk` | **status** — this pull made more power than the last |
+| `:1993` | `dTq > 0 ? T.ok : T.dangerInk` | **status** |
+| `:1994` | `dKnock < 0 ? T.ok : T.dangerInk` | **status** — less knock is genuinely better |
+
+Raising a VE cell by one is not *good*; it is just positive. The stepper is showing a sign,
+and painting a sign green teaches the player that green means nothing in particular —
+which is what makes them ignore it when `:1992` uses it to say something real.
+
+Fix `:374` and `:1618`. **Leave `:1992`-`:1994` alone** — a delta against the previous pull
+is a verdict, and that is exactly what the status scale is for. Use `T.inkSoft` or the
+`accInk`/`ink2` pairing already in use; state what you chose.
+
+Check the file for any other `T.ok`/`T.warn`/`T.danger` used for something that is not a
+judgement, and report what you find rather than assuming these five are all of them.
+
+- [ ] **Step 2d: Three more hand-rolled `Panel` duplicates, and one Panel fighting itself**
+
+Beyond `:2246`, `grep` finds `:1773` and `:1777` (both `panel2` + a `line` border + radius 10
++ `11px 13px`, which is `<Panel tight>`), and `:360` (radius 9). Convert what genuinely is a
+panel; leave anything that only shares one property, and say which you left.
+
+Separately, `EcuLab.jsx:1096` is `<Panel style={{ background: T.panel, marginBottom: 10 }}>`
+— it overrides the primitive's own surface, which is most of what `Panel` is. Task 2
+classified two such sites as deliberate "recessed" treatments. Decide whether this one is
+the same intent or a leftover, and say which.
+
+- [ ] **Step 2e: The `quiet` variant is too quiet**
+
+`Button`'s `quiet` uses `--ink3` and measures **2.87-3.47:1** depending on surface — below
+AA for its 10.5px size. `RESET ALL TO STOCK` went from 6.21:1 to 3.47:1 when it adopted the
+variant, so this task doubled the blast radius of a primitive-level problem.
+
+Raise `quiet` to `--ink2` and re-measure every place it is used. This is the same class of
+defect Task 3 fixed in `StatTile` — a token chosen for hierarchy without checking it
+against the surface it lands on — so **add the assertion beside `StatTile`'s**, using the
+contrast helper that already exists in `tests/ui/readouts.test.jsx`, rather than fixing it
+silently.
+
 - [ ] **Step 3: Confirm every duplicate is gone**
 
 ```bash
@@ -779,6 +831,25 @@ git fetch origin
 git rebase origin/main
 ```
 A pre-rebase green says nothing about the post-rebase tree. Re-run step 4 in full.
+
+- [ ] **Step 6b: Write down what this PR deliberately did not do**
+
+These came out of the task reviews and belong to #59, which rebuilds the shell. The PR body
+should name them so they are handed over rather than lost:
+
+1. **The app has no content width cap.** Nothing in `EcuLab.jsx`, `index.html` or
+   `tokens.css` sets a `max-width`; the root is `height: 100dvh` with unconstrained width,
+   so every container *is* the viewport. This is the actual root of "buttons span the whole
+   screen" — and it is why `Button`'s `block` prop ships with **zero adopters**: using it
+   anywhere today reproduces the complaint. #59 must add the cap first; three or four sites
+   then become honest `block` candidates.
+2. **Two hand-rolled disclosures want a primitive.** `ExpandableInfo` and `BuildSection`
+   are both expand/collapse rows, and **neither carries `aria-expanded`** — the state is
+   conveyed only by a rotated chevron, so a screen-reader user cannot tell open from shut.
+3. **`Seg` needs two things before three more call sites can adopt it:** a stacked
+   (icon-over-label) layout for the TUNE sub-tabs, and a badge slot for the DYNO sub-tabs'
+   unread dot. Both groups are `Seg` in all but name today.
+4. **The sound toggle has no `aria-pressed`**, and its accessible name is the glyph `♪`/`✕`.
 
 - [ ] **Step 7: Open the PR**
 

--- a/docs/superpowers/plans/2026-08-21-adopt-design-system.md
+++ b/docs/superpowers/plans/2026-08-21-adopt-design-system.md
@@ -230,6 +230,53 @@ git commit -m "Use the Panel primitive, dropping styles that restated its own lo
 **Interfaces:**
 - Produces: `StatTile`'s `tone="alt"`; `statusTone(v)` exported from `src/ui/theme.js`.
 
+**Two defects in the primitive itself, found while planning. Fix these FIRST — migrating
+before you do would ship an accessibility regression on ten tiles.**
+
+Measured against `panel2` (`#1a2130`), the surface every StatTile sits on:
+
+| Element | Local copy | Primitive | Ratio | Needs |
+|---|---|---|---|---|
+| `.label` (~9.5px, **small text**) | `T.ink2` 5.14:1 | `--ink3` **2.87:1** | **FAILS AA** | 4.5:1 |
+| `.acc .value` (24px, large text) | `T.accInk` 8.69:1 | `--acc` 5.86:1 | passes | 3:1 |
+
+1. **`.label` must not use `--ink3`.** At 2.87:1 it fails WCAG AA for small text; the copy
+   it replaces passed at 5.14:1. Change `.label` to `var(--ink2)`. This is the same class
+   of defect PR 1's own review found when RUN DYNO PULL rendered at 1.14:1 — a token
+   chosen for hierarchy without checking it against the surface it lands on.
+
+2. **`.acc .value` should use `var(--acc-ink)`, not `var(--acc)`.** Every call site passes
+   `T.accInk` today. `accInk` is the readable-on-dark variant and exists for exactly this;
+   `--acc` is the interactive accent. Using it here both dims the figure (8.69 → 5.86)
+   and spends the interactive colour on something that is not interactive — the rule this
+   PR enforces, in its quieter form. Compare `Note`, which correctly uses `warnInk` for
+   text on a warn surface.
+
+Both are primitive-level fixes with primitive-level tests, and they belong here because
+this is the task that first puts `StatTile` on screen. Add a contrast assertion so neither
+can regress:
+
+```js
+it('keeps the label readable on the surface it sits on', () => {
+  // ~9.5px is small text: WCAG AA wants 4.5:1. This failed at 2.87:1 with --ink3,
+  // which is a hierarchy token, not a legibility one.
+  expect(Number(contrast(tokens.ink2, tokens.panel2))).toBeGreaterThanOrEqual(4.5);
+});
+```
+
+**There is no contrast helper in this repo** — I checked. PR 1's contrast findings, including
+the 1.14:1 one, were all caught by human review, which is exactly why this pair survived
+into a shipped primitive. Write a small one in the test file you are already editing:
+relative luminance per WCAG, then `(lighter + 0.05) / (darker + 0.05)`. Roughly fifteen
+lines.
+
+Keep it to the two pairs this task needs. Sweeping every token combination in the design
+system is a real and worthwhile job, but it is not this task — if you notice other failing
+pairs while you are in there, **report them rather than fixing them**, and they will be
+triaged.
+
+---
+
 All ten call sites pass a raw `color`. The primitive takes a semantic `tone` of `neutral|acc|ok|warn|danger`. Three of the ten cannot be expressed:
 
 ```

--- a/docs/superpowers/plans/2026-08-21-adopt-design-system.md
+++ b/docs/superpowers/plans/2026-08-21-adopt-design-system.md
@@ -1,0 +1,667 @@
+# Adopt the Design System (PR 3a) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `src/ui/EcuLab.jsx` use the nine primitives PR 1 built for it, delete the eight duplicate components it still defines instead, and fix the four findings PR 1's review carried forward — all inside one file, with no structural movement.
+
+**Architecture:** Pure substitution. Each task swaps one duplicate component for its primitive across every call site, deletes the copy, and runs the behavioural suites. The render stays monolithic; splitting it into screens is #59.
+
+**Tech Stack:** React 18, CSS Modules, Vitest + @testing-library/react, JSDoc types checked by `tsc --checkJs`. No new dependencies.
+
+## Global Constraints
+
+- **Node 20 or 22 only — never 26.** `.nvmrc` pins 22. Newer V8 shifts float results and invalidates the fingerprint hash.
+- **`tests/fingerprint.test.js` must stay green and must NEVER be regenerated.** Never run `npm run test:fingerprint:update`.
+- **No changes to `src/sim/`, `tests/fixtures/`, `package.json` or `package-lock.json`.**
+- **No new dependencies.**
+- **`tests/ui/characterisation.test.jsx` must stay byte-identical and green.** It has been unchanged since it was written and pins the flows this PR touches.
+- In `tests/ui/build-store.test.jsx` and `tests/ui/session-store.test.jsx`, setup may change if a migration genuinely invalidates a precondition; **assertions may not.**
+- `src/ui/EcuLab.jsx` carries `@ts-nocheck`; `src/ui/primitives/`, `src/ui/state/` and `tests/` ARE typechecked. `npm run typecheck` must exit 0.
+- No vitest globals and no setup file: import every helper explicitly from `vitest`; component tests call `afterEach(cleanup)`; jsdom is opt-in via `// @vitest-environment jsdom` as the literal first line.
+- ESLint `no-undef` and `no-unused-vars` are active; `npm run lint` must exit 0. Deleting a component orphans its imports — expect lint to catch that and fix it in the same task.
+- **NEVER run a bare `git stash` in this repo.** `node_modules` is tracked as a self-referential symlink; stashing deletes the real installed directory and breaks vitest and tsc. Use `cp` to a scratch path.
+- `git status` permanently shows ` D node_modules`. **Never stage it.** `git add` explicit paths only, never `git add -A`.
+- macOS: BSD `sed` has no `\b`. Prefer explicit edits over `sed` on this file.
+- Capture exit codes on the line **after** the command, never after a pipe.
+- Branch is `feat/74-adopt-design-system`. Never commit to `main`.
+- Every commit message ends with the repo's `Co-Authored-By:` and `Claude-Session:` trailers.
+
+## The rule this PR is enforcing
+
+PR 1 established it and this file still breaks it in three places:
+
+> **The accent is never a status, and a status is never decoration.**
+
+A status colour (`ok`/`warn`/`danger`) means something is healthy, marginal or wrong. Using one because it looks nice — a chart series, a stepper button — teaches the player to ignore it, which is exactly when a real alarm stops working.
+
+## What this PR is NOT
+
+Not the screen split. Not routing. Not the sidebar shell. The component stays one file and the render does not move. That is #59, and it depends on this landing first.
+
+## The visual-regression problem, stated up front
+
+The behavioural suites pin behaviour, not pixels. **Nothing in this repo catches a visual regression, and nobody has loaded the app in a browser during the overhaul.** Every task here changes how something looks.
+
+Two mitigations, both mandatory:
+
+1. **One primitive per commit.** A reviewer can hold "did Panel's 15 sites survive" in their head; they cannot hold "did 100 substitutions survive".
+2. **Every deliberate visual change gets recorded in the task's report** — not just the ones this plan predicts. If a migration changes spacing, weight, or colour anywhere, say so. An unrecorded visual change is indistinguishable from a mistake at review time.
+
+## Known deliberate visual changes
+
+These are intended. Anything else you find is a finding.
+
+| Where | Change | Why |
+|---|---|---|
+| Intercooler toggle | loses its cyan switch, becomes accent like every other toggle | `Toggle` has no `color` prop, and a series colour decorating one control is the rule above being broken |
+| AFR + timing chart series | `T.ok`/`T.warn` → `T.cyan`/`T.violet` | permanent chart lines must not wear alarm colours |
+| Duty-cycle preview | inline bands → `Bar` with `higherIsBetter={false}` | deletes the second copy of `utilisationColor`'s thresholds |
+
+## Primitive APIs (verified against `src/ui/primitives/` on `main`)
+
+```
+Button   ({ children, variant='primary'|'ghost'|'danger'|'quiet', size='md', block=false, type='button', ...rest })
+Panel    ({ children, tight=false, as='div', ...rest })          // rest spreads onto the element
+Eyebrow  ({ children, icon })
+Note     ({ children, tone='info'|'warn'|'danger' })
+StatTile ({ label, value, unit, tone='neutral'|'acc'|'ok'|'warn'|'danger' })
+Bar      ({ label, value, max=100, higherIsBetter=true })
+Seg      ({ label, options: [{id,label,icon?}], value, onChange, equal=false })
+Select   ({ label, groups: [{label, options:[{value,label}]}], extra=[], value, onChange })
+Toggle   ({ label, sub, checked, onChange })
+```
+
+## Call-site inventory (measured on `main`, `3544b11`)
+
+| Duplicate in EcuLab.jsx | Primitive | Sites | Complication |
+|---|---|---|---|
+| `Eyebrow` (:59) | `Eyebrow` | 11 | none — identical shape |
+| `Note` (:73) | `Note` | 8 | none — primitive adds a `danger` tone the copy lacked |
+| `Panel` (:67) | `Panel` | 15 | **14 pass `style`** |
+| `StatTile` (:194) | `StatTile` | 10 | all 10 pass `color`; enum has no value for 3 of them |
+| `HealthBar` (:203) | `Bar` | 3 | plus 2 inline duty-band copies to fold in |
+| `Seg` (:103) | `Seg` | 8 | `{value,label}` → `{id,label}`; 1 passes `wrap` |
+| `GroupedSelect` (:145) | `Select` | 1 | needs an accessible `label` |
+| `ToggleRow` (:180) | `Toggle` | 2 | 1 passes `color={T.cyan}` |
+| raw `<button>` | `Button` | 34 | 15 carry `width: '100%'` |
+
+`PickList` (:121, 2 sites) has **no** primitive equivalent and stays. Do not invent one.
+
+---
+
+### Task 1: Eyebrow and Note — prove the pattern
+
+**Files:**
+- Modify: `src/ui/EcuLab.jsx`
+
+**Interfaces:**
+- Consumes: `Eyebrow`, `Note` from `src/ui/primitives/`.
+- Produces: the migration pattern every later task repeats.
+
+These two are first because their shapes are identical to the copies, so nothing but the import changes. If a suite goes red here, the problem is the harness, not the migration — sort that out before Task 2 rather than debugging it under a real transform.
+
+- [ ] **Step 1: Confirm the shapes really are identical**
+
+```bash
+sed -n '59,66p;73,83p' src/ui/EcuLab.jsx
+sed -n '/export function Eyebrow/,/^}/p' src/ui/primitives/Eyebrow.jsx
+sed -n '/export function Note/,/^}/p' src/ui/primitives/Note.jsx
+```
+
+`Note`'s copy handles `info` and `warn` and silently falls back to `info` for anything else. The primitive adds `danger` and puts `role="alert"` on it. No call site passes `danger` today, so this is additive — but check that claim rather than trusting it:
+
+```bash
+grep -n '<Note' src/ui/EcuLab.jsx | grep -c 'danger'
+```
+Expected: **0**.
+
+- [ ] **Step 2: Import the primitives and delete the copies**
+
+Add to the import block near the top of `EcuLab.jsx`:
+
+```jsx
+import { Eyebrow } from './primitives/Eyebrow.jsx';
+import { Note } from './primitives/Note.jsx';
+```
+
+Delete the local `const Eyebrow = ...` (:59-65) and `const Note = ...` (:73-83). Leave every call site untouched — that is the point of going first with these two.
+
+- [ ] **Step 3: Let lint find the orphans**
+
+```bash
+npm run lint > /tmp/lint.txt 2>&1; echo "EXIT=$?"
+```
+
+Deleting `Note` orphans the `Info` icon import from `lucide-react` if nothing else uses it. Check before removing it — `Info` may well appear elsewhere:
+
+```bash
+grep -n '<Info' src/ui/EcuLab.jsx
+```
+
+Remove only what is genuinely unused. Lint must exit 0.
+
+- [ ] **Step 4: Run the behavioural suites**
+
+```bash
+npx vitest run tests/ui/ > /tmp/t.txt 2>&1; echo "EXIT=$?"
+```
+Expected: PASS. `characterisation.test.jsx` must not be edited.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/EcuLab.jsx
+git commit -m "Use the Eyebrow and Note primitives instead of local copies"
+```
+
+---
+
+### Task 2: Panel — and the fourteen style overrides
+
+**Files:**
+- Modify: `src/ui/EcuLab.jsx`
+
+**Interfaces:**
+- Consumes: `Panel` from `src/ui/primitives/Panel.jsx`.
+
+The copy is `({children, style, tight})` and merges `...style` **last**, so a call site can override the panel's own background, border and radius. The primitive is `({children, tight, as, ...rest})` and sets its look in CSS — an inline `style` still wins, because inline beats a class.
+
+So the mechanical swap works. That is the trap: it works while leaving fourteen inline overrides in place, several of which exist only to restate what the panel already does. Migrating without reading them ships the duplication into #59, where it gets copied into fourteen screen files.
+
+- [ ] **Step 1: Read all fifteen call sites and classify each**
+
+```bash
+python3 - <<'PY'
+import re
+s = open('src/ui/EcuLab.jsx').read()
+for m in re.finditer(r'<Panel(?=[\s/>])', s):
+    i, depth = m.end(), 0
+    while i < len(s):
+        c = s[i]
+        if c == '{': depth += 1
+        elif c == '}': depth -= 1
+        elif c == '>' and depth == 0:
+            print(f"line {s[:m.start()].count(chr(10))+1}: {' '.join(s[m.start():i+1].split())}")
+            break
+        i += 1
+PY
+```
+
+Sort each `style` prop into one of three buckets and record the classification in your report:
+
+1. **Restates the panel's own look** (`background: T.panel2`, `border: 1px solid ${T.line}`, `borderRadius: 12`, the default padding) — **delete it.** The primitive already does this.
+2. **Layout the panel does not own** (`marginTop`, `flex`, `display`, `gap`, `minWidth`) — **keep it**, passed through `...rest`.
+3. **Deliberately different from the primitive** (a different background for emphasis, say) — **keep it, and say so in your report.** This is the bucket that hides real visual intent, so do not collapse one into bucket 1 because it looks close.
+
+- [ ] **Step 2: Import the primitive, delete the copy, apply the classification**
+
+```jsx
+import { Panel } from './primitives/Panel.jsx';
+```
+
+Delete the local `const Panel = ...` (:67-71). Apply your bucket decisions.
+
+- [ ] **Step 3: Verify nothing lost its box**
+
+A panel whose style you emptied should still render as a panel. Confirm the primitive's class is actually applied:
+
+```bash
+npx vitest run tests/ui/ > /tmp/t.txt 2>&1; echo "EXIT=$?"
+npm run lint > /tmp/l.txt 2>&1; echo "EXIT=$?"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ui/EcuLab.jsx
+git commit -m "Use the Panel primitive, dropping styles that restated its own look"
+```
+
+---
+
+### Task 3: StatTile — and the two tones the enum is missing
+
+**Files:**
+- Modify: `src/ui/primitives/StatTile.jsx`, `src/ui/primitives/StatTile.module.css`
+- Modify: `src/ui/theme.js`
+- Modify: `src/ui/EcuLab.jsx`
+- Test: `tests/ui/readouts.test.jsx` (holds `describe('StatTile')` and `describe('Bar')`), `tests/theme.test.js` (note: NOT under `tests/ui/`)
+
+**Interfaces:**
+- Produces: `StatTile`'s `tone="alt"`; `statusTone(v)` exported from `src/ui/theme.js`.
+
+All ten call sites pass a raw `color`. The primitive takes a semantic `tone` of `neutral|acc|ok|warn|danger`. Three of the ten cannot be expressed:
+
+```
+:1288  CAREER TOTAL  color={T.cyan}
+:1295  PEAK TORQUE   color={T.cyan}
+:2040  PEAK TQ       color={T.cyan}
+```
+
+Read those three in context before deciding anything. Each sits **beside** a figure in `T.accInk` — `PEAK WHP` next to `PEAK TQ`, `BEST PULL` next to `CAREER TOTAL`. The cyan is a *pairing* device: two related quantities, told apart at a glance. It is not a status and it is not arbitrary.
+
+`neutral` would erase the pairing. `acc` would erase it harder, by making both tiles identical.
+
+**Add a fifth tone, `alt`.** Name it for what it means — the second quantity in a paired readout — not for the colour it happens to use. Document it in the primitive's JSDoc as never being a status.
+
+The other two are dynamic:
+
+```
+:1299  TUNING     color={statusColor(scores.tuning.score)}
+:1300  ENGINEER   color={statusColor(scores.engineer.score)}
+```
+
+Do **not** inline the thresholds as `score >= 90 ? 'ok' : ...`. `theme.js` already warns that duplicated bands drift apart, and this PR exists partly to delete one such duplicate. Add a `statusTone` beside `statusColor`, deriving from the same comparison so the two cannot disagree.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/theme.test.js` — it already imports `T, heat, statusColor, utilisationColor`, so extend that import with `statusTone`:
+
+```js
+describe('statusTone', () => {
+  it('names the same band statusColor paints', () => {
+    // The point of having both is that a caller who needs a token and a caller who
+    // needs a semantic name cannot end up on different sides of a threshold.
+    const cases = [100, 95, 90, 89, 60, 55, 54, 20, 0];
+    const map = { ok: T.ok, warn: T.warn, danger: T.danger };
+    cases.forEach((v) => {
+      expect(map[statusTone(v)]).toBe(statusColor(v));
+    });
+  });
+
+  it('returns exactly the three status names', () => {
+    expect(new Set([100, 60, 10].map(statusTone))).toEqual(new Set(['ok', 'warn', 'danger']));
+  });
+});
+```
+
+Append to `describe('StatTile')` in `tests/ui/readouts.test.jsx`:
+
+```jsx
+it('gives the alt tone its own class, distinct from the partner it sits beside', () => {
+  // `alt` marks the second quantity in a paired readout — torque beside power. If it
+  // resolved to the same colour as its partner the pairing would be invisible, which
+  // is the whole reason the tone exists.
+  const { container } = render(<StatTile label="PEAK TQ" value={300} tone="alt" />);
+  expect(container.querySelector(`.${tileStyles.alt}`)).toBeTruthy();
+  expect(container.querySelector(`.${tileStyles.acc}`)).toBeNull();
+});
+```
+
+That follows the file's existing pattern — `applies the tone it is given` queries
+`` `.${tileStyles.warn}` `` off the imported stylesheet object rather than reading a hashed
+className off the DOM node. Use the same import that test uses.
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+npx vitest run tests/theme.test.js tests/ui/readouts.test.jsx > /tmp/t.txt 2>&1; echo "EXIT=$?"
+```
+Expected: FAIL — `statusTone is not defined`, and `tone="alt"` producing no distinct class.
+
+- [ ] **Step 3: Implement**
+
+In `src/ui/theme.js`, beside `statusColor`:
+
+```js
+/**
+ * The NAME of the band `statusColor` paints, for consumers that take a semantic tone
+ * rather than a colour — `StatTile`, and anything else with a token-driven variant.
+ *
+ * Derived from the same comparison as `statusColor` rather than repeating its
+ * thresholds, because two copies of a band drift apart and then disagree about
+ * whether the same number is a warning.
+ *
+ * @param {number} v 0-100
+ * @returns {'ok'|'warn'|'danger'}
+ */
+export const statusTone = (v) => (v >= 90 ? 'ok' : v >= 55 ? 'warn' : 'danger');
+```
+
+In `StatTile.module.css`, add an `.alt` rule using `var(--cyan)`. In `StatTile.jsx`, add `'alt'` to the tone union in the JSDoc and note what it is for.
+
+- [ ] **Step 4: Migrate the ten call sites**
+
+```
+color={T.accInk}                    → tone="acc"
+color={T.ink}                       → (drop it — neutral is the default)
+color={T.cyan}                      → tone="alt"
+color={statusColor(scores.x.score)} → tone={statusTone(scores.x.score)}
+```
+
+- [ ] **Step 5: Delete the copy and verify**
+
+Delete the local `function StatTile` (:194-201). Then:
+
+```bash
+npx vitest run tests/ui/ > /tmp/t.txt 2>&1; echo "EXIT=$?"
+npm run lint > /tmp/l.txt 2>&1; echo "EXIT=$?"
+npm run typecheck > /tmp/tc.txt 2>&1; echo "EXIT=$?"
+```
+
+`typecheck` matters here: `StatTile.jsx` is typechecked and you widened a union.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/theme.js src/ui/primitives/StatTile.jsx src/ui/primitives/StatTile.module.css src/ui/EcuLab.jsx tests/theme.test.js tests/ui/readouts.test.jsx
+git commit -m "Give StatTile a paired-quantity tone, and name the status bands once"
+```
+
+---
+
+### Task 4: Bar — and deleting the second copy of the duty bands
+
+**Files:**
+- Modify: `src/ui/EcuLab.jsx`
+- Modify: `src/ui/theme.js` (comment only)
+- Test: `tests/ui/readouts.test.jsx`
+
+**Interfaces:**
+- Consumes: `Bar` from `src/ui/primitives/Bar.jsx`, `utilisationColor` from `src/ui/theme.js`.
+
+Two different readouts collapse into one primitive here, and they point in opposite directions.
+
+`HealthBar` (3 sites) shows component wear: **high is good**, so `higherIsBetter` defaults to true and those sites need no extra prop.
+
+The injector duty preview is the opposite: **high is dangerous**. It is currently drawn inline, twice, with its own copy of the thresholds:
+
+```
+:312   const zoneColor = pct > 0.9 ? T.danger : pct > 0.75 ? T.warn : T.ok;   // 0-1 scale
+:1961  background: dutyPreview > 90 ? T.danger : dutyPreview > 75 ? T.warn : T.ok   // 0-100
+```
+
+`theme.js`'s `utilisationColor` carries exactly those bands and its docstring says, in as many words, that the inline copy must be changed together with it *until that panel moves onto `Bar`*. This is that moment. `Bar` already calls `utilisationColor` when `higherIsBetter={false}`.
+
+**Read `:312` before assuming it is the same thing.** It is on a 0-1 scale and belongs to `DialMark`, a gauge, not a bar. It may not be a `Bar` at all. If it is not, leave the markup alone but still route its colour through `utilisationColor(pct * 100)` so the thresholds live in one place — and say in your report which of the two you did and why.
+
+- [ ] **Step 1: Confirm `Bar` already has the direction right — do not add a test**
+
+`describe('Bar')` in `tests/ui/readouts.test.jsx` already pins this, in three tests better
+than one would be: `inverts the scale when a high value is the dangerous end`, `reads an
+ordinary duty cycle as healthy, not as an alarm` (60% duty must NOT be a warning), and
+`reads a duty cycle with no headroom left as dangerous`.
+
+Read them, satisfy yourself the primitive is correct, and move on. **Adding another
+direction test here would be duplicate coverage.** Note the pattern those tests use —
+`container.querySelector('[data-fill]')`, a data attribute rather than a hashed CSS Module
+class — if you need to query a fill anywhere.
+
+- [ ] **Step 2: Migrate the three HealthBar sites**
+
+```jsx
+import { Bar } from './primitives/Bar.jsx';
+```
+
+`<HealthBar label="Piston" value={health.piston} />` → `<Bar label="Piston" value={health.piston} />`.
+
+Delete the local `function HealthBar` (:203-216).
+
+- [ ] **Step 3: Move the duty preview onto Bar**
+
+Replace the hand-rolled bar at `:1961` with `<Bar label={...} value={dutyPreview} higherIsBetter={false} />`. Keep whatever surrounding text the panel has — only the bar itself moves.
+
+`:1963` colours a caption with `dutyPreview > 90 ? T.dangerInk : T.inkSoft`. That is a *third* copy of the 90 threshold. Route it through `utilisationColor` too, or leave it and say why in your report — but do not leave it unexamined.
+
+- [ ] **Step 4: Update theme.js's now-stale instruction**
+
+`utilisationColor`'s docstring tells the reader the inline copy exists and must be kept in sync. Once it does not, that comment is a lie that will send someone hunting. Rewrite it to say the bands now live here alone.
+
+- [ ] **Step 5: Verify the thresholds really are gone**
+
+```bash
+grep -n '> 90 ?\|> 75 ?\|> 0.9 ?\|> 0.75 ?' src/ui/EcuLab.jsx
+```
+Anything left must be deliberate and explained in your report.
+
+```bash
+npx vitest run tests/ui/ > /tmp/t.txt 2>&1; echo "EXIT=$?"
+npm run lint > /tmp/l.txt 2>&1; echo "EXIT=$?"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/EcuLab.jsx src/ui/theme.js tests/ui/readouts.test.jsx
+git commit -m "Move health and duty readouts onto Bar, deleting the duplicated bands"
+```
+
+---
+
+### Task 5: Seg and Select
+
+**Files:**
+- Modify: `src/ui/EcuLab.jsx`
+
+**Interfaces:**
+- Consumes: `Seg`, `Select` from `src/ui/primitives/`.
+
+`Seg`'s options shape changed and every one of the 8 sites needs a real transform:
+
+```
+copy:      options={[{ value, label }]}   value={selected}  onChange  wrap
+primitive: options={[{ id, label, icon? }]}  value={selected}  onChange  equal  label (REQUIRED)
+```
+
+`label` is new and mandatory — it is the group's accessible name, which the copy never had. **Do not pass a placeholder.** Each Seg is a real choice with a real name; read the surrounding markup and use the label the player already sees (the section heading, the field caption). A generic `label="options"` is worse than useless: it makes the a11y tree lie while looking done.
+
+Exactly one site passes `wrap` — the injector-size picker. That becomes `equal`, which is the primitive's name for the same intent (equal-width, wrapping).
+
+`GroupedSelect` → `Select` is a single site, the engine preset picker, and also needs a `label`.
+
+- [ ] **Step 1: List the sites and their real names**
+
+```bash
+grep -n '<Seg' src/ui/EcuLab.jsx
+grep -n '<GroupedSelect' src/ui/EcuLab.jsx
+```
+
+For each, read the enclosing block and write down the human name of the choice. Put that table in your report — a reviewer cannot check an accessible name they cannot see.
+
+- [ ] **Step 2: Migrate**
+
+The options transform is mechanical but must be done per site, because several build their options inline from a catalogue:
+
+```jsx
+// before
+<Seg options={OCTANE_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={...} onChange={...} />
+// after
+<Seg label="Fuel octane" options={OCTANE_OPTS.map((o) => ({ label: o.label, id: o.label }))} value={...} onChange={...} />
+```
+
+Delete the local `function Seg` (:103-119) and `function GroupedSelect` (:145-178).
+
+**`PickList` (:121) stays.** It has no primitive and this PR does not create one.
+
+- [ ] **Step 3: Verify the accessible names exist**
+
+The controls suite already covers `Seg` and `Select` in isolation. What is new is that `EcuLab` now passes real names, so check one end to end:
+
+```bash
+npx vitest run tests/ui/ > /tmp/t.txt 2>&1; echo "EXIT=$?"
+```
+
+`build-store.test.jsx` and `session-store.test.jsx` query several of these controls **by accessible name**. If a query breaks, the name you chose differs from what the test expects — that is a signal about your naming, not a reason to edit the test's assertions. Setup may adapt; assertions may not.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ui/EcuLab.jsx
+git commit -m "Move segmented pickers and the preset select onto the primitives"
+```
+
+---
+
+### Task 6: Toggle — and the intercooler's cyan switch
+
+**Files:**
+- Modify: `src/ui/EcuLab.jsx`
+
+Two sites. The turbo-kit toggle maps across unchanged. The intercooler passes `color={T.cyan}`, and `Toggle` has no `color` prop.
+
+**Drop the colour rather than adding the prop back.** `cyan` is a chart-series token. One toggle wearing it while every other toggle is accent is decoration borrowed from a colour that means something elsewhere — the rule this PR is enforcing. It is a real visual change: record it.
+
+- [ ] **Step 1: Migrate both sites**
+
+```jsx
+import { Toggle } from './primitives/Toggle.jsx';
+```
+
+`<ToggleRow label="Intercooler" sub="..." checked={mods.intercooler} onChange={...} color={T.cyan} />`
+→ `<Toggle label="Intercooler" sub="..." checked={mods.intercooler} onChange={...} />`
+
+Delete the local `function ToggleRow` (:180-192).
+
+- [ ] **Step 2: Check nothing queried the switch by its old shape**
+
+`ToggleRow` rendered an unlabelled `<button>`; `Toggle` is a `role="switch"` with an accessible name. Tests reaching the old shape through DOM traversal will need their **setup** updated — `tests/ui/build-store.test.jsx` has a `toggleFor(label)` helper that walks `parentElement.parentElement.querySelector('button')` precisely because the old one had no name.
+
+That helper can now be a plain `getByRole('switch', { name })`. Simplify it, keep every assertion, and note the change.
+
+```bash
+npx vitest run tests/ui/ > /tmp/t.txt 2>&1; echo "EXIT=$?"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/ui/EcuLab.jsx tests/ui/build-store.test.jsx
+git commit -m "Move toggles onto the Toggle primitive, dropping a borrowed series colour"
+```
+
+---
+
+### Task 7: Button — 34 raw buttons, 15 of them full-width
+
+**Files:**
+- Modify: `src/ui/EcuLab.jsx`
+
+The largest task, and the one where "it still renders" is least reassuring. Work in passes and commit between them.
+
+`Button` is **content-width by default with a `block` opt-in** — the opposite of the current default, which is why 15 buttons carry `width: '100%'`. That inversion is the point: PR 1's review found the app's most important control, RUN DYNO PULL, rendering its label at 1.14:1 contrast while running. Buttons that span the screen because nothing stopped them are the symptom.
+
+Variants: `primary` (the main action), `ghost` (secondary), `danger` (**destructive only** — not an emphasis variant), `quiet` (lowest weight, e.g. RESET ALL TO STOCK).
+
+- [ ] **Step 1: Inventory every raw button and assign a variant**
+
+```bash
+grep -n '<button' src/ui/EcuLab.jsx
+```
+
+For each, decide `variant` and whether it is genuinely `block`. Put the table in your report. Rules:
+- **`danger` is for destructive actions only.** A red-looking button that merely feels important is the rule this PR enforces, broken again.
+- **`block` only where the button genuinely spans its container by design** — a primary call to action in a narrow panel. Not "it was 100% before". Several of the 15 are full-width only because nothing stopped them.
+- Buttons inside the tuning grid and selection dock are dense controls with their own layout. If `Button` does not fit one, **leave it raw and say why.** Forcing every button through the primitive is not the goal; deleting *unconsidered* markup is.
+
+- [ ] **Step 2: Migrate in passes, committing between them**
+
+Suggested passes: the BUILD tab; the TUNE tab and selection dock; the DYNO tab; the DASH tab and everything left. Run `npx vitest run tests/ui/` after each.
+
+- [ ] **Step 3: Confirm the full-width buttons are gone or deliberate**
+
+```bash
+grep -c "width: '100%'" src/ui/EcuLab.jsx
+```
+
+Whatever remains must be non-button markup or a documented `block` decision. State the final count and what it is.
+
+- [ ] **Step 4: Full gate**
+
+```bash
+npx vitest run tests/ui/ > /tmp/t.txt 2>&1; echo "EXIT=$?"
+npm run lint > /tmp/l.txt 2>&1; echo "EXIT=$?"
+npm run typecheck > /tmp/tc.txt 2>&1; echo "EXIT=$?"
+```
+
+---
+
+### Task 8: The last two findings, then the PR
+
+**Files:**
+- Modify: `src/ui/EcuLab.jsx`
+
+- [ ] **Step 1: Take the alarm colours off the chart series**
+
+`EcuLab.jsx:2110-2111`:
+
+```jsx
+<Line dataKey="afr" name="AFR actual" stroke={T.ok} ... />
+<Line dataKey="timing" name="Timing used" stroke={T.warn} ... />
+```
+
+Two permanent series drawn in green and amber. Nothing is healthy or marginal — they are just lines, on screen for every pull. `tokens.js` ships `cyan` and `violet` for exactly this. Switch them, and check the chart's other series for the same problem while you are there.
+
+- [ ] **Step 2: Fix the comparison that asks nothing**
+
+`EcuLab.jsx:296`:
+
+```jsx
+stroke={i > 9 ? T.danger : T.line === T.line ? T.ink3 : T.line}
+```
+
+`T.line === T.line` is always true, so the third branch is unreachable and the tach's minor ticks are always `T.ink3`. Reduce it to what it actually does:
+
+```jsx
+stroke={i > 9 ? T.danger : T.ink3}
+```
+
+Do **not** guess at what it was meant to compare and implement that instead — the observable behaviour today is `T.ink3`, and this PR changes nothing observable. Note in the report that the intent is unrecoverable from the code.
+
+Keep `T.danger` here: on a tachometer that is the redline, a genuine warning.
+
+- [ ] **Step 3: Confirm every duplicate is gone**
+
+```bash
+grep -n '^function \|^const [A-Z][A-Za-z]* = ' src/ui/EcuLab.jsx
+```
+
+Expected to remain: `ExpandableInfo`, `PickList`, `JourneyBanner`, `BuildSection`, `DialMark`, `Tach`, `TuningGrid`, `cellReference`, `SelectionDock`, `LiveGauge`, `TrimBar`, `EcuLabApp`, `EcuLab`. **Gone:** `Eyebrow`, `Panel`, `Note`, `Seg`, `GroupedSelect`, `ToggleRow`, `StatTile`, `HealthBar`.
+
+- [ ] **Step 4: The full gate**
+
+```bash
+node --version    # v20.x or v22.x
+npm test
+npm run lint
+npm run typecheck
+npm run build
+```
+
+- [ ] **Step 5: Prove the physics and the pinned behaviour never moved**
+
+```bash
+git diff origin/main --stat -- src/sim/ tests/fixtures/ tests/fingerprint.test.js package.json package-lock.json
+git diff origin/main --stat -- tests/ui/characterisation.test.jsx
+```
+Both expected: **no output.**
+
+- [ ] **Step 6: Re-sync, then re-run the gate**
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+A pre-rebase green says nothing about the post-rebase tree. Re-run step 4 in full.
+
+- [ ] **Step 7: Open the PR**
+
+The body must state: which duplicates were deleted and how many call sites each moved; **every visual change**, the three predicted ones and any others found; which buttons stayed raw and why; and that `characterisation.test.jsx` is byte-identical. Close #74, reference #6, and note that #59 depends on it.
+
+- [ ] **Step 8: Check no auto-merge is queued**
+
+```bash
+gh pr view --json autoMergeRequest
+```
+Expected `null`. **Do not merge this PR.**
+
+---
+
+## Notes for the implementer
+
+**Nothing here catches a visual regression.** The suites pin behaviour. Every task changes appearance, so the report is the only record a reviewer has of what you meant to change. Record every visual delta, including ones this plan did not predict.
+
+**One primitive per commit.** A reviewer can check fifteen Panel sites; nobody can check a hundred substitutions at once.
+
+**`characterisation.test.jsx` is not yours to edit.** It has been byte-identical since it was written and pins the flows this PR touches. If it goes red, the migration is wrong. In `build-store.test.jsx` and `session-store.test.jsx`, setup may adapt to a changed accessible name or DOM shape; **assertions may not.**
+
+**When a primitive does not fit, say so.** `PickList` has no equivalent and stays. Some dense grid buttons may not suit `Button`. Reporting a considered exception is worth more than forcing a bad fit — but leaving markup unexamined is not an exception, it is an omission.

--- a/docs/superpowers/plans/2026-08-21-adopt-design-system.md
+++ b/docs/superpowers/plans/2026-08-21-adopt-design-system.md
@@ -656,6 +656,44 @@ Do **not** guess at what it was meant to compare and implement that instead — 
 
 Keep `T.danger` here: on a tachometer that is the redline, a genuine warning.
 
+- [ ] **Step 2b: Two more findings, both surfaced by Task 2's review**
+
+**A hand-rolled div that is a `Panel`.** Around `EcuLab.jsx:2276`, inside the score
+block, sits:
+
+```jsx
+<div style={{ flex: 1, background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 12, padding: 14 }}>
+```
+
+That is the `Panel` primitive's exact look, written out by hand — and it kept the literal
+`padding: 14` while every migrated `Panel` moved to `--sp-lg` (13px). So it now sits 1px
+looser than the real `Panel` directly above it in the same block. It was never a `<Panel>`
+call, so Task 2's 15-site sweep correctly did not catch it.
+
+Replace it with `<Panel style={{ flex: 1 }}>`. Then look for siblings: any other div
+setting `background: T.panel2` **and** a `T.line` border is the same duplication. List what
+you find and convert what genuinely is a panel — but do not force a div that merely shares
+one property.
+
+**An animation shorthand fighting its own longhand.** `EcuLab.jsx:305-306`:
+
+```jsx
+animation: running ? `cylpulse ...s ease-in-out infinite` : 'none',
+animationDelay: `${i * (0.5 / cylinders)}s`,
+```
+
+React warns about this on every render of the tach. `animation` is a shorthand that resets
+`animation-delay`, so declaring the longhand beside it in the same object is order-dependent
+and the per-cylinder stagger may not apply at all. Fold the delay into the shorthand — it
+takes a delay as its second time value:
+
+```jsx
+animation: running ? `cylpulse ${dur}s ${i * (0.5 / cylinders)}s ease-in-out infinite` : 'none',
+```
+
+Confirm the console warning is gone afterwards. This is pre-existing, not something this PR
+introduced — say so in the PR body rather than implying otherwise.
+
 - [ ] **Step 3: Confirm every duplicate is gone**
 
 ```bash

--- a/docs/superpowers/plans/2026-08-21-adopt-design-system.md
+++ b/docs/superpowers/plans/2026-08-21-adopt-design-system.md
@@ -526,6 +526,52 @@ Delete the local `function Seg` (:103-119) and `function GroupedSelect` (:145-17
 
 **`PickList` (:121) stays.** It has no primitive and this PR does not create one.
 
+- [ ] **Step 2b: Pin the transform at the call sites, not just in the primitive**
+
+Task 4's review proved the hole this closes: it set `higherIsBetter={true}` on the duty
+`Bar` — a 95%-duty injector painted bright green — and **all 179 tests passed**. `Bar`'s
+three direction tests render the primitive in isolation and say nothing about the props
+the app hands it.
+
+`Seg` has the same hole, and a nastier failure. If a call site keeps the old
+`{value, label}` shape, every option gets `id: undefined`, so:
+
+- `aria-pressed={undefined === value}` is false for **every** option — no selection shows
+- `onClick={() => onChange(undefined)}` — clicking a choice writes `undefined` into the
+  build, and the sim gets garbage
+
+It renders. It looks nearly right. Nothing in lint or typecheck can see it, because
+`EcuLab.jsx` carries `@ts-nocheck`.
+
+**Write one test that covers all eight sites and cannot drift**, rather than eight tests
+naming them. Render the app, walk every `role="group"` the screen exposes, and assert each
+has exactly one option with `aria-pressed="true"`:
+
+```jsx
+it('every segmented control shows exactly one option as selected', () => {
+  // A Seg still passed the old {value,label} shape renders every option with
+  // id: undefined, so aria-pressed is false on all of them and onChange fires with
+  // undefined. The control looks almost right and silently writes garbage. Counting
+  // pressed options catches that without naming a single call site — so a ninth Seg
+  // added later is covered the day it appears.
+  launch();
+  const groups = screen.getAllByRole('group');
+  expect(groups.length).toBeGreaterThan(0);   // guard: prove we actually found Segs
+  groups.forEach((group) => {
+    const pressed = within(group).getAllByRole('button', { pressed: true });
+    expect(pressed).toHaveLength(1);
+  });
+});
+```
+
+Segs live on several tabs, so one `launch()` will not reveal all eight. Visit each tab that
+holds one and run the same check — or write it as a helper called per tab. Say in your
+report which tabs you covered and how many groups each revealed, so the total is auditable
+against the eight known sites.
+
+**Prove it bites:** revert one call site to `{ value, label }` and confirm the test fails.
+Restore.
+
 - [ ] **Step 3: Verify the accessible names exist**
 
 The controls suite already covers `Seg` and `Select` in isolation. What is new is that `EcuLab` now passes real names, so check one end to end:

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -60,6 +60,8 @@ import { Note } from './primitives/Note.jsx';
 import { Panel } from './primitives/Panel.jsx';
 import { StatTile } from './primitives/StatTile.jsx';
 import { Bar } from './primitives/Bar.jsx';
+import { Seg } from './primitives/Seg.jsx';
+import { Select } from './primitives/Select.jsx';
 
 function ExpandableInfo({ title, children }) {
   const [open, setOpen] = useState(false);
@@ -78,25 +80,6 @@ function ExpandableInfo({ title, children }) {
   );
 }
 
-// Segmented row of equal-width option buttons — replaces the repeated
-// flex-row-of-buttons pattern used all over the tuning screens.
-function Seg({ options, value, onChange, wrap }) {
-  return (
-    <div style={{ display: 'flex', gap: 7, marginBottom: 4, flexWrap: wrap ? 'wrap' : 'nowrap' }}>
-      {options.map((o) => {
-        const active = o.value === value;
-        return (
-          <button key={o.value} onClick={() => onChange(o.value)} style={{
-            flex: wrap ? '1 1 30%' : 1, padding: '11px 4px', borderRadius: 9, fontWeight: 700, fontSize: 12.5,
-            border: `1px solid ${active ? T.acc : T.line}`, background: active ? T.accBg : T.panel2,
-            color: active ? T.accInk : T.ink2, transition: 'all .15s',
-          }}>{o.label}</button>
-        );
-      })}
-    </div>
-  );
-}
-
 // Full-width descriptive rows for choices that need a subtitle (turbine, injectors).
 function PickList({ options, value, onChange }) {
   return (
@@ -111,48 +94,6 @@ function PickList({ options, value, onChange }) {
           }}>{o.label}{o.sub && <div style={{ fontSize: 11, color: T.ink2, marginTop: 2, fontWeight: 400 }}>{o.sub}</div>}</button>
         );
       })}
-    </div>
-  );
-}
-
-// A native <select> with optgroup headings, styled to the theme. Native rather than a
-// custom panel so that keyboard navigation, type-ahead and screen-reader semantics come
-// from the platform instead of being reimplemented, and so a phone gets its own picker
-// wheel. Used where a list has grown past what a stack of PickList buttons can carry.
-//
-// `groups` is [{ label, options: [{ label, value }] }]; `extra` holds options that
-// belong to no group and render after all of them.
-function GroupedSelect({ groups, extra = [], value, onChange }) {
-  return (
-    <div style={{ position: 'relative', marginBottom: 13 }}>
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        style={{
-          width: '100%', appearance: 'none', WebkitAppearance: 'none',
-          padding: '11px 34px 11px 13px', borderRadius: 9,
-          border: `1px solid ${T.line}`, background: T.panel2, color: T.ink,
-          fontFamily: T.sans, fontSize: 13, fontWeight: 600,
-        }}
-      >
-        {groups.map((g) => (
-          <optgroup key={g.label} label={g.label} style={{ background: T.panel, color: T.ink2 }}>
-            {g.options.map((o) => (
-              <option key={o.value} value={o.value} style={{ background: T.panel2, color: T.ink }}>{o.label}</option>
-            ))}
-          </optgroup>
-        ))}
-        {extra.map((o) => (
-          <option key={o.value} value={o.value} style={{ background: T.panel2, color: T.ink }}>{o.label}</option>
-        ))}
-      </select>
-      <ChevronDown
-        size={16}
-        style={{
-          position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)',
-          color: T.ink2, pointerEvents: 'none',
-        }}
-      />
     </div>
   );
 }
@@ -1424,7 +1365,8 @@ export function EcuLabApp() {
               sub={`${engineDerived.displacementL.toFixed(1)}L ${engineConfig.configuration} · ${engineConfig.compression.toFixed(1)}:1 · ${engineConfig.camDuration}° cam`}
             >
               <div style={{ fontSize: 12, color: T.ink2, marginBottom: 6, fontWeight: 600 }}>Start From a Real Engine</div>
-              <GroupedSelect
+              <Select
+                label="Start from a real engine"
                 groups={PRESET_GROUPS.map((g) => ({
                   label: g.manufacturer,
                   // The heading carries the manufacturer, so strip it off the option
@@ -1504,7 +1446,7 @@ export function EcuLabApp() {
               </ExpandableInfo>
 
               <div style={{ fontSize: 12, color: T.ink2, marginBottom: 6, marginTop: 10, fontWeight: 600 }}>Configuration</div>
-              <Seg options={CONFIG_OPTS.map((c) => ({ label: `${c} · ${CYL_COUNT[c]}cyl`, value: c }))} value={engineConfig.configuration} onChange={(v) => setCfg({ configuration: v })} />
+              <Seg label="Configuration" options={CONFIG_OPTS.map((c) => ({ label: `${c} · ${CYL_COUNT[c]}cyl`, id: c }))} value={engineConfig.configuration} onChange={(v) => setCfg({ configuration: v })} />
               <ExpandableInfo title="Why cylinder count and layout matter">
                 For the same total displacement, spreading it across more, smaller cylinders means each one needs less peak pressure to make the same overall torque — a small real knock-margin benefit and smoother delivery. More cylinders also means more bearings and friction, so it is a trade-off, not a free upgrade.
               </ExpandableInfo>
@@ -1552,9 +1494,9 @@ export function EcuLabApp() {
               </ExpandableInfo>
 
               <div style={{ fontSize: 12, color: T.ink2, marginBottom: 6, fontWeight: 600 }}>Block Material</div>
-              <Seg options={MATERIAL_OPTS.map((m) => ({ label: m, value: m }))} value={engineConfig.blockMaterial} onChange={(v) => setCfg({ blockMaterial: v })} />
+              <Seg label="Block Material" options={MATERIAL_OPTS.map((m) => ({ label: m, id: m }))} value={engineConfig.blockMaterial} onChange={(v) => setCfg({ blockMaterial: v })} />
               <div style={{ fontSize: 12, color: T.ink2, margin: '10px 0 6px', fontWeight: 600 }}>Head Material</div>
-              <Seg options={MATERIAL_OPTS.map((m) => ({ label: m, value: m }))} value={engineConfig.headMaterial} onChange={(v) => setCfg({ headMaterial: v })} />
+              <Seg label="Head Material" options={MATERIAL_OPTS.map((m) => ({ label: m, id: m }))} value={engineConfig.headMaterial} onChange={(v) => setCfg({ headMaterial: v })} />
               <ExpandableInfo title="Why block and head material matter">
                 Aluminum conducts heat roughly three times faster than cast iron, so an aluminum head pulls heat away from the combustion chamber faster — a real, measurable knock-margin benefit. Cast iron is heavier and a worse conductor, but stiffer under heat, which is part of why some high-output blocks still use it.
               </ExpandableInfo>
@@ -1601,7 +1543,7 @@ export function EcuLabApp() {
                   <div style={{ fontSize: 12, color: T.ink2, marginBottom: 6, fontWeight: 600 }}>Turbine Size</div>
                   <PickList options={TURBINE_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={TURBINE_OPTS[turbineIdx].label} onChange={(v) => dispatch({ type: ACTIONS.SET_TURBINE, value: TURBINE_OPTS.findIndex((o) => o.label === v) })} />
                   <div style={{ fontSize: 12, color: T.ink2, marginBottom: 6, marginTop: 4, fontWeight: 600 }}>Compressor Size</div>
-                  <Seg options={COMPRESSOR_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={COMPRESSOR_OPTS[compressorIdx].label} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'compressorIdx', value: COMPRESSOR_OPTS.findIndex((o) => o.label === v) })} />
+                  <Seg label="Compressor Size" options={COMPRESSOR_OPTS.map((o) => ({ label: o.label, id: o.label }))} value={COMPRESSOR_OPTS[compressorIdx].label} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'compressorIdx', value: COMPRESSOR_OPTS.findIndex((o) => o.label === v) })} />
                   <div style={{ fontSize: 11, color: T.ink3, marginBottom: 10, marginTop: 4 }}>Ceiling before it runs outside its efficient range: ~{COMPRESSOR_OPTS[compressorIdx].boostCeiling} psi</div>
                   <ExpandableInfo title="Turbine vs. compressor — different jobs">
                     The turbine sits in the exhaust and spins from exhaust energy — its size sets how quickly it spools (small = fast but chokes exhaust flow up top; large = laggy but flows more at redline). The compressor sits in the intake and does the actual pressurizing — its size sets a practical boost ceiling before it's forced outside its efficient operating range, making hot, inefficient, knock-prone air.
@@ -1703,7 +1645,7 @@ export function EcuLabApp() {
               sub={EXHAUST_DIA_OPTS[exhaustDiaIdx].label}
             >
               <div style={{ fontSize: 12, color: T.ink2, marginBottom: 6, fontWeight: 600 }}>Exhaust Diameter</div>
-              <Seg options={EXHAUST_DIA_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={EXHAUST_DIA_OPTS[exhaustDiaIdx].label} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'exhaustDiaIdx', value: EXHAUST_DIA_OPTS.findIndex((o) => o.label === v) })} />
+              <Seg label="Exhaust Diameter" options={EXHAUST_DIA_OPTS.map((o) => ({ label: o.label, id: o.label }))} value={EXHAUST_DIA_OPTS[exhaustDiaIdx].label} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'exhaustDiaIdx', value: EXHAUST_DIA_OPTS.findIndex((o) => o.label === v) })} />
               <div style={{ fontSize: 11, color: T.ink3, marginBottom: 4 }}>
                 Estimated ideal for this build: ~{idealExhaustDia.toFixed(2)} in
                 {turboOn && Math.max(...boostCurve) > 0 && <span style={{ color: T.accInk }}> (raised by boost)</span>}
@@ -1883,7 +1825,7 @@ export function EcuLabApp() {
             {turboOn && <Note>Turbo hardware and the boost target curve live on <b>BUILD</b> — this tab is fuel-side tuning: octane, injectors, and MAF/ECU.</Note>}
 
             <div style={{ fontSize: 12, color: T.ink2, margin: '12px 0 6px', fontWeight: 600 }}>Fuel Octane</div>
-            <Seg options={OCTANE_OPTS.map((o) => ({ label: o.label, value: o.label }))} value={OCTANE_OPTS[octaneIdx].label} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'octaneIdx', value: OCTANE_OPTS.findIndex((o) => o.label === v) })} />
+            <Seg label="Fuel Octane" options={OCTANE_OPTS.map((o) => ({ label: o.label, id: o.label }))} value={OCTANE_OPTS[octaneIdx].label} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'octaneIdx', value: OCTANE_OPTS.findIndex((o) => o.label === v) })} />
             <ExpandableInfo title="What octane actually does — and what E85 costs you">
               Octane measures a fuel's resistance to auto-igniting under heat and pressure before the spark fires it — not energy content or "power." Higher octane tolerates more cylinder pressure and temperature before knock, letting a tuner run more advance or more boost safely. It does not add power on its own; it raises the ceiling for how much timing/boost you can use before knock becomes the limit.
               <br /><br /><b style={{ color: T.ink }}>E85 is not a free upgrade.</b> Its stoichiometric point is about 9.8:1, not gasoline's 14.7:1 — so hitting the same lambda takes roughly <b style={{ color: T.accInk }}>1.43× the fuel volume</b>. Switch to E85 without upsizing injectors and you will run out of duty cycle long before you cash in that knock margin. Watch the duty preview below change the moment you select it.
@@ -1895,7 +1837,7 @@ export function EcuLabApp() {
             <div style={{ fontSize: 12, color: T.ink2, margin: '12px 0 6px', fontWeight: 600 }}>
               ECU Injector Scaling <span style={{ color: T.ink3, fontWeight: 400 }}>— what the ECU thinks is fitted</span>
             </div>
-            <Seg options={INJECTOR_OPTS.map((o) => ({ label: `${o.cc}`, value: o.cc }))} value={ecuInjectorCc} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'ecuInjectorCc', value: v })} wrap />
+            <Seg label="ECU Injector Scaling" options={INJECTOR_OPTS.map((o) => ({ label: `${o.cc}`, id: o.cc }))} value={ecuInjectorCc} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'ecuInjectorCc', value: v })} equal />
             {ecuInjectorCc !== injectorCc ? (
               <div style={{ background: T.dangerBg, border: `1px solid ${T.dangerLine}`, borderRadius: 10, padding: '11px 13px', margin: '8px 0', fontSize: 12, color: T.dangerInk, lineHeight: 1.5 }}>
                 <b>Scaling mismatch.</b> Hardware is {injectorCc}cc but the ECU is calibrated for {ecuInjectorCc}cc — every pulse delivers about {((injectorCc / ecuInjectorCc) * 100).toFixed(0)}% of the intended fuel, so the engine runs {injectorCc > ecuInjectorCc ? 'far too rich' : 'dangerously lean'} everywhere.
@@ -1985,7 +1927,7 @@ export function EcuLabApp() {
             {journeyStep === 3 && <JourneyBanner step={3} onAdvance={() => dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'journeyStep', value: 99 })} onDismiss={() => dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'journeyStep', value: 99 })} />}
             <Eyebrow icon={Activity}>Dyno Cell</Eyebrow>
             <div style={{ fontSize: 12, color: T.ink2, marginBottom: 8, fontWeight: 600 }}>Manifold pressure for the pull (load)</div>
-            <Seg options={[100, 70, 40].map((l) => ({ label: `${l} kPa`, value: l }))} value={loadKpa} onChange={(v) => dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'loadKpa', value: v })} />
+            <Seg label="Manifold pressure for the pull (load)" options={[100, 70, 40].map((l) => ({ label: `${l} kPa`, id: l }))} value={loadKpa} onChange={(v) => dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'loadKpa', value: v })} />
             <div style={{ fontSize: 10.5, color: T.ink3, marginTop: 4, marginBottom: 4 }}>
               ~100 kPa is wide-open throttle naturally aspirated. Boost adds on top and walks the tables into the higher-MAP rows automatically.
             </div>

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -125,7 +125,7 @@ function JourneyBanner({ step, onAdvance, onDismiss }) {
     <div style={{ background: T.accBg, border: `1px solid ${T.acc}`, borderRadius: 12, padding: '13px 14px', margin: '0 0 14px' }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 10 }}>
         <div style={{ fontSize: 11, letterSpacing: 1, color: T.accInk, fontWeight: 800 }}>{j.title.toUpperCase()}</div>
-        <button onClick={onDismiss} style={{ background: 'none', border: 'none', color: T.ink3, fontSize: 10.5, fontWeight: 700, flexShrink: 0 }}>SKIP GUIDE</button>
+        <Button variant="quiet" size="sm" style={{ flexShrink: 0 }} onClick={onDismiss}>SKIP GUIDE</Button>
       </div>
       <div style={{ fontSize: 12.5, color: T.inkSoft, lineHeight: 1.55, marginTop: 7 }}>{j.body}</div>
       <div style={{ display: 'flex', gap: 5, marginTop: 11, marginBottom: 10 }}>
@@ -133,9 +133,16 @@ function JourneyBanner({ step, onAdvance, onDismiss }) {
           <div key={i} style={{ flex: 1, height: 3, borderRadius: 2, background: i <= step ? T.acc : T.line }} />
         ))}
       </div>
-      <button onClick={onAdvance} style={{ width: '100%', padding: '11px 0', borderRadius: 9, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 12.5 }}>
+      {/* The closest thing this file has to a justified `block`, and still not one.
+          The card looks bounded, but nothing bounds it: index.html lays the app out
+          mobile-first and neither the shell nor any tab body sets a max-width, so
+          this banner is as wide as the window. `block` here would put a 2500px-wide
+          "Done building — go tune it" on a desktop monitor, which is the complaint
+          this PR exists to answer. Give the app a max-width first; `block` becomes
+          honest the moment a container is genuinely narrow. */}
+      <Button onClick={onAdvance}>
         {j.cta}
-      </button>
+      </Button>
     </div>
   );
 }
@@ -1054,12 +1061,16 @@ export function EcuLabApp() {
             </div>
           </div>
           <div style={{ display: 'flex', gap: 6, flexShrink: 0 }}>
-            <button onClick={() => setAppView('tutorial')} title="Tutorial" style={{ background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 9, padding: 9, color: T.ink2 }}>
-              <Info size={16} />
-            </button>
-            <button onClick={repairEngine} title="Repair engine" style={{ background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 9, padding: 9, color: T.ink2 }}>
-              <Wrench size={16} />
-            </button>
+            {/* Icon-only, so the label has to be spelled out: `title` alone leaves a
+                button whose accessible name depends on the tooltip surviving. Note
+                the lower-case names — the start screen's TUTORIAL button is queried
+                by exact name and must stay the only match. */}
+            <Button variant="ghost" size="sm" title="Tutorial" aria-label="Tutorial" onClick={() => setAppView('tutorial')}>
+              <Info size={16} aria-hidden="true" />
+            </Button>
+            <Button variant="ghost" size="sm" title="Repair engine" aria-label="Repair engine" onClick={repairEngine}>
+              <Wrench size={16} aria-hidden="true" />
+            </Button>
           </div>
         </div>
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 9 }}>
@@ -1102,11 +1113,17 @@ export function EcuLabApp() {
                         : live.cranking ? 'Starter engaged…' : 'Engine off. Start it to watch the ECU work in real time.'}
                     </div>
                     <div style={{ display: 'flex', gap: 7 }}>
-                      <button onClick={live.running || live.cranking ? stopEngine : startEngine} style={{
-                        flex: 1, padding: '11px 0', borderRadius: 9, border: 'none', fontWeight: 800, fontSize: 12.5,
-                        background: live.running || live.cranking ? T.panel2 : T.ok, color: live.running || live.cranking ? T.ink : T.okBg,
-                        borderWidth: 1, borderStyle: 'solid', borderColor: live.running || live.cranking ? T.line : T.ok,
-                      }}>{live.running || live.cranking ? 'STOP' : 'START ENGINE'}</button>
+                      {/* START was filled with `ok`. Green here is decoration, not
+                          state — the engine is not running when the button says
+                          START — and spending a status colour on an action is the
+                          rule Toggle's docstring closed. It takes the accent; STOP
+                          is the secondary state and takes `ghost`. Not `danger`:
+                          shutting an engine down destroys nothing. */}
+                      <Button
+                        variant={live.running || live.cranking ? 'ghost' : 'primary'}
+                        style={{ flex: 1 }}
+                        onClick={live.running || live.cranking ? stopEngine : startEngine}
+                      >{live.running || live.cranking ? 'STOP' : 'START ENGINE'}</Button>
                       <button onClick={() => { if (!soundOn) ensureAudio()?.ctx.resume(); dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'soundOn', value: !soundOn }); }} title="Engine sound" style={{
                         width: 46, padding: '11px 0', borderRadius: 9, fontWeight: 800, fontSize: 13,
                         border: `1px solid ${soundOn ? T.acc : T.line}`, background: soundOn ? T.accBg : T.panel2,

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -62,6 +62,7 @@ import { StatTile } from './primitives/StatTile.jsx';
 import { Bar } from './primitives/Bar.jsx';
 import { Seg } from './primitives/Seg.jsx';
 import { Select } from './primitives/Select.jsx';
+import { Toggle } from './primitives/Toggle.jsx';
 
 function ExpandableInfo({ title, children }) {
   const [open, setOpen] = useState(false);
@@ -94,20 +95,6 @@ function PickList({ options, value, onChange }) {
           }}>{o.label}{o.sub && <div style={{ fontSize: 11, color: T.ink2, marginTop: 2, fontWeight: 400 }}>{o.sub}</div>}</button>
         );
       })}
-    </div>
-  );
-}
-
-function ToggleRow({ label, sub, checked, onChange, color = T.acc }) {
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 10, padding: 13 }}>
-      <div style={{ marginRight: 10 }}>
-        <div style={{ fontWeight: 700, fontSize: 13.5, color: T.ink }}>{label}</div>
-        {sub && <div style={{ fontSize: 11.5, color: T.ink2, marginTop: 1 }}>{sub}</div>}
-      </div>
-      <button onClick={() => onChange(!checked)} style={{ width: 48, height: 27, borderRadius: 14, border: 'none', position: 'relative', flexShrink: 0, background: checked ? color : T.panel3, transition: 'background .2s' }}>
-        <div style={{ position: 'absolute', top: 3, left: checked ? 24 : 3, width: 21, height: 21, borderRadius: 11, background: T.ink, transition: 'left .2s', boxShadow: `0 1px 3px ${shadowAlpha(0.4)}` }} />
-      </button>
     </div>
   );
 }
@@ -1541,7 +1528,7 @@ export function EcuLabApp() {
               icon={Wind} label="Forced Induction"
               sub={turboOn ? `On · ${turbineCount > 1 ? `Twin ${TURBINE_OPTS[turbineIdx].label.split(' ')[0].toLowerCase()}` : TURBINE_OPTS[turbineIdx].label.split(' ')[0]} turbine · peak ${Math.max(...boostCurve)} psi` : 'Not installed'}
             >
-              <ToggleRow label="Turbo kit" sub="Adds boost near WOT, with spool lag off idle" checked={turboOn} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: v })} />
+              <Toggle label="Turbo kit" sub="Adds boost near WOT, with spool lag off idle" checked={turboOn} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: v })} />
 
               <div style={{ maxHeight: turboOn ? 3000 : 0, opacity: turboOn ? 1 : 0, overflow: 'hidden', transition: 'max-height .4s ease, opacity .3s ease' }}>
                 <div style={{ paddingTop: 12 }}>
@@ -1557,7 +1544,7 @@ export function EcuLabApp() {
                   </ExpandableInfo>
 
                   <div style={{ marginTop: 4, marginBottom: 14 }}>
-                    <ToggleRow label="Intercooler" sub="Cools charge air, buys knock margin under boost" checked={mods.intercooler} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'mods', value: { ...mods, intercooler: v } })} color={T.cyan} />
+                    <Toggle label="Intercooler" sub="Cools charge air, buys knock margin under boost" checked={mods.intercooler} onChange={(v) => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'mods', value: { ...mods, intercooler: v } })} />
                   </div>
 
                   <div style={{ fontSize: 12, color: T.ink2, marginBottom: 8, fontWeight: 600 }}>Boost Target Curve</div>

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -55,6 +55,7 @@ import { StartScreen } from './screens/StartScreen.jsx';
 import { TutorialScreen } from './screens/TutorialScreen.jsx';
 import { StoreProvider, useBuild, useSession, useTune } from './state/StoreProvider.jsx';
 import { ACTIONS } from './state/reducer.js';
+import { Button } from './primitives/Button.jsx';
 import { Eyebrow } from './primitives/Eyebrow.jsx';
 import { Note } from './primitives/Note.jsx';
 import { Panel } from './primitives/Panel.jsx';
@@ -1410,12 +1411,15 @@ export function EcuLabApp() {
                     <b style={{ color: T.accInk }}>This replaces your current tune.</b> Loading {presetPrompt.name} overwrites your VE, spark and fuel tables with its factory calibration. Your career stats are kept.
                   </div>
                   <div style={{ display: 'flex', gap: 7 }}>
-                    <button onClick={() => applyEnginePreset(presetPrompt)} style={{ flex: 1, padding: '10px 0', borderRadius: 8, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 12 }}>
+                    {/* The one `danger` in the app. This prompt is raised ONLY when
+                        `hasTuningWork()` is true, so confirming it always destroys
+                        hand-edited VE/spark/fuel tables that nothing can restore. */}
+                    <Button variant="danger" size="sm" style={{ flex: 1 }} onClick={() => applyEnginePreset(presetPrompt)}>
                       LOAD {presetPrompt.name.toUpperCase()}
-                    </button>
-                    <button onClick={() => dispatch({ type: ACTIONS.SET_PRESET_PROMPT, value: null })} style={{ flex: 1, padding: '10px 0', borderRadius: 8, border: `1px solid ${T.line}`, background: T.panel, color: T.ink2, fontWeight: 700, fontSize: 12 }}>
+                    </Button>
+                    <Button variant="ghost" size="sm" style={{ flex: 1 }} onClick={() => dispatch({ type: ACTIONS.SET_PRESET_PROMPT, value: null })}>
                       CANCEL
-                    </button>
+                    </Button>
                   </div>
                 </div>
               )}
@@ -1501,9 +1505,9 @@ export function EcuLabApp() {
               sub={`${Object.values(mods).filter((v) => v).length}/4 installed`}
             >
               <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 9 }}>
-                <button onClick={resetToStock} style={{ display: 'flex', alignItems: 'center', gap: 4, background: 'none', border: 'none', color: T.ink2, fontSize: 11, fontWeight: 600 }}>
-                  <RotateCcw size={12} /> RESET ALL TO STOCK
-                </button>
+                <Button variant="quiet" size="sm" onClick={resetToStock}>
+                  <RotateCcw size={12} aria-hidden="true" /> RESET ALL TO STOCK
+                </Button>
               </div>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                 {Object.keys(MOD_INFO).map((key) => (
@@ -1600,22 +1604,22 @@ export function EcuLabApp() {
                       ))}
                     </div>
                     <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
-                      <button onClick={() => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'boostCurve', value: RPM.map(() => clamp(Number(boostCurve[boostSel]) || 0, 0, 25)) })}
-                        style={{ flex: 1, padding: '9px 0', borderRadius: 8, border: `1px solid ${T.line}`, background: T.panel, color: T.ink2, fontWeight: 700, fontSize: 11 }}>
+                      <Button variant="ghost" size="sm" style={{ flex: 1 }}
+                        onClick={() => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'boostCurve', value: RPM.map(() => clamp(Number(boostCurve[boostSel]) || 0, 0, 25)) })}>
                         FLAT ACROSS ALL
-                      </button>
-                      <button onClick={() => { const peak = boostCurve[boostSel]; dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'boostCurve', value: RPM.map((r) => Math.round(peak * clamp((r - 1500) / 2600, 0, 1))) }); }}
-                        style={{ flex: 1, padding: '9px 0', borderRadius: 8, border: `1px solid ${T.line}`, background: T.panel, color: T.ink2, fontWeight: 700, fontSize: 11 }}>
+                      </Button>
+                      <Button variant="ghost" size="sm" style={{ flex: 1 }}
+                        onClick={() => { const peak = boostCurve[boostSel]; dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'boostCurve', value: RPM.map((r) => Math.round(peak * clamp((r - 1500) / 2600, 0, 1))) }); }}>
                         SPOOL RAMP
-                      </button>
+                      </Button>
                       {/* Built from RPM so the curve can never be shorter than the
                           axis. A hand-written literal previously had seven entries
                           for eight breakpoints, and the next edit put NaN through
                           the entire simulation. */}
-                      <button onClick={() => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'boostCurve', value: RPM.map(() => 0) })}
-                        style={{ flex: 1, padding: '9px 0', borderRadius: 8, border: `1px solid ${T.line}`, background: T.panel, color: T.ink2, fontWeight: 700, fontSize: 11 }}>
+                      <Button variant="ghost" size="sm" style={{ flex: 1 }}
+                        onClick={() => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'boostCurve', value: RPM.map(() => 0) })}>
                         ZERO
-                      </button>
+                      </Button>
                     </div>
                     <div style={{ fontSize: 10.5, color: Math.max(...boostCurve) > COMPRESSOR_OPTS[compressorIdx].boostCeiling ? T.danger : T.ink3, marginTop: 8 }}>
                       Compressor efficient to ~{COMPRESSOR_OPTS[compressorIdx].boostCeiling} psi{Math.max(...boostCurve) > COMPRESSOR_OPTS[compressorIdx].boostCeiling ? ' — you are past it, expect hot inefficient air' : ''}

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -48,7 +48,7 @@ import {
   deriveEngine, idealExhaustDiameter, interp2, presetById,
   simulateSweep, turbineWithCount, veRecommendations
 } from '../sim/index.js';
-import { T, accAlpha, deltaHeat, heat, shadowAlpha, statusColor } from './theme.js';
+import { T, accAlpha, deltaHeat, heat, shadowAlpha, statusColor, statusTone } from './theme.js';
 import { BUILD_VERSION } from '../version.js';
 import { loadCareer, saveCareer } from '../storage.js';
 import { StartScreen } from './screens/StartScreen.jsx';
@@ -58,6 +58,7 @@ import { ACTIONS } from './state/reducer.js';
 import { Eyebrow } from './primitives/Eyebrow.jsx';
 import { Note } from './primitives/Note.jsx';
 import { Panel } from './primitives/Panel.jsx';
+import { StatTile } from './primitives/StatTile.jsx';
 
 function ExpandableInfo({ title, children }) {
   const [open, setOpen] = useState(false);
@@ -165,15 +166,6 @@ function ToggleRow({ label, sub, checked, onChange, color = T.acc }) {
       <button onClick={() => onChange(!checked)} style={{ width: 48, height: 27, borderRadius: 14, border: 'none', position: 'relative', flexShrink: 0, background: checked ? color : T.panel3, transition: 'background .2s' }}>
         <div style={{ position: 'absolute', top: 3, left: checked ? 24 : 3, width: 21, height: 21, borderRadius: 11, background: T.ink, transition: 'left .2s', boxShadow: `0 1px 3px ${shadowAlpha(0.4)}` }} />
       </button>
-    </div>
-  );
-}
-
-function StatTile({ label, value, unit, color = T.ink, flex = 1 }) {
-  return (
-    <div style={{ flex, background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 11, padding: 13 }}>
-      <div style={{ fontSize: 9.5, color: T.ink2, letterSpacing: 1, fontWeight: 700 }}>{label}</div>
-      <div style={{ fontSize: 24, fontWeight: 800, fontFamily: T.mono, color, marginTop: 2 }}>{value}<span style={{ fontSize: 11.5, color: T.ink2, marginLeft: 3, fontWeight: 600 }}>{unit}</span></div>
     </div>
   );
 }
@@ -1262,20 +1254,20 @@ export function EcuLabApp() {
               sub={result ? `Best ${bestScore} · ${pullCount} pulls logged` : `${pullCount} pulls logged`}
             >
               <div style={{ display: 'flex', gap: 10, marginBottom: 12 }}>
-                <StatTile label="BEST PULL" value={bestScore} color={T.accInk} />
-                <StatTile label="CAREER TOTAL" value={totalScore} color={T.cyan} />
-                <StatTile label="PULLS" value={pullCount} color={T.ink} />
+                <StatTile label="BEST PULL" value={bestScore} tone="acc" />
+                <StatTile label="CAREER TOTAL" value={totalScore} tone="alt" />
+                <StatTile label="PULLS" value={pullCount} />
               </div>
               {result && scores ? (
                 <>
                   <div style={{ display: 'flex', gap: 10, marginBottom: 10 }}>
-                    <StatTile label="PEAK POWER" value={result.peakHp} unit="whp" color={T.accInk} />
-                    <StatTile label="PEAK TORQUE" value={result.peakTq} unit="lb-ft" color={T.cyan} />
+                    <StatTile label="PEAK POWER" value={result.peakHp} unit="whp" tone="acc" />
+                    <StatTile label="PEAK TORQUE" value={result.peakTq} unit="lb-ft" tone="alt" />
                   </div>
                   <div style={{ display: 'flex', gap: 10 }}>
-                    <StatTile label="PULL SCORE" value={scores.pull} color={T.accInk} />
-                    <StatTile label="TUNING" value={scores.tuning.score} color={statusColor(scores.tuning.score)} />
-                    <StatTile label="ENGINEER" value={scores.engineer.score} color={statusColor(scores.engineer.score)} />
+                    <StatTile label="PULL SCORE" value={scores.pull} tone="acc" />
+                    <StatTile label="TUNING" value={scores.tuning.score} tone={statusTone(scores.tuning.score)} />
+                    <StatTile label="ENGINEER" value={scores.engineer.score} tone={statusTone(scores.engineer.score)} />
                   </div>
                 </>
               ) : <Note>No dyno pull logged yet — head to DYNO and run one.</Note>}
@@ -2014,8 +2006,8 @@ export function EcuLabApp() {
             {result && (
               <>
                 <div style={{ display: 'flex', gap: 10, marginBottom: 14 }}>
-                  <StatTile label="PEAK WHP" value={result.peakHp} color={T.accInk} />
-                  <StatTile label="PEAK TQ" value={result.peakTq} unit="lb-ft" color={T.cyan} />
+                  <StatTile label="PEAK WHP" value={result.peakHp} tone="acc" />
+                  <StatTile label="PEAK TQ" value={result.peakTq} unit="lb-ft" tone="alt" />
                 </div>
 
                 {prevResult && !running && (() => {

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -360,13 +360,13 @@ function SelectionDock({ data, setData, selection, min, max, decimals, unit, onC
       {selection.type === 'cell' && kind && (() => {
         const ref = cellReference(kind, selection.row, selection.col, current);
         return (
-          <div style={{ background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 9, padding: '9px 11px', marginBottom: 9, fontSize: 11.5, lineHeight: 1.55, color: T.ink2 }}>
+          <Panel tight style={{ marginBottom: 9, fontSize: 11.5, lineHeight: 1.55, color: T.ink2 }}>
             <div style={{ fontSize: 9.5, letterSpacing: 1, color: T.cyan, fontWeight: 800, marginBottom: 5 }}>REFERENCE · {RPM[selection.col]} RPM / {LOAD[selection.row]} kPa</div>
             <div>{ref.what}</div>
             <div style={{ marginTop: 4, color: T.ink }}>{ref.typical}</div>
             <div style={{ marginTop: 4 }}><b style={{ color: T.inkSoft }}>Affects: </b>{ref.affects}</div>
             {ref.note && <div style={{ marginTop: 4, color: T.warn }}>{ref.note}</div>}
-          </div>
+          </Panel>
         );
       })()}
       <input type="range" min={min} max={max} step={smallStep} value={current} onChange={(e) => setAbs(Number(e.target.value))} style={{ width: '100%', accentColor: T.acc }} />
@@ -1777,13 +1777,13 @@ export function EcuLabApp() {
                   <div style={{ fontSize: 11, color: T.ink3, marginTop: 8 }}>Edit them yourself — a calibration is yours to make, not something the app should silently rewrite.</div>
                 </div>
               ) : calAdvice.underAdvanced.length > 4 ? (
-                <div style={{ background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12, color: T.ink2, lineHeight: 1.5 }}>
+                <Panel tight style={{ margin: '10px 0', fontSize: 12, color: T.ink2, lineHeight: 1.5 }}>
                   <b style={{ color: T.accInk }}>Timing left on the table.</b> {calAdvice.underAdvanced.length} cells are more than 3° below what this build would tolerate. Safe, but you are giving away torque — advance them a little at a time and pull between each change.
-                </div>
+                </Panel>
               ) : calAdvice.pastMbt.length > 0 ? (
-                <div style={{ background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12, color: T.ink2, lineHeight: 1.5 }}>
+                <Panel tight style={{ margin: '10px 0', fontSize: 12, color: T.ink2, lineHeight: 1.5 }}>
                   <b style={{ color: T.accInk }}>Past peak torque.</b> {calAdvice.pastMbt.length} cells command more advance than the burn can use — the charge is already finishing where it should, so the extra degrees are working against the piston on its way up rather than adding torque. Not dangerous here — these cells are inside the knock limit — but pulling them back gains a little power and buys margin.
-                </div>
+                </Panel>
               ) : (
                 <div style={{ background: T.okBg, border: `1px solid ${T.okLine}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12.5, color: T.ok }}>
                   Spark table sits within the knock limit for this hardware.
@@ -2253,11 +2253,11 @@ export function EcuLabApp() {
                           {[['TUNING SCORE', scores.tuning], ['ENGINEER SCORE', scores.engineer]].map(([label, s]) => {
                             const c = statusColor(s.score);
                             return (
-                              <div key={label} style={{ flex: 1, background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 12, padding: 14 }}>
+                              <Panel key={label} style={{ flex: 1 }}>
                                 <div style={{ fontSize: 9.5, color: T.ink2, letterSpacing: 1, fontWeight: 700 }}>{label}</div>
                                 <div style={{ fontSize: 28, fontWeight: 800, fontFamily: T.mono, color: c, marginTop: 2 }}>{s.score}</div>
                                 <div style={{ fontSize: 11, color: c, fontWeight: 700 }}>{s.label}</div>
-                              </div>
+                              </Panel>
                             );
                           })}
                         </div>

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -368,10 +368,14 @@ function SelectionDock({ data, setData, selection, min, max, decimals, unit, onC
       })()}
       <input type="range" min={min} max={max} step={smallStep} value={current} onChange={(e) => setAbs(Number(e.target.value))} style={{ width: '100%', accentColor: T.acc }} />
       <div style={{ display: 'flex', gap: 7, marginTop: 9 }}>
+        {/* One colour for all four: the +/- is already in the label. Painting the
+            positive steps with the status green said "raising this cell is good", which
+            is not something a stepper can know — and spending the status scale on a sign
+            is what teaches a player to ignore it where it means something. */}
         {[-bigStep, -smallStep, smallStep, bigStep].map((d, i) => (
           <button key={i} onClick={() => apply(d)} style={{
             flex: 1, padding: '11px 0', borderRadius: 8, border: `1px solid ${T.line}`, background: T.panel2,
-            color: d < 0 ? T.accInk : T.ok, fontWeight: 800, fontFamily: T.mono, fontSize: 13,
+            color: T.accInk, fontWeight: 800, fontFamily: T.mono, fontSize: 13,
           }}>{d > 0 ? '+' : ''}{d}</button>
         ))}
       </div>
@@ -1166,7 +1170,7 @@ export function EcuLabApp() {
                 <div style={{ display: 'flex', gap: 6, marginTop: 6, flexWrap: 'wrap' }}>
                   <LiveGauge label="LAMBDA" value={live.sensedLambda.toFixed(2)} unit="λ" color={T.violet} />
                   <LiveGauge label="COOLANT" value={Math.round(live.sensedCoolant)} unit="°C" warn={live.sensedCoolant > 105} />
-                  <LiveGauge label="TIMING" value={live.live ? live.live.timing : '—'} unit="°" color={T.warn} warn={!!(live.live && live.live.knock)} />
+                  <LiveGauge label="TIMING" value={live.live ? live.live.timing : '—'} unit="°" warn={!!(live.live && live.live.knock)} />
                 </div>
                 <div style={{ display: 'flex', gap: 6, marginTop: 6, flexWrap: 'wrap' }}>
                   <LiveGauge label="INJ PW" value={live.live ? live.live.pw : '—'} unit="ms" />
@@ -1615,7 +1619,7 @@ export function EcuLabApp() {
                       {[-5, -1, 1, 5].map((d) => (
                         <button key={d} onClick={() => setBoostAt(boostSel, (boostCurve[boostSel] ?? 0) + d)}
                           style={{ flex: 1, padding: '11px 0', borderRadius: 8, border: `1px solid ${T.line}`, background: T.panel,
-                            color: d < 0 ? T.accInk : T.ok, fontWeight: 800, fontFamily: T.mono, fontSize: 14 }}>
+                            color: T.accInk, fontWeight: 800, fontFamily: T.mono, fontSize: 14 }}>
                           {d > 0 ? '+' : ''}{d}
                         </button>
                       ))}
@@ -2045,8 +2049,11 @@ export function EcuLabApp() {
                       <Tooltip contentStyle={{ background: T.panel2, border: `1px solid ${T.line}`, fontSize: 11 }} />
                       <Legend wrapperStyle={{ fontSize: 11 }} />
                       <Line dataKey="afrCommanded" name="AFR commanded" stroke={T.ink3} strokeDasharray="3 3" dot={false} isAnimationActive={false} />
-                      <Line dataKey="afr" name="AFR actual" stroke={T.ok} strokeWidth={2} dot={false} isAnimationActive={false} />
-                      <Line dataKey="timing" name="Timing used" stroke={T.warn} strokeWidth={2} dot={false} isAnimationActive={false} />
+                      {/* Series identity colours, not status: both lines are on screen for
+                          every pull, so green and amber here reported a health this chart
+                          never measures. */}
+                      <Line dataKey="afr" name="AFR actual" stroke={T.cyan} strokeWidth={2} dot={false} isAnimationActive={false} />
+                      <Line dataKey="timing" name="Timing used" stroke={T.violet} strokeWidth={2} dot={false} isAnimationActive={false} />
                     </LineChart>
                   </ResponsiveContainer>
                 </Panel>

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -1938,15 +1938,21 @@ export function EcuLabApp() {
 
             <div style={{ margin: '14px 0' }}><Tach rpm={running || result ? currentRpm : 1500} cylinders={engineDerived.cyl} running={running} fullScaleRpm={tachFullScaleRpm} /></div>
 
-            <button onClick={doRun} disabled={running} style={{
-              width: '100%', padding: '15px 0', borderRadius: 12, border: 'none', marginBottom: 16,
-              background: running ? T.panel3 : T.acc, color: running ? T.ink2 : T.accOn, fontWeight: 800, fontSize: 14.5,
-              display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8, letterSpacing: 0.3,
-              boxShadow: running ? 'none' : `0 6px 18px ${accAlpha(0.22)}`,
-            }}>
-              <Play size={16} />
-              {running ? 'SWEEPING…' : 'RUN DYNO PULL'}
-            </button>
+            {/* The app's most important control, and the one PR 1's review caught
+                rendering its label at 1.14:1 while running — panel3 fill under ink2
+                text. `disabled` now dims the whole button instead of recolouring the
+                label, so the contrast between fill and label never changes.
+
+                Deliberately NOT `block`. This sits in the main content column, which
+                on a desktop window is the window; the hand-rolled width:100% here is
+                the literal button that spanned the screen. `lg` gives it its weight
+                instead. */}
+            <div style={{ marginBottom: 16 }}>
+              <Button size="lg" onClick={doRun} disabled={running}>
+                <Play size={16} aria-hidden="true" />
+                {running ? 'SWEEPING…' : 'RUN DYNO PULL'}
+              </Button>
+            </div>
 
             {result && (
               <>
@@ -2119,9 +2125,14 @@ export function EcuLabApp() {
                       <br /><br />The ECU has no way to measure cylinder filling directly. It fuels from your table and nothing else, so a wrong table means wrong fuel, every time. Blue cells are within tolerance; red means your table is lying to the ECU at that point. Correct, re-pull, repeat until it is flat. A cell you hit squarely lands on the truth in one pass; the rest take a couple, because every logged point is interpolated between four cells.
                     </ExpandableInfo>
                     {!histogram ? (
-                      <button onClick={buildHistogram} style={{ width: '100%', padding: '12px 0', borderRadius: 10, border: `1px solid ${T.cyan}`, background: T.cyanBg, color: T.cyan, fontWeight: 800, fontSize: 12.5, marginBottom: 16 }}>
-                        BUILD HISTOGRAM FROM THIS PULL
-                      </button>
+                      /* Was a cyan-outlined width:100% bar. Cyan is the chart-series
+                         hue — the same borrowed colour Task 6 took off the intercooler
+                         toggle — so this takes the accent like every other action. */
+                      <div style={{ marginBottom: 16 }}>
+                        <Button onClick={buildHistogram}>
+                          BUILD HISTOGRAM FROM THIS PULL
+                        </Button>
+                      </div>
                     ) : (
                       <div style={{ marginBottom: 16 }}>
                         <div style={{ overflowX: 'auto', border: `1px solid ${T.line}`, borderRadius: 10, marginBottom: 8 }}>
@@ -2150,12 +2161,14 @@ export function EcuLabApp() {
                         </div>
                         <div style={{ fontSize: 10.5, color: T.ink3, marginBottom: 8 }}>Cells show % airflow error (blank = not visited during this pull). Rows are MAP kPa, columns RPM.</div>
                         <div style={{ display: 'flex', gap: 8 }}>
-                          <button onClick={applyHistogram} style={{ flex: 2, padding: '12px 0', borderRadius: 10, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 12.5 }}>
+                          <Button style={{ flex: 2 }} onClick={applyHistogram}>
                             APPLY CORRECTIONS TO VE
-                          </button>
-                          <button onClick={() => dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'histogram', value: null })} style={{ flex: 1, padding: '12px 0', borderRadius: 10, border: `1px solid ${T.line}`, background: T.panel2, color: T.ink2, fontWeight: 700, fontSize: 12.5 }}>
+                          </Button>
+                          {/* Not `danger`: discarding throws away a histogram that
+                              BUILD HISTOGRAM regenerates from the same pull. */}
+                          <Button variant="ghost" style={{ flex: 1 }} onClick={() => dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'histogram', value: null })}>
                             DISCARD
-                          </button>
+                          </Button>
                         </div>
                       </div>
                     )}

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -57,12 +57,7 @@ import { StoreProvider, useBuild, useSession, useTune } from './state/StoreProvi
 import { ACTIONS } from './state/reducer.js';
 import { Eyebrow } from './primitives/Eyebrow.jsx';
 import { Note } from './primitives/Note.jsx';
-
-const Panel = ({ children, style, tight }) => (
-  <div style={{ background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 12, padding: tight ? '10px 12px' : 14, ...style }}>
-    {children}
-  </div>
-);
+import { Panel } from './primitives/Panel.jsx';
 
 function ExpandableInfo({ title, children }) {
   const [open, setOpen] = useState(false);

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -1923,9 +1923,15 @@ export function EcuLabApp() {
               <div style={{ marginTop: 8 }}>
                 <Bar label="Duty" value={dutyPreview} higherIsBetter={false} />
               </div>
-              <div style={{ fontSize: 12, marginTop: 7, color: dutyDangerous ? T.dangerInk : T.inkSoft }}>
-                {dutyPreview.toFixed(0)}% duty {dutyDangerous ? '— undersized for this build, expect forced lean-out' : ''}
-              </div>
+              {/* The figure itself is the Bar's, now that it has a label row of its own —
+                  restating it here put the same number on screen twice, seven pixels
+                  apart. What is left is the part the Bar cannot say: what an undersized
+                  injector is about to do to the mixture. */}
+              {dutyDangerous && (
+                <div style={{ fontSize: 12, marginTop: 7, color: T.dangerInk }}>
+                  Undersized for this build — expect forced lean-out
+                </div>
+              )}
             </Panel>
 
             <Eyebrow icon={Zap}>Fuel Control &amp; MAF Scaling</Eyebrow>
@@ -2108,9 +2114,12 @@ export function EcuLabApp() {
                               : p.richRisk ? 'far richer than commanded — check injector scaling'
                               : `lambda ${p.lambda} · best power here is ${p.bestAfr}:1`,
                             ok: !p.fuelLimited && !p.richRisk && !p.leanRisk },
+                          // Same "no headroom left" cutoff as the build tab's duty preview,
+                          // asked the same way: utilisationColor owns the band, and this
+                          // reads its verdict rather than restating >90 twice more.
                           { k: 'Injectors', asked: null, got: `${p.duty}% duty`,
-                            note: `${p.pw} ms of the ${(120000 / p.rpm).toFixed(1)} ms available${p.duty > 90 ? ' — at the limit' : ''}`,
-                            ok: p.duty <= 90 },
+                            note: `${p.pw} ms of the ${(120000 / p.rpm).toFixed(1)} ms available${utilisationColor(p.duty) === T.danger ? ' — at the limit' : ''}`,
+                            ok: utilisationColor(p.duty) !== T.danger },
                           { k: 'Heat', asked: null, got: `${p.egt}°C`,
                             note: `intake charge ${p.iat}°C${p.egtRisk ? ' · exhaust running hot — retard and lean mixture are what put it there' : ''}`,
                             ok: !p.egtRisk },

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -1366,7 +1366,12 @@ export function EcuLabApp() {
             >
               <div style={{ fontSize: 12, color: T.ink2, marginBottom: 6, fontWeight: 600 }}>Start From a Real Engine</div>
               <Select
-                label="Start from a real engine"
+                // The primitive is inline-block with a 200px floor, so it must be told
+                // to fill this column — the legacy control was width:100% and the
+                // section is a single narrow stack. The margin is the 13px the old one
+                // carried; nothing after it should close up.
+                style={{ display: 'block', marginBottom: 13 }}
+                label="Start From a Real Engine"
                 groups={PRESET_GROUPS.map((g) => ({
                   label: g.manufacturer,
                   // The heading carries the manufacturer, so strip it off the option

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -345,7 +345,7 @@ function SelectionDock({ data, setData, selection, min, max, decimals, unit, onC
             {decimals ? current.toFixed(decimals) : Math.round(current)}<span style={{ fontSize: 12, color: T.ink2, marginLeft: 4 }}>{unit}</span>
           </div>
         </div>
-        <button onClick={onClose} style={{ color: T.ink2, background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 7, fontSize: 11.5, fontWeight: 700, padding: '8px 14px' }}>DONE</button>
+        <Button variant="ghost" size="sm" onClick={onClose}>DONE</Button>
       </div>
       {selection.type === 'cell' && kind && (() => {
         const ref = cellReference(kind, selection.row, selection.col, current);
@@ -1709,9 +1709,12 @@ export function EcuLabApp() {
                         <div style={{ fontSize: 10.5, color: T.cyan, fontFamily: T.mono, marginTop: 3 }}>{r.cells.join('   ')}</div>
                       </div>
                     ))}
-                    <button onClick={recalcVE} style={{ width: '100%', marginTop: 4, padding: '11px 0', borderRadius: 9, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 12.5 }}>
+                    {/* Was width:100%. It is the only action in this advisory box and
+                        reads as one at its own width; the box is already the full
+                        content column, so stretching it only made it wider. */}
+                    <Button onClick={recalcVE} style={{ marginTop: 4 }}>
                       ACCEPT RE-LOGGED VALUES
-                    </button>
+                    </Button>
                     <div style={{ fontSize: 10.5, color: T.ink3, textAlign: 'center', marginTop: 6 }}>Or type them in yourself — these are the measured targets, not a suggestion.</div>
                   </div>
                 )
@@ -1837,9 +1840,14 @@ export function EcuLabApp() {
             {ecuInjectorCc !== injectorCc ? (
               <div style={{ background: T.dangerBg, border: `1px solid ${T.dangerLine}`, borderRadius: 10, padding: '11px 13px', margin: '8px 0', fontSize: 12, color: T.dangerInk, lineHeight: 1.5 }}>
                 <b>Scaling mismatch.</b> Hardware is {injectorCc}cc but the ECU is calibrated for {ecuInjectorCc}cc — every pulse delivers about {((injectorCc / ecuInjectorCc) * 100).toFixed(0)}% of the intended fuel, so the engine runs {injectorCc > ecuInjectorCc ? 'far too rich' : 'dangerously lean'} everywhere.
-                <button onClick={() => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'ecuInjectorCc', value: injectorCc })} style={{ display: 'block', width: '100%', marginTop: 9, padding: '10px 0', borderRadius: 8, border: 'none', background: T.acc, color: T.accOn, fontWeight: 800, fontSize: 12.5 }}>
-                  RESCALE ECU TO {injectorCc}cc
-                </button>
+                {/* The wrapper, not the button, is what breaks the line: the button
+                    sits inside a paragraph and is inline-flex, so without a block
+                    parent it would run on from the end of the warning text. */}
+                <div style={{ marginTop: 9 }}>
+                  <Button onClick={() => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'ecuInjectorCc', value: injectorCc })}>
+                    RESCALE ECU TO {injectorCc}cc
+                  </Button>
+                </div>
               </div>
             ) : (
               <div style={{ fontSize: 11, color: T.ok, margin: '6px 0 4px' }}>ECU scaling matches the fitted injectors.</div>

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -186,7 +186,7 @@ function DialMark({ size = 64, pct = 0.62, live = false }) {
           <line key={i}
             x1={50 + inner * Math.sin(a)} y1={50 - inner * Math.cos(a)}
             x2={50 + outer * Math.sin(a)} y2={50 - outer * Math.cos(a)}
-            stroke={i > 9 ? T.danger : T.line === T.line ? T.ink3 : T.line} strokeWidth={i % 3 === 0 ? 1.6 : 1} />
+            stroke={i > 9 ? T.danger : T.ink3} strokeWidth={i % 3 === 0 ? 1.6 : 1} />
         );
       })}
       <g style={{ transition: live ? 'none' : 'transform .6s cubic-bezier(.34,1.4,.64,1)' }} transform={`rotate(${angle} 50 50)`}>
@@ -217,8 +217,11 @@ function Tach({ rpm, cylinders, running, fullScaleRpm }) {
         {Array.from({ length: cylinders }).map((_, i) => (
           <div key={i} style={{
             width: 8, height: 24, borderRadius: 2, background: zoneColor,
-            animation: running ? `cylpulse ${Math.max(0.12, 50 / Math.max(rpm, 500))}s ease-in-out infinite` : 'none',
-            animationDelay: `${i * (0.5 / cylinders)}s`, opacity: running ? undefined : 0.3,
+            // Duration then delay, both inside the shorthand: `animation` resets
+            // `animation-delay`, so declaring the longhand beside it left the
+            // per-cylinder stagger dependent on property order.
+            animation: running ? `cylpulse ${Math.max(0.12, 50 / Math.max(rpm, 500))}s ${i * (0.5 / cylinders)}s ease-in-out infinite` : 'none',
+            opacity: running ? undefined : 0.3,
           }} />
         ))}
       </div>

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -1431,10 +1431,10 @@ export function EcuLabApp() {
                     {/* The one `danger` in the app. This prompt is raised ONLY when
                         `hasTuningWork()` is true, so confirming it always destroys
                         hand-edited VE/spark/fuel tables that nothing can restore. */}
-                    <Button variant="danger" size="sm" style={{ flex: 1 }} onClick={() => applyEnginePreset(presetPrompt)}>
+                    <Button variant="danger" style={{ flex: 1 }} onClick={() => applyEnginePreset(presetPrompt)}>
                       LOAD {presetPrompt.name.toUpperCase()}
                     </Button>
-                    <Button variant="ghost" size="sm" style={{ flex: 1 }} onClick={() => dispatch({ type: ACTIONS.SET_PRESET_PROMPT, value: null })}>
+                    <Button variant="ghost" style={{ flex: 1 }} onClick={() => dispatch({ type: ACTIONS.SET_PRESET_PROMPT, value: null })}>
                       CANCEL
                     </Button>
                   </div>

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -48,7 +48,7 @@ import {
   deriveEngine, idealExhaustDiameter, interp2, presetById,
   simulateSweep, turbineWithCount, veRecommendations
 } from '../sim/index.js';
-import { T, accAlpha, deltaHeat, heat, shadowAlpha, statusColor, statusTone } from './theme.js';
+import { T, accAlpha, deltaHeat, heat, shadowAlpha, statusColor, statusTone, utilisationColor } from './theme.js';
 import { BUILD_VERSION } from '../version.js';
 import { loadCareer, saveCareer } from '../storage.js';
 import { StartScreen } from './screens/StartScreen.jsx';
@@ -59,6 +59,7 @@ import { Eyebrow } from './primitives/Eyebrow.jsx';
 import { Note } from './primitives/Note.jsx';
 import { Panel } from './primitives/Panel.jsx';
 import { StatTile } from './primitives/StatTile.jsx';
+import { Bar } from './primitives/Bar.jsx';
 
 function ExpandableInfo({ title, children }) {
   const [open, setOpen] = useState(false);
@@ -170,20 +171,6 @@ function ToggleRow({ label, sub, checked, onChange, color = T.acc }) {
   );
 }
 
-function HealthBar({ label, value }) {
-  const c = statusColor(value);
-  return (
-    <div style={{ marginBottom: 10 }}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: 10.5, color: T.ink2, marginBottom: 4, fontWeight: 600 }}>
-        <span>{label}</span><span style={{ color: c, fontWeight: 800 }}>{Math.round(value)}%</span>
-      </div>
-      <div style={{ height: 7, background: T.panel, borderRadius: 4, overflow: 'hidden', border: `1px solid ${T.line}` }}>
-        <div style={{ width: `${value}%`, height: '100%', background: c, borderRadius: 4, transition: 'width .4s', boxShadow: `0 0 8px ${c}66` }} />
-      </div>
-    </div>
-  );
-}
-
 // Guided first run. Walks a new player through the actual working order a tuner
 // uses — build the engine, calibrate it, hear it run, then measure it — and then
 // gets out of the way. Purely navigational: it never changes the simulation.
@@ -279,7 +266,7 @@ function Tach({ rpm, cylinders, running, fullScaleRpm }) {
   // fullScaleRpm is redline * 1.1 (see tachFullScaleRpm), so redline itself always
   // sits at pct ≈ 0.909 regardless of engine — the red zone has to start at or just
   // below that, not above it, or the needle never shows red at the engine's own redline.
-  const zoneColor = pct > 0.9 ? T.danger : pct > 0.75 ? T.warn : T.ok;
+  const zoneColor = utilisationColor(pct * 100);
   return (
     <Panel style={{ textAlign: 'center', background: T.panel }}>
       <style>{`@keyframes cylpulse{0%,100%{opacity:.25;transform:scaleY(.6)}50%{opacity:1;transform:scaleY(1)}}`}</style>
@@ -662,6 +649,10 @@ export function EcuLabApp() {
     const pw = fuelMassG / ((ecuInjectorCc * fuel.density) / 60000) + INJ_DEADTIME_MS;
     return clamp((pw / (120000 / rpm)) * 100, 0, 220);
   }, [ve, afr, turboOn, boostCurve, ecuInjectorCc, fuel, mods.intercooler, engineDerived]);
+  // Single source of truth for the "no headroom left" cutoff is utilisationColor's
+  // own >90 band — comparing its output rather than re-testing dutyPreview keeps this
+  // caption from becoming a fourth copy of the threshold.
+  const dutyDangerous = utilisationColor(dutyPreview) === T.danger;
 
   const needsMafRecal = mods.intake || turboOn;
   const changeTab = (t) => { setTab(t); setSelection(null); };
@@ -1279,9 +1270,11 @@ export function EcuLabApp() {
               sub={`${Math.round(overallHealth)}% overall`}
             >
               <Panel>
-                <HealthBar label="PISTON / RINGS · knock, detonation" value={health.piston} />
-                <HealthBar label="BEARINGS · sustained cylinder pressure" value={health.bearing} />
-                <HealthBar label="VALVES · lean-under-boost heat" value={health.valve} />
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+                  <Bar label="PISTON / RINGS · knock, detonation" value={health.piston} />
+                  <Bar label="BEARINGS · sustained cylinder pressure" value={health.bearing} />
+                  <Bar label="VALVES · lean-under-boost heat" value={health.valve} />
+                </div>
               </Panel>
               {needsMafRecal && <Note tone="warn">Your intake and/or turbo plumbing changed the MAF reading — head to <b>FUEL</b> to rescale it before your next pull.</Note>}
             </BuildSection>
@@ -1927,11 +1920,11 @@ export function EcuLabApp() {
                 <div style={{ fontSize: 10, color: T.ink2, letterSpacing: 1, fontWeight: 700 }}>INJECTOR DUTY PREVIEW · WOT @ 6500 RPM</div>
                 {fuel.stoich < 14 && <div style={{ fontSize: 10, color: T.accInk, fontFamily: T.mono, fontWeight: 700 }}>{fuel.label} stoich {fuel.stoich}:1</div>}
               </div>
-              <div style={{ height: 8, background: T.panel, borderRadius: 4, marginTop: 8, overflow: 'hidden', border: `1px solid ${T.line}` }}>
-                <div style={{ width: `${Math.min(100, dutyPreview)}%`, height: '100%', background: dutyPreview > 90 ? T.danger : dutyPreview > 75 ? T.warn : T.ok }} />
+              <div style={{ marginTop: 8 }}>
+                <Bar label="Duty" value={dutyPreview} higherIsBetter={false} />
               </div>
-              <div style={{ fontSize: 12, marginTop: 7, color: dutyPreview > 90 ? T.dangerInk : T.inkSoft }}>
-                {dutyPreview.toFixed(0)}% duty {dutyPreview > 90 ? '— undersized for this build, expect forced lean-out' : ''}
+              <div style={{ fontSize: 12, marginTop: 7, color: dutyDangerous ? T.dangerInk : T.inkSoft }}>
+                {dutyPreview.toFixed(0)}% duty {dutyDangerous ? '— undersized for this build, expect forced lean-out' : ''}
               </div>
             </Panel>
 

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -55,31 +55,14 @@ import { StartScreen } from './screens/StartScreen.jsx';
 import { TutorialScreen } from './screens/TutorialScreen.jsx';
 import { StoreProvider, useBuild, useSession, useTune } from './state/StoreProvider.jsx';
 import { ACTIONS } from './state/reducer.js';
-
-const Eyebrow = ({ children, icon: Icon }) => (
-  <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
-    <div style={{ width: 3, height: 13, background: T.acc, borderRadius: 2 }} />
-    {Icon && <Icon size={13} color={T.accInk} />}
-    <span style={{ fontSize: 10.5, letterSpacing: 1.6, color: T.accInk, textTransform: 'uppercase', fontWeight: 800 }}>{children}</span>
-  </div>
-);
+import { Eyebrow } from './primitives/Eyebrow.jsx';
+import { Note } from './primitives/Note.jsx';
 
 const Panel = ({ children, style, tight }) => (
   <div style={{ background: T.panel2, border: `1px solid ${T.line}`, borderRadius: 12, padding: tight ? '10px 12px' : 14, ...style }}>
     {children}
   </div>
 );
-
-const Note = ({ children, tone = 'info' }) => {
-  const colors = { info: [T.ink2, T.line, T.panel2], warn: [T.warn, T.warnLine, T.warnBg] };
-  const [fg, bd, bgc] = colors[tone] || colors.info;
-  return (
-    <div style={{ display: 'flex', gap: 9, background: bgc, border: `1px solid ${bd}`, borderRadius: 10, padding: '11px 13px', margin: '10px 0', fontSize: 12.5, color: fg === T.ink2 ? T.inkSoft : fg, lineHeight: 1.55 }}>
-      <Info size={15} style={{ flexShrink: 0, marginTop: 1, color: fg }} />
-      <div>{children}</div>
-    </div>
-  );
-};
 
 function ExpandableInfo({ title, children }) {
   const [open, setOpen] = useState(false);

--- a/src/ui/primitives/Button.module.css
+++ b/src/ui/primitives/Button.module.css
@@ -10,7 +10,13 @@
   font-family: var(--sans);
   font-weight: 800;
   letter-spacing: 0.05em;
-  white-space: nowrap;
+  /* No `white-space: nowrap`, and `min-width: 0` so a flex item can shrink
+     below its label's content width. A row like LOAD <preset name> / CANCEL
+     inside a narrow card needs somewhere to go under `nowrap`'s default
+     min-width: auto: it either overflows the card or it wraps. A two-line
+     button that stays inside its container beats a one-line button that
+     escapes it, so wrapping is left on. */
+  min-width: 0;
   cursor: pointer;
   transition: background-color 0.14s ease, border-color 0.14s ease, color 0.14s ease;
 }
@@ -20,8 +26,15 @@
   outline-offset: 2px;
 }
 
+/* Named, not composited: opacity over --bg compresses fill and label toward
+   each other's backdrop, which drags contrast toward 1:1 rather than
+   preserving it. Naming the disabled colours keeps them moving together
+   for real, at 4.59:1 (--panel3 on --ink2) instead of collapsing to 2.24:1. */
 .button:disabled {
-  opacity: 0.45;
+  opacity: 1;
+  background: var(--panel3);
+  color: var(--ink2);
+  border-color: var(--line);
   cursor: not-allowed;
 }
 

--- a/src/ui/primitives/Button.module.css
+++ b/src/ui/primitives/Button.module.css
@@ -66,13 +66,17 @@
 }
 .danger:hover:not(:disabled) { background: var(--danger); color: var(--bg); }
 
-/* Text-only, for escape hatches that must not compete with the primary action. */
+/* Text-only, for escape hatches that must not compete with the primary action.
+   Quiet is about weight, not legibility: --ink3 measured 2.87-3.47:1 across the
+   surfaces these buttons land on (--acc-bg, --bg), well under AA for 10.5px text,
+   and with no fill or border to read the control by there is nothing else to see.
+   --ink2 clears 4.5:1 everywhere and still sits two steps below the primary. */
 .quiet {
   background: transparent;
   border-color: transparent;
-  color: var(--ink3);
+  color: var(--ink2);
 }
-.quiet:hover:not(:disabled) { color: var(--ink2); }
+.quiet:hover:not(:disabled) { color: var(--ink); }
 
 /* --- sizes --- */
 

--- a/src/ui/primitives/Panel.jsx
+++ b/src/ui/primitives/Panel.jsx
@@ -5,10 +5,17 @@ import React from 'react';
 import styles from './Panel.module.css';
 
 /**
- * @param {object} props
- * @param {React.ReactNode} props.children
- * @param {boolean} [props.tight] reduce the padding
- * @param {React.ElementType} [props.as] element to render, defaults to a div
+ * @typedef {Object} PanelProps
+ * @property {React.ReactNode} children
+ * @property {boolean} [tight] reduce the padding
+ * @property {React.ElementType} [as] element to render, defaults to a div
+ */
+
+/**
+ * Anything not named above — `style`, `className`, `id`, `aria-*` — lands on the
+ * element, which is how a caller supplies the layout the panel does not own.
+ *
+ * @param {PanelProps & React.HTMLAttributes<HTMLDivElement>} props
  * @returns {React.ReactElement}
  */
 export function Panel({ children, tight = false, as: As = 'div', ...rest }) {

--- a/src/ui/primitives/Select.jsx
+++ b/src/ui/primitives/Select.jsx
@@ -4,10 +4,12 @@
  * Deliberately native: keyboard navigation, type-ahead and screen-reader semantics
  * come free, and on a phone it opens the platform picker. Only the chevron is ours.
  *
- * Known migration gap: the legacy `GroupedSelect` this replaces is `width: 100%`
- * with a bottom margin; this primitive's wrapper is `inline-block` with a
- * `min-width`. A drop-in swap will change layout at every call site — callers
- * will need to size and space it themselves.
+ * Sizing is the caller's. The legacy `GroupedSelect` this replaces was `width: 100%`
+ * with a bottom margin; this wrapper is `inline-block` with a `min-width`, so a bare
+ * swap makes the control shrink to its content. Anything not named here — `style`,
+ * `className`, `id` — lands on the wrapper, which is how a caller sizes and spaces it.
+ * Without that passthrough the instruction to "size it yourself" had no mechanism
+ * behind it.
  */
 
 import { ChevronDown } from 'lucide-react';
@@ -16,17 +18,21 @@ import React from 'react';
 import styles from './Select.module.css';
 
 /**
- * @param {object} props
- * @param {string} props.label accessible name
- * @param {Array<{label: string, options: Array<{value: string, label: string}>}>} props.groups
- * @param {Array<{value: string, label: string}>} [props.extra] ungrouped options, appended last
- * @param {string} props.value
- * @param {(value: string) => void} props.onChange
+ * @typedef {Object} SelectProps
+ * @property {string} label accessible name
+ * @property {Array<{label: string, options: Array<{value: string, label: string}>}>} groups
+ * @property {Array<{value: string, label: string}>} [extra] ungrouped options, appended last
+ * @property {string} value
+ * @property {(value: string) => void} onChange
+ */
+
+/**
+ * @param {SelectProps & React.HTMLAttributes<HTMLDivElement>} props
  * @returns {React.ReactElement}
  */
-export function Select({ label, groups, extra = [], value, onChange }) {
+export function Select({ label, groups, extra = [], value, onChange, ...rest }) {
   return (
-    <div className={styles.wrap}>
+    <div className={styles.wrap} {...rest}>
       <select
         className={styles.select}
         aria-label={label}

--- a/src/ui/primitives/StatTile.jsx
+++ b/src/ui/primitives/StatTile.jsx
@@ -9,7 +9,9 @@ import styles from './StatTile.module.css';
  * @param {string} props.label
  * @param {string|number} props.value
  * @param {string} [props.unit]
- * @param {'neutral'|'acc'|'ok'|'warn'|'danger'} [props.tone]
+ * @param {'neutral'|'acc'|'alt'|'ok'|'warn'|'danger'} [props.tone] `alt` marks the
+ *   second quantity in a paired readout (e.g. torque beside a power figure in `acc`)
+ *   so the two can be told apart at a glance. It is never a status.
  * @returns {React.ReactElement}
  */
 export function StatTile({ label, value, unit, tone = 'neutral' }) {

--- a/src/ui/primitives/StatTile.module.css
+++ b/src/ui/primitives/StatTile.module.css
@@ -12,7 +12,7 @@
   font-size: var(--fs-micro);
   font-weight: 700;
   letter-spacing: 0.12em;
-  color: var(--ink3);
+  color: var(--ink2);
 }
 
 .value {
@@ -30,7 +30,8 @@
   color: var(--ink2);
 }
 
-.acc .value { color: var(--acc); }
+.acc .value { color: var(--acc-ink); }
+.alt .value { color: var(--cyan); }
 .ok .value { color: var(--ok); }
 .warn .value { color: var(--warn); }
 .danger .value { color: var(--danger); }

--- a/src/ui/primitives/Toggle.jsx
+++ b/src/ui/primitives/Toggle.jsx
@@ -1,10 +1,13 @@
 /**
  * An on/off row for a single hardware option.
  *
- * Known migration gap: the legacy `ToggleRow` this replaces has a `color` prop,
- * used non-default at one call site (the intercooler toggle, `color={T.cyan}`).
- * This primitive has no equivalent. Migrating that call site needs a decision:
- * either add the prop here, or accept the default accent colour there.
+ * There is deliberately no `color` prop. The legacy `ToggleRow` this replaces had one,
+ * used at a single call site to paint the intercooler switch `T.cyan` — a chart-series
+ * token, documented in `tokens.js` as the "secondary data hue, for charts that must plot
+ * two series at once". One control wearing a colour that means something else elsewhere
+ * is the rule this design system is built on being broken: the accent is never a status,
+ * and a status is never decoration. That call site now uses the accent like every other
+ * toggle, and the decision is closed — do not re-add the prop.
  */
 
 import React, { useId } from 'react';

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -56,6 +56,19 @@ const T = {
 export const statusColor = (v) => (v >= 90 ? T.ok : v >= 55 ? T.warn : T.danger);
 
 /**
+ * The NAME of the band `statusColor` paints, for consumers that take a semantic tone
+ * rather than a colour — `StatTile`, and anything else with a token-driven variant.
+ *
+ * Derived from the same comparison as `statusColor` rather than repeating its
+ * thresholds, because two copies of a band drift apart and then disagree about
+ * whether the same number is a warning.
+ *
+ * @param {number} v 0-100
+ * @returns {'ok'|'warn'|'danger'}
+ */
+export const statusTone = (v) => (v >= 90 ? 'ok' : v >= 55 ? 'warn' : 'danger');
+
+/**
  * Status colour for a value where HIGH is the dangerous end: injector duty cycle,
  * or any "how much of the available capacity is spent" reading.
  *

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -52,21 +52,22 @@ const T = {
   sans: tokens.sans,
 };
 
-/** Maps a 0-100 health/quality value onto the green/amber/red status scale. */
-export const statusColor = (v) => (v >= 90 ? T.ok : v >= 55 ? T.warn : T.danger);
-
 /**
- * The NAME of the band `statusColor` paints, for consumers that take a semantic tone
- * rather than a colour — `StatTile`, and anything else with a token-driven variant.
+ * The NAME of the band a 0-100 health/quality value falls into, for consumers that
+ * take a semantic tone rather than a colour — `StatTile`, and anything else with a
+ * token-driven variant.
  *
- * Derived from the same comparison as `statusColor` rather than repeating its
- * thresholds, because two copies of a band drift apart and then disagree about
- * whether the same number is a warning.
+ * The single source of truth for where the bands sit. `statusColor` below maps this
+ * tone onto a colour rather than repeating the thresholds, because two copies of a
+ * band drift apart and then disagree about whether the same number is a warning.
  *
  * @param {number} v 0-100
  * @returns {'ok'|'warn'|'danger'}
  */
 export const statusTone = (v) => (v >= 90 ? 'ok' : v >= 55 ? 'warn' : 'danger');
+
+/** Maps a 0-100 health/quality value onto the green/amber/red status scale. */
+export const statusColor = (v) => T[statusTone(v)];
 
 /**
  * Status colour for a value where HIGH is the dangerous end: injector duty cycle,

--- a/src/ui/theme.js
+++ b/src/ui/theme.js
@@ -83,10 +83,9 @@ export const statusColor = (v) => T[statusTone(v)];
  * sized so that sustained duty above ~90% has no headroom left for the next
  * enrichment the ECU asks for.
  *
- * These bands are copied exactly — thresholds and comparison operators — from the
- * inline duty preview in `EcuLab.jsx`. That copy is still there because this PR does
- * not migrate screens. When that panel moves onto `Bar`, delete the inline version
- * and call this instead; until then the two must be changed together.
+ * The bands live here alone now — the injector duty preview and the tachometer's
+ * redline zone in `EcuLab.jsx` both call this instead of re-testing the thresholds
+ * inline. Do not let a new inline copy creep back in; change the bands here.
  *
  * @param {number} v 0-100
  * @returns {string} a status colour

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -9,7 +9,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { tokens } from '../src/ui/tokens.js';
-import { T, heat, statusColor, utilisationColor } from '../src/ui/theme.js';
+import { T, heat, statusColor, statusTone, utilisationColor } from '../src/ui/theme.js';
 
 describe('T', () => {
   it('exposes every key the existing screens read', () => {
@@ -64,6 +64,22 @@ describe('utilisationColor', () => {
   it('is red above 90', () => {
     expect(utilisationColor(91)).toBe(tokens.danger);
     expect(utilisationColor(100)).toBe(tokens.danger);
+  });
+});
+
+describe('statusTone', () => {
+  it('names the same band statusColor paints', () => {
+    // The point of having both is that a caller who needs a token and a caller who
+    // needs a semantic name cannot end up on different sides of a threshold.
+    const cases = [100, 95, 90, 89, 60, 55, 54, 20, 0];
+    const map = { ok: T.ok, warn: T.warn, danger: T.danger };
+    cases.forEach((v) => {
+      expect(map[statusTone(v)]).toBe(statusColor(v));
+    });
+  });
+
+  it('returns exactly the three status names', () => {
+    expect(new Set([100, 60, 10].map(statusTone))).toEqual(new Set(['ok', 'warn', 'danger']));
   });
 });
 

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -68,13 +68,24 @@ describe('utilisationColor', () => {
 });
 
 describe('statusTone', () => {
-  it('names the same band statusColor paints', () => {
-    // The point of having both is that a caller who needs a token and a caller who
-    // needs a semantic name cannot end up on different sides of a threshold.
-    const cases = [100, 95, 90, 89, 60, 55, 54, 20, 0];
-    const map = { ok: T.ok, warn: T.warn, danger: T.danger };
-    cases.forEach((v) => {
-      expect(map[statusTone(v)]).toBe(statusColor(v));
+  it('names a tone for every band, and every name is a real token', () => {
+    // This used to compare `map[statusTone(v)]` against `statusColor(v)` across a
+    // spread of values. That test could not fail any more: `statusColor` is now
+    // `T[statusTone(v)]`, so the comparison reduced to `T[x] === T[x]` and held for
+    // any thresholds and any implementation. The property it claimed to guard —
+    // that the two cannot disagree — is now true by construction, which is why the
+    // restructure was worth making.
+    //
+    // What the restructure DID introduce is a new way to fail. `statusColor` used to
+    // name `T.ok`/`T.warn`/`T.danger` directly, so renaming one broke at the
+    // reference. It is now a dynamic lookup, and a rename would make `statusColor`
+    // return `undefined` — a colour that silently disappears rather than an error.
+    // That is what is worth pinning.
+    [100, 95, 90, 89, 60, 55, 54, 20, 0].forEach((v) => {
+      const tone = statusTone(v);
+      expect(Object.keys(T)).toContain(tone);
+      expect(typeof statusColor(v)).toBe('string');
+      expect(statusColor(v)).toMatch(/^#[0-9a-f]{6}$/i);
     });
   });
 

--- a/tests/ui/build-store.test.jsx
+++ b/tests/ui/build-store.test.jsx
@@ -563,3 +563,38 @@ describe('every segmented control', () => {
     expect(total).toBe(8);
   });
 });
+
+describe('every toggle', () => {
+  it('is a named switch that reports its own state', () => {
+    // A Toggle is the one control here with no visible text of its own on the switch —
+    // its whole identity is the accessible name and the aria-checked state. Drop the
+    // label at a call site and it still renders, still works, and announces itself as
+    // an unnamed switch; get `checked` wrong and it reports the opposite of the build.
+    // EcuLab.jsx carries @ts-nocheck, so neither lint nor tsc sees either mistake, and
+    // Toggle's own tests render it in isolation and never inspect what the app passes.
+    launch();
+    fireEvent.click(screen.getByText('Forced Induction'));
+    const switches = screen.getAllByRole('switch');
+    expect(switches.length).toBeGreaterThan(0);
+    switches.forEach((sw) => {
+      expect(sw.getAttribute('aria-label') || sw.textContent).toBeTruthy();
+      expect(sw.getAttribute('aria-checked')).toMatch(/^(true|false)$/);
+    });
+  });
+
+  it('installs the intercooler when switched on, and reports it', () => {
+    // The intercooler had no coverage at all, before this migration or after. It is
+    // also the call site that lost a prop in the swap, so it is the one most likely to
+    // have been broken by it.
+    launch();
+    fireEvent.click(screen.getByText('Forced Induction'));
+    const intercooler = screen.getByRole('switch', { name: /Intercooler/ });
+    expect(intercooler.getAttribute('aria-checked')).toBe('false');
+
+    fireEvent.click(intercooler);
+
+    expect(screen.getByRole('switch', { name: /Intercooler/ }).getAttribute('aria-checked')).toBe('true');
+    // And it reached the build, not just the switch: the parts count reads the mod set.
+    expect(screen.getByText(/[1-4]\/4 installed/)).toBeTruthy();
+  });
+});

--- a/tests/ui/build-store.test.jsx
+++ b/tests/ui/build-store.test.jsx
@@ -504,3 +504,62 @@ describe('the injector-duty preview call site', () => {
     expect(fill.style.background).toBe(refFill.style.background);
   });
 });
+
+/**
+ * The segmented controls on screen right now.
+ *
+ * `role="group"` alone is not enough: `<optgroup>` carries that role implicitly, so the
+ * preset picker's three manufacturer headings answer to it too. A Seg is the group whose
+ * children are `aria-pressed` buttons.
+ * @returns {HTMLElement[]}
+ */
+function segmentedControls() {
+  return screen.queryAllByRole('group')
+    .filter((g) => g.querySelector('button[aria-pressed]'));
+}
+
+/** Asserts every Seg on the current screen shows exactly one option as selected. */
+function expectEverySegHasOneSelection() {
+  const groups = segmentedControls();
+  expect(groups.length).toBeGreaterThan(0);
+  groups.forEach((group) => {
+    // `label` is the group's accessible name and the primitive has no default. Drop it
+    // at a call site and the control still renders, still works, and announces itself
+    // as an unnamed group of buttons — so a screen-reader user hears the options with
+    // no idea what choice they belong to. Counting selections alone does not see that.
+    expect(group.getAttribute('aria-label')).toBeTruthy();
+    const pressed = within(group).getAllByRole('button', { pressed: true });
+    expect(pressed).toHaveLength(1);
+  });
+  return groups.length;
+}
+
+describe('every segmented control', () => {
+  it('shows exactly one option as selected, on every tab that has one', () => {
+    // Seg's options changed shape from {value,label} to {id,label}. A call site left on
+    // the old shape gives every option `id: undefined`, so `aria-pressed` is false on
+    // ALL of them and `onChange` fires with undefined — the control renders, shows no
+    // selection, and writes garbage into the build. EcuLab.jsx carries @ts-nocheck, so
+    // neither lint nor tsc can see it, and the primitive's own tests render it in
+    // isolation and never inspect what the app passes.
+    //
+    // Counting pressed options catches that without naming a single call site, so a
+    // ninth Seg added later is covered the day it appears.
+    launch();
+    let total = expectEverySegHasOneSelection();
+
+    // The remaining Segs are on other tabs, and the two ECU ones are behind a sub-view
+    // that is not the default.
+    fireEvent.click(screen.getByRole('button', { name: /TUNE/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'ECU' }));
+    total += expectEverySegHasOneSelection();
+
+    fireEvent.click(screen.getByRole('button', { name: /DYNO/ }));
+    total += expectEverySegHasOneSelection();
+
+    // Guard the sweep itself: if navigation silently failed, the per-tab assertions
+    // above would each pass on whatever happened to be showing. Eight is the count of
+    // <Seg> call sites in EcuLab.jsx today.
+    expect(total).toBe(8);
+  });
+});

--- a/tests/ui/build-store.test.jsx
+++ b/tests/ui/build-store.test.jsx
@@ -28,6 +28,7 @@ import {
 } from '../../src/sim/index.js';
 import { LOAD, RPM } from '../../src/sim/tables.js';
 import EcuLab, { EcuLabApp } from '../../src/ui/EcuLab.jsx';
+import { Bar } from '../../src/ui/primitives/Bar.jsx';
 import { StoreProvider, useBuild, useTune } from '../../src/ui/state/StoreProvider.jsx';
 import { ACTIONS } from '../../src/ui/state/reducer.js';
 
@@ -442,5 +443,64 @@ describe('choosing Custom build from the preset picker', () => {
     fireEvent.change(presetPicker(), { target: { value: '__custom__' } });
 
     expect(headerEngineName()).toMatch(/^\d\.\dL /);
+  });
+});
+
+describe('the injector-duty preview call site', () => {
+  it('paints the Duty bar as dangerous, not healthy, once duty cycle has no headroom left', () => {
+    // TUNE/readouts.test.jsx's describe('Bar') proves the PRIMITIVE inverts colour
+    // correctly given higherIsBetter={false} — it renders Bar in isolation. It says
+    // nothing about whether EcuLab's own INJECTOR DUTY PREVIEW call site (ECU Fuel
+    // System, EcuLab.jsx ~1924) actually PASSES that prop. A reviewer flipped it to
+    // higherIsBetter={true} — 95% duty, an injector out of headroom and about to lean
+    // the mixture out, painted bright green — and all existing tests, including the
+    // Bar unit tests, stayed green. This drives the real app to a build that reaches
+    // a genuinely dangerous duty cycle and reads the colour off the rendered bar.
+    launch();
+
+    // dutyPreview (EcuLab.jsx:639) is computed at WOT @ 6500 RPM. It scales inversely
+    // with ecuInjectorCc (a fresh build already starts at 315cc, the smallest on the
+    // menu, so no edit is needed there) and rises with airflow — so fit a turbo and
+    // dial the boost target at 6500 RPM to its maximum.
+    fireEvent.click(screen.getByRole('button', { name: /BUILD/ }));
+    fireEvent.click(screen.getByText('Forced Induction'));
+    fireEvent.click(toggleFor('Turbo kit'));
+
+    const columns = within(screen.getByTestId('boost-columns')).getAllByRole('button');
+    fireEvent.click(columns[RPM.indexOf(6500)]);
+    // Every collapsed BuildSection stays mounted (its content is hidden with
+    // max-height, not unmounted — see BuildSection in EcuLab.jsx), so the Engine
+    // Architecture section's five sliders are still in the DOM here alongside the
+    // boost slider. max=25 is unique to the boost-curve range input.
+    const slider = screen.getAllByRole('slider').find((s) => s.getAttribute('max') === '25');
+    fireEvent.change(slider, { target: { value: '25' } });
+
+    // The true VE the boosted hardware breathes is not what the ECU's calibration
+    // table believes until the player accepts it — RESET ALL TO STOCK rebuilds the VE
+    // table from the CURRENT hardware (hwForVe, which reads turboOn and boostCurve),
+    // which is what lets dutyPreview's own VE lookup see the boosted cylinder filling
+    // instead of the naturally-aspirated baseline it started on.
+    fireEvent.click(screen.getByRole('button', { name: /RESET ALL TO STOCK/ }));
+
+    fireEvent.click(screen.getByRole('button', { name: /TUNE/ }));
+    fireEvent.click(screen.getByRole('button', { name: 'ECU' }));
+
+    const meter = screen.getByRole('meter', { name: 'Duty' });
+    const dutyValue = Number(meter.getAttribute('aria-valuenow'));
+    // Guard the setup rather than trusting it: utilisationColor's danger band is
+    // strictly above 90. If the boost/injector combination above did not actually
+    // push duty past that line, the colour assertion below could pass or fail for
+    // the wrong reason.
+    expect(dutyValue).toBeGreaterThan(90);
+
+    // Compare against a Bar known to render dangerous, the same way
+    // readouts.test.jsx's own describe('Bar') tests do, rather than a hardcoded
+    // colour literal: jsdom normalizes an inline `background` to `rgb(...)`, so a
+    // hex literal copied out of theme.js would never string-match what the DOM
+    // actually holds.
+    const dangerRef = render(<Bar label="Reference" value={20} max={100} />);
+    const fill = /** @type {HTMLElement} */ (meter.querySelector('[data-fill]'));
+    const refFill = /** @type {HTMLElement} */ (dangerRef.container.querySelector('[data-fill]'));
+    expect(fill.style.background).toBe(refFill.style.background);
   });
 });

--- a/tests/ui/build-store.test.jsx
+++ b/tests/ui/build-store.test.jsx
@@ -565,21 +565,39 @@ describe('every segmented control', () => {
 });
 
 describe('every toggle', () => {
-  it('is a named switch that reports its own state', () => {
-    // A Toggle is the one control here with no visible text of its own on the switch —
-    // its whole identity is the accessible name and the aria-checked state. Drop the
-    // label at a call site and it still renders, still works, and announces itself as
-    // an unnamed switch; get `checked` wrong and it reports the opposite of the build.
-    // EcuLab.jsx carries @ts-nocheck, so neither lint nor tsc sees either mistake, and
-    // Toggle's own tests render it in isolation and never inspect what the app passes.
+  it('carries an accessible name at every call site', () => {
+    // Toggle puts the name in `aria-label`, so dropping `label` leaves a switch that
+    // renders, works, and announces itself unnamed. EcuLab.jsx carries @ts-nocheck and
+    // Toggle's own tests render it in isolation, so nothing else would see it.
+    //
+    // This asserts `aria-label` directly and deliberately does NOT fall back to
+    // textContent: the sub-label lives inside the same <button>, so textContent stays
+    // truthy with the name gone and the fallback made the assertion unfailable. An
+    // earlier version of this test had exactly that bug.
     launch();
     fireEvent.click(screen.getByText('Forced Induction'));
     const switches = screen.getAllByRole('switch');
-    expect(switches.length).toBeGreaterThan(0);
+    expect(switches.length).toBeGreaterThan(1);
     switches.forEach((sw) => {
-      expect(sw.getAttribute('aria-label') || sw.textContent).toBeTruthy();
-      expect(sw.getAttribute('aria-checked')).toMatch(/^(true|false)$/);
+      expect(sw.getAttribute('aria-label')).toBeTruthy();
     });
+  });
+
+  it('installs the turbo when switched on, and reports it', () => {
+    // The partner to the intercooler test below. Without this, breaking Turbo kit's
+    // `checked` or `onChange` was caught only incidentally, by an unrelated duty-cycle
+    // test whose threshold happens to need turboOn — change that number and a broken
+    // turbo switch would pass the whole suite.
+    launch();
+    fireEvent.click(screen.getByText('Forced Induction'));
+    const summary = () => screen.getByText(/Not installed|turbine · peak/).textContent;
+    expect(summary()).toBe('Not installed');
+
+    fireEvent.click(screen.getByRole('switch', { name: /Turbo kit/ }));
+
+    expect(screen.getByRole('switch', { name: /Turbo kit/ }).getAttribute('aria-checked')).toBe('true');
+    // And it reached the build, not just the switch: the section summary reads turboOn.
+    expect(summary()).toMatch(/turbine · peak/);
   });
 
   it('installs the intercooler when switched on, and reports it', () => {

--- a/tests/ui/build-store.test.jsx
+++ b/tests/ui/build-store.test.jsx
@@ -238,13 +238,13 @@ describe('opening and dismissing the overwrite prompt', () => {
 
 
 /**
- * ToggleRow renders its switch as an unlabelled button beside the label text, so it
- * has to be reached through the row rather than by name.
+ * The Toggle primitive renders a `role="switch"` with the label as its accessible
+ * name, so it can be reached directly rather than through the row's DOM shape.
  * @param {string} label
- * @returns {HTMLButtonElement}
+ * @returns {HTMLElement}
  */
 function toggleFor(label) {
-  return screen.getByText(label).parentElement.parentElement.querySelector('button');
+  return screen.getByRole('switch', { name: label });
 }
 
 /**

--- a/tests/ui/button-call-sites.test.jsx
+++ b/tests/ui/button-call-sites.test.jsx
@@ -1,0 +1,273 @@
+// @vitest-environment jsdom
+
+/**
+ * What the APP hands `Button`, as opposed to what `Button.test.jsx` proves about the
+ * component in isolation.
+ *
+ * Button.test.jsx renders `<Button variant="danger">` and checks the danger class
+ * lands. It cannot see a call site that asks for `variant="ghos"`, and neither can
+ * anything else: `Button` builds its className as `styles[variant]`, and
+ * `.filter(Boolean)` quietly drops the `undefined` a typo produces. The button still
+ * renders, still clicks, still passes every existing test — it just arrives with no
+ * fill, no border and an inherited text colour. Same shape of hole as the 95%-duty
+ * injector that rendered bright green with every test passing: the primitive was fine,
+ * the props were not.
+ *
+ * So these tests drive the real screens and assert, of every Button the app actually
+ * mounts, that it carries exactly one variant, that it is not full-width, and that
+ * `danger` is spent only on the one destructive confirm.
+ */
+
+import { readFileSync } from 'node:fs';
+import { URL as NodeURL } from 'node:url';
+
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import React from 'react';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
+
+import EcuLab from '../../src/ui/EcuLab.jsx';
+import styles from '../../src/ui/primitives/Button.module.css';
+
+// jsdom has no ResizeObserver, and the sweep runs a dyno pull — whose result panel
+// mounts recharts' <ResponsiveContainer>, which throws without one. Same stub as
+// characterisation.test.jsx.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+const hadResizeObserver = 'ResizeObserver' in window;
+if (!hadResizeObserver) window.ResizeObserver = ResizeObserverStub;
+afterAll(() => {
+  if (!hadResizeObserver) delete window.ResizeObserver;
+});
+
+afterEach(cleanup);
+
+const VARIANTS = ['primary', 'ghost', 'danger', 'quiet'];
+
+/** Renders the app and clicks past the start screen. */
+function launch() {
+  render(<EcuLab />);
+  clickButton('START');
+}
+
+/** @param {string|RegExp} name */
+function clickButton(name) {
+  fireEvent.click(screen.getByRole('button', { name }));
+}
+
+/**
+ * Walks the app, collecting every Button that mounts along the way.
+ *
+ * Most of this is setup rather than navigation, and deliberately so — six of the
+ * call sites only exist in a state the app has to be driven into. A bolt-on has to
+ * be fitted before the VE table goes stale and offers ACCEPT RE-LOGGED VALUES; the
+ * ECU scaling has to be knocked off the fitted injectors before RESCALE appears; the
+ * engine has to be started before STOP replaces START; a pull has to finish before
+ * the histogram trio exists at all. A Button that never mounts is a Button this
+ * sweep never checks.
+ * @returns {Promise<HTMLElement[]>}
+ */
+async function sweep() {
+  const seen = new Set();
+  const collect = () => {
+    for (const el of document.querySelectorAll(`.${styles.button}`)) seen.add(el);
+  };
+
+  launch();
+  collect();
+
+  // BUILD is the landing tab, and its sections arrive collapsed.
+  for (const section of ['Engine Architecture', 'Bolt-On Parts', 'Forced Induction', 'Exhaust']) {
+    fireEvent.click(screen.getByText(section));
+    collect();
+  }
+  // Fitting a part leaves the logged VE table behind the hardware, which is what
+  // puts the ACCEPT RE-LOGGED VALUES advisory on TUNE > AIR.
+  const uninstalled = screen.getAllByRole('button')
+    .filter((b) => b.textContent.includes('INSTALL') && !(/** @type {HTMLButtonElement} */ (b).disabled));
+  fireEvent.click(uninstalled[0]);
+  collect();
+
+  clickButton(/TUNE/);
+  collect();
+  for (const view of ['AIR', 'SPARK', 'FUEL', 'ECU']) {
+    clickButton(view);
+    collect();
+    // Selecting a grid cell mounts the SelectionDock and its DONE button.
+    const grid = screen.queryByTestId('tuning-grid');
+    if (grid) {
+      const cells = within(grid).getAllByRole('button');
+      fireEvent.click(cells[cells.length - 1]);
+      collect();
+    }
+  }
+  // Still on ECU: telling the ECU a different injector size is fitted raises the
+  // scaling-mismatch warning and its RESCALE button.
+  const scaling = within(screen.getByRole('group', { name: 'ECU Injector Scaling' })).getAllByRole('button');
+  fireEvent.click(scaling.find((b) => b.getAttribute('aria-pressed') === 'false'));
+  collect();
+
+  clickButton(/HOME/);
+  collect();
+  fireEvent.click(screen.getByText('Live Engine'));
+  collect();
+  clickButton('START ENGINE'); // mounts STOP, the other branch of that variant
+  collect();
+
+  clickButton(/DYNO/);
+  collect();
+  clickButton('RUN DYNO PULL');
+  collect();
+  await waitFor(() => expect(screen.getByRole('button', { name: 'DATALOG' })).toBeTruthy(), { timeout: 5000 });
+  clickButton('DATALOG');
+  collect();
+  clickButton('BUILD HISTOGRAM FROM THIS PULL'); // mounts APPLY CORRECTIONS / DISCARD
+  collect();
+
+  return [...seen];
+}
+
+/** How many of the four variant classes an element carries. */
+function variantsOn(el) {
+  return VARIANTS.filter((v) => el.classList.contains(styles[v]));
+}
+
+// Every Button the sweep is supposed to reach. Asserting the labels, not just a
+// count, is what stops the sweep quietly degrading: a navigation click that stopped
+// working would drop its screen's buttons and every "all of them are fine" assertion
+// below would go on passing over the shorter list.
+const EXPECTED = [
+  'SKIP GUIDE', 'RESET ALL TO STOCK', 'FLAT ACROSS ALL', 'SPOOL RAMP', 'ZERO',
+  'ACCEPT RE-LOGGED VALUES', 'DONE', 'RESCALE ECU TO', 'STOP', 'RUN DYNO PULL',
+  'BUILD HISTOGRAM FROM THIS PULL', 'APPLY CORRECTIONS TO VE', 'DISCARD',
+];
+
+describe('every Button the app mounts', () => {
+  it('is exactly one variant, never full-width, and never red', async () => {
+    // One expensive sweep — it runs a dyno pull — shared by the three assertions,
+    // rather than three renders of the whole app.
+    const found = await sweep();
+
+    const text = found.map((el) => el.textContent);
+    for (const label of EXPECTED) {
+      expect({ label, reached: text.some((t) => t.includes(label)) }).toEqual({ label, reached: true });
+    }
+
+    for (const el of found) {
+      const label = el.textContent || el.getAttribute('aria-label');
+
+      // A mistyped variant produces styles[variant] === undefined, which filter(Boolean)
+      // drops: the button renders with no variant class at all and nothing notices.
+      expect({ label, variants: variantsOn(el) }).toEqual({ label, variants: [expect.any(String)] });
+
+      // The inversion this task exists for. If a call site ever earns `block`, turn
+      // this into a named exception and say why in the same edit — do not delete it.
+      expect({ label, block: el.classList.contains(styles.block) }).toEqual({ label, block: false });
+      expect({ label, width: el.style.width }).toEqual({ label, width: '' });
+
+      // `danger` means destructive, not important. The one button that earns it is
+      // unreachable from here by construction — see the next test.
+      expect({ label, danger: el.classList.contains(styles.danger) }).toEqual({ label, danger: false });
+    }
+  }, 30000);
+});
+
+describe('the danger variant', () => {
+  it('is spent on the preset-overwrite confirm and nowhere else', async () => {
+    // The sweep above proves nothing on the ordinary screens is red. On its own that
+    // would pass just as well if `danger` had no call site at all, or if the confirm
+    // had quietly become unreachable — so prove the other half here.
+    //
+    // `choosePreset` only raises this prompt when `hasTuningWork()` is true, which is
+    // exactly why the confirm is destructive: reaching it means there is hand-edited
+    // calibration work for it to overwrite.
+    launch();
+    clickButton(/TUNE/);
+    const grid = within(screen.getByTestId('tuning-grid'));
+    const cells = grid.getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent));
+    fireEvent.click(cells[Math.floor(cells.length / 2)]);
+    fireEvent.click(within(screen.getByTestId('selection-dock')).getByRole('button', { name: '+1' }));
+    clickButton(/BUILD/);
+
+    const picker = /** @type {HTMLSelectElement[]} */ (screen.getAllByRole('combobox'))
+      .find((el) => el.querySelector('optgroup'));
+    const preset = [...picker.querySelectorAll('option')].map((o) => o.value).find((v) => v && v !== '__custom__');
+    fireEvent.change(picker, { target: { value: preset } });
+
+    expect(screen.getByRole('button', { name: /^LOAD / }).classList.contains(styles.danger)).toBe(true);
+    // Its partner is not: backing out of the prompt destroys nothing.
+    expect(screen.getByRole('button', { name: 'CANCEL' }).classList.contains(styles.ghost)).toBe(true);
+  });
+});
+
+describe('the Button call sites in EcuLab.jsx', () => {
+  const source = readFileSync(new NodeURL('../../src/ui/EcuLab.jsx', import.meta.url), 'utf8');
+
+  /**
+   * The text of every `<Button …>` opening tag in the file.
+   *
+   * Scanning to the first `>` would stop inside `onClick={() => …}`, so track brace
+   * depth and accept only a `>` outside braces.
+   * @returns {string[]}
+   */
+  function openingTags() {
+    const tags = [];
+    let from = source.indexOf('<Button');
+    while (from !== -1) {
+      let depth = 0;
+      let i = from;
+      for (; i < source.length; i += 1) {
+        const c = source[i];
+        if (c === '{') depth += 1;
+        else if (c === '}') depth -= 1;
+        else if (c === '>' && depth === 0) break;
+      }
+      tags.push(source.slice(from, i + 1));
+      from = source.indexOf('<Button', i);
+    }
+    return tags;
+  }
+
+  /**
+   * Every variant name written at a call site — both `variant="ghost"` and every
+   * branch of `variant={cond ? 'ghost' : 'primary'}`, which is why a single regex
+   * capture is not enough.
+   * @param {string} tag
+   * @returns {string[]}
+   */
+  function variantsNamedIn(tag) {
+    const names = [];
+    for (const m of tag.matchAll(/variant=(?:"([^"]*)"|\{([^}]*)\})/g)) {
+      if (m[1] !== undefined) names.push(m[1]);
+      else for (const lit of m[2].matchAll(/'([^']*)'/g)) names.push(lit[1]);
+    }
+    return names;
+  }
+
+  it('finds the call sites at all', () => {
+    // Guards the scanner, not the code: one that matched nothing would make every
+    // test below pass over an empty list.
+    expect(openingTags().length).toBeGreaterThanOrEqual(18);
+  });
+
+  it('names a real variant at every call site, including the ones the sweep cannot mount', () => {
+    // The DOM sweep can only judge what it can reach. This catches a typo anywhere,
+    // including inside a conditional branch that only renders in a state the sweep
+    // never enters. No `variant` at all is fine — the primitive defaults to primary.
+    const named = openingTags().flatMap(variantsNamedIn);
+    expect(named.length).toBeGreaterThanOrEqual(10);
+    for (const v of named) expect({ variant: v, known: VARIANTS.includes(v) }).toEqual({ variant: v, known: true });
+  });
+
+  it('gives every Button a click handler, so none of them is inert', () => {
+    // `Button` spreads its rest props straight onto the element, so an omitted
+    // onClick is not a type error and not a render error — it is a button that looks
+    // right and does nothing. Nothing in the DOM can tell the difference, which is
+    // why this one reads the source.
+    for (const tag of openingTags()) {
+      expect({ tag, wired: tag.includes('onClick=') }).toEqual({ tag, wired: true });
+    }
+  });
+});

--- a/tests/ui/button-call-sites.test.jsx
+++ b/tests/ui/button-call-sites.test.jsx
@@ -120,6 +120,10 @@ async function sweep() {
   collect();
   clickButton('RUN DYNO PULL');
   collect();
+  // `disabled={running}` is the entire mechanism behind the disabled-state
+  // contrast fix, and losing it also lets a second pull fire mid-sweep. The
+  // label switches to SWEEPING… while running, so query for that.
+  expect(/** @type {HTMLButtonElement} */ (screen.getByRole('button', { name: 'SWEEPING…' })).disabled).toBe(true);
   await waitFor(() => expect(screen.getByRole('button', { name: 'DATALOG' })).toBeTruthy(), { timeout: 5000 });
   clickButton('DATALOG');
   collect();
@@ -157,6 +161,13 @@ describe('every Button the app mounts', () => {
 
     for (const el of found) {
       const label = el.textContent || el.getAttribute('aria-label');
+
+      // Honest here because every Button in the sweep either carries real
+      // label text or is icon-only (Tutorial, Repair engine — the only two
+      // whose textContent is empty), so `|| aria-label` is the whole name,
+      // not a fallback masked by a sub-label sharing the element. Catches a
+      // deleted `title`+`aria-label` pair leaving a nameless icon button.
+      expect({ label, named: Boolean(label) }).toEqual({ label, named: true });
 
       // A mistyped variant produces styles[variant] === undefined, which filter(Boolean)
       // drops: the button renders with no variant class at all and nothing notices.

--- a/tests/ui/controls.test.jsx
+++ b/tests/ui/controls.test.jsx
@@ -104,6 +104,25 @@ describe('Select', () => {
     render(<Select label="Engine" groups={GROUPS} value="n54" onChange={() => {}} />);
     expect(screen.getByRole('combobox', { name: 'Engine' })).toBeTruthy();
   });
+
+  it('lets the caller size it, since the primitive will not', () => {
+    // The wrapper is inline-block with a 200px floor, so a bare swap for the old
+    // full-width control shrinks it. The docstring says callers must size it
+    // themselves — this is the mechanism that makes that possible, and without it
+    // the instruction was unfollowable.
+    const { container } = render(
+      <Select
+        label="Engine"
+        groups={[{ label: 'Nissan', options: [{ value: 'vq', label: 'VQ35DE' }] }]}
+        value="vq"
+        onChange={() => {}}
+        style={{ display: 'block', marginBottom: 13 }}
+      />,
+    );
+    const wrap = /** @type {HTMLElement} */ (container.firstChild);
+    expect(wrap.style.display).toBe('block');
+    expect(wrap.style.marginBottom).toBe('13px');
+  });
 });
 
 describe('Toggle', () => {

--- a/tests/ui/readouts.test.jsx
+++ b/tests/ui/readouts.test.jsx
@@ -20,7 +20,7 @@ afterEach(cleanup);
 
 // WCAG relative-luminance contrast ratio between two hex colours. There is no
 // contrast helper anywhere in this repo — every contrast finding so far (including
-// the two fixed in this PR) was caught by a human reading a diff.
+// the three fixed in this PR) was caught by a human reading a diff.
 function contrast(hexA, hexB) {
   const luminance = (hex) => {
     const [r, g, b] = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16) / 255);
@@ -43,24 +43,37 @@ const tileCss = readFileSync(
   'utf8',
 );
 
+// Button's stylesheet, read the same way and for the same reason. Its `quiet`
+// variant is measured below, beside StatTile's label: same class of defect (a
+// hierarchy token used where a legibility one was needed), same kind of guard.
+const buttonCss = readFileSync(
+  new NodeURL('../../src/ui/primitives/Button.module.css', import.meta.url),
+  'utf8',
+);
+
 // tokens.js keyed by the CSS custom property name it declares (e.g. `accInk` ->
 // `acc-ink`), so a `var(--x)` pulled out of the stylesheet can be resolved to a hex
 // value without hardcoding the mapping a second time.
 const tokensByCssName = new Map(Object.entries(tokens).map(([name, value]) => [camelToKebab(name), value]));
 
 /**
- * The custom-property name (without `--`) a declaration in StatTile.module.css
- * resolves to, e.g. `customPropertyOf('.label', 'color')` -> `'ink2'`. Throws if the
- * selector or declaration isn't found, so a typo here fails loudly instead of
- * silently asserting against `undefined`.
+ * The custom-property name (without `--`) a declaration in `css` resolves to, e.g.
+ * `customPropertyIn(tileCss, 'StatTile.module.css', '.label', 'color')` -> `'ink2'`.
+ * Throws if the selector or declaration isn't found, so a typo here fails loudly
+ * instead of silently asserting against `undefined`.
  */
-function customPropertyOf(selector, property) {
-  const escapedSelector = selector.replace(/[.[\]]/g, '\\$&');
-  const rule = tileCss.match(new RegExp(`${escapedSelector}\\s*{([^}]*)}`));
-  if (!rule) throw new Error(`no "${selector}" rule in StatTile.module.css`);
+function customPropertyIn(css, name, selector, property) {
+  const escapedSelector = selector.replace(/[.[\]()]/g, '\\$&');
+  const rule = css.match(new RegExp(`${escapedSelector}\\s*{([^}]*)}`));
+  if (!rule) throw new Error(`no "${selector}" rule in ${name}`);
   const decl = rule[1].match(new RegExp(`${property}\\s*:\\s*var\\(--([a-z0-9-]+)\\)`));
-  if (!decl) throw new Error(`no "${property}" declaration on "${selector}" in StatTile.module.css`);
+  if (!decl) throw new Error(`no "${property}" declaration on "${selector}" in ${name}`);
   return decl[1];
+}
+
+/** `customPropertyIn` bound to StatTile's stylesheet, which most of this file reads. */
+function customPropertyOf(selector, property) {
+  return customPropertyIn(tileCss, 'StatTile.module.css', selector, property);
 }
 
 /** Resolves a custom-property name read from the stylesheet to its token hex value. */
@@ -134,6 +147,36 @@ describe('StatTile', () => {
     // what `.acc .value` actually sets, clears 9.57:1 — comfortably past the bar,
     // and read from the stylesheet rather than assumed.
     expect(contrast(accValueColor, tileBg)).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// Not a readout, but it lives here because this is where the contrast helper is, and
+// because it is the same defect StatTile's label had: a token picked for hierarchy
+// without checking it against the surface it lands on. `quiet` has no fill and no
+// border, so its label is the entire control — if that fails AA the button is not
+// quiet, it is missing.
+describe('Button, quiet variant', () => {
+  // Every surface a quiet button is placed on today: --acc-bg (the journey banner's
+  // SKIP GUIDE), --bg (the tutorial's SKIP and BUILD's RESET ALL TO STOCK). --panel
+  // and --panel2 are the two surfaces it would land on next, and --panel3 is the
+  // lightest surface in the system, so it bounds the whole set.
+  const surfaces = ['bg', 'panel', 'panel2', 'panel3', 'accBg'];
+
+  it('stays readable on every surface it lands on', () => {
+    // `size="sm"` is --fs-xs, 10.5px: small text, so AA wants 4.5:1, not 3:1. --ink3
+    // measured 2.87-3.47:1 across these; --ink2 measures 4.59-6.21:1.
+    const quietColor = tokenFor(customPropertyIn(buttonCss, 'Button.module.css', '.quiet', 'color'));
+    // Collected rather than asserted one at a time, so a failure names the surfaces.
+    const failing = surfaces.filter((surface) => contrast(quietColor, tokens[surface]) < 4.5);
+    expect(failing).toEqual([]);
+  });
+
+  it('brightens on hover rather than dimming', () => {
+    // The hover colour used to be --ink2, which is now the resting colour; leaving it
+    // there would have made hover a no-op.
+    const resting = customPropertyIn(buttonCss, 'Button.module.css', '.quiet', 'color');
+    const hovered = customPropertyIn(buttonCss, 'Button.module.css', '.quiet:hover:not(:disabled)', 'color');
+    expect(contrast(tokenFor(hovered), tokens.bg)).toBeGreaterThan(contrast(tokenFor(resting), tokens.bg));
   });
 });
 

--- a/tests/ui/readouts.test.jsx
+++ b/tests/ui/readouts.test.jsx
@@ -114,6 +114,20 @@ describe('StatTile', () => {
     expect(contrast(labelColor, tileBg)).toBeGreaterThanOrEqual(4.5);
   });
 
+  it('paints tone text with an ink variant, never with the interactive accent', () => {
+    // Contrast alone cannot pin this: --acc on --panel measures 6.46:1 and clears the
+    // 3:1 large-text bar perfectly well, so a correct WCAG assertion stays green if
+    // someone puts it back. What is wrong with it is not legibility, it is meaning.
+    //
+    // --acc is the interactive accent: the colour of a thing you can click. A stat
+    // tile's figure is a readout. Spending the interactive colour on it is the quiet
+    // half of the rule this whole PR enforces — the accent is never a status, and a
+    // status is never decoration. --acc-ink is the readable-on-dark variant that
+    // exists for exactly this, and it is what all four call sites passed before the
+    // migration.
+    expect(customPropertyOf('.acc .value', 'color')).toBe('acc-ink');
+  });
+
   it('keeps the acc value readable on the surface it sits on', () => {
     // `.value` renders at --fs-lg (18px) and font-weight 800 — WCAG "large text",
     // which AA holds to 3:1 rather than 4.5:1. --acc alone clears 6.46:1; --acc-ink,

--- a/tests/ui/readouts.test.jsx
+++ b/tests/ui/readouts.test.jsx
@@ -7,12 +7,28 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { Bar } from '../../src/ui/primitives/Bar.jsx';
 import { StatTile } from '../../src/ui/primitives/StatTile.jsx';
 import tileStyles from '../../src/ui/primitives/StatTile.module.css';
+import { tokens } from '../../src/ui/tokens.js';
 
 // This file's queries rely on `screen` being scoped to the current test's render;
 // without this, meters from earlier tests accumulate in the DOM and unscoped
 // role/name queries start matching more than one element. Matches the pattern
 // already used in Button.test.jsx and surfaces.test.jsx.
 afterEach(cleanup);
+
+// WCAG relative-luminance contrast ratio between two hex colours. There is no
+// contrast helper anywhere in this repo — every contrast finding so far (including
+// the two fixed in this PR) was caught by a human reading a diff.
+function contrast(hexA, hexB) {
+  const luminance = (hex) => {
+    const [r, g, b] = [1, 3, 5].map((i) => parseInt(hex.slice(i, i + 2), 16) / 255);
+    const lin = (c) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4);
+    const [R, G, B] = [r, g, b].map(lin);
+    return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+  };
+  const [l1, l2] = [luminance(hexA), luminance(hexB)];
+  const [lighter, darker] = l1 > l2 ? [l1, l2] : [l2, l1];
+  return (lighter + 0.05) / (darker + 0.05);
+}
 
 describe('StatTile', () => {
   it('renders label, value and unit', () => {
@@ -30,6 +46,30 @@ describe('StatTile', () => {
   it('applies the tone it is given', () => {
     const { container } = render(<StatTile label="KNOCK" value="0.4" tone="warn" />);
     expect(container.querySelector(`.${tileStyles.warn}`)).toBeTruthy();
+  });
+
+  it('gives the alt tone its own class, distinct from the partner it sits beside', () => {
+    // `alt` marks the second quantity in a paired readout — torque beside power. If it
+    // resolved to the same colour as its partner the pairing would be invisible, which
+    // is the whole reason the tone exists.
+    const { container } = render(<StatTile label="PEAK TQ" value={300} tone="alt" />);
+    expect(container.querySelector(`.${tileStyles.alt}`)).toBeTruthy();
+    expect(container.querySelector(`.${tileStyles.acc}`)).toBeNull();
+  });
+
+  it('keeps the label readable on the surface it sits on', () => {
+    // ~9.5px is small text: WCAG AA wants 4.5:1. This failed at 2.87:1 with --ink3,
+    // which is a hierarchy token, not a legibility one.
+    expect(Number(contrast(tokens.ink2, tokens.panel2))).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('keeps the acc value at the brightness every call site already relied on', () => {
+    // Every acc call site passes T.accInk today. --acc alone only clears 5.86:1 —
+    // still AA for 24px large text, but a needless dim from the 8.69:1 callers expect,
+    // and it spends the interactive accent on something that isn't interactive.
+    expect(Number(contrast(tokens.accInk, tokens.panel2))).toBeGreaterThanOrEqual(
+      Number(contrast(tokens.acc, tokens.panel2)),
+    );
   });
 });
 

--- a/tests/ui/readouts.test.jsx
+++ b/tests/ui/readouts.test.jsx
@@ -1,5 +1,8 @@
 // @vitest-environment jsdom
 
+import { readFileSync } from 'node:fs';
+import { URL as NodeURL } from 'node:url';
+
 import { cleanup, render, screen } from '@testing-library/react';
 import React from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
@@ -7,7 +10,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { Bar } from '../../src/ui/primitives/Bar.jsx';
 import { StatTile } from '../../src/ui/primitives/StatTile.jsx';
 import tileStyles from '../../src/ui/primitives/StatTile.module.css';
-import { tokens } from '../../src/ui/tokens.js';
+import { camelToKebab, tokens } from '../../src/ui/tokens.js';
 
 // This file's queries rely on `screen` being scoped to the current test's render;
 // without this, meters from earlier tests accumulate in the DOM and unscoped
@@ -30,6 +33,49 @@ function contrast(hexA, hexB) {
   return (lighter + 0.05) / (darker + 0.05);
 }
 
+// Read the real stylesheet rather than trusting a value copied out of it by hand.
+// `tests/tokens.test.js` reads tokens.css the same way, for the same reason: a
+// hardcoded stand-in for a stylesheet value can drift from the stylesheet silently.
+// Under jsdom the global `URL` is jsdom's own, which `readFileSync` rejects, so this
+// uses node:url's URL explicitly.
+const tileCss = readFileSync(
+  new NodeURL('../../src/ui/primitives/StatTile.module.css', import.meta.url),
+  'utf8',
+);
+
+// tokens.js keyed by the CSS custom property name it declares (e.g. `accInk` ->
+// `acc-ink`), so a `var(--x)` pulled out of the stylesheet can be resolved to a hex
+// value without hardcoding the mapping a second time.
+const tokensByCssName = new Map(Object.entries(tokens).map(([name, value]) => [camelToKebab(name), value]));
+
+/**
+ * The custom-property name (without `--`) a declaration in StatTile.module.css
+ * resolves to, e.g. `customPropertyOf('.label', 'color')` -> `'ink2'`. Throws if the
+ * selector or declaration isn't found, so a typo here fails loudly instead of
+ * silently asserting against `undefined`.
+ */
+function customPropertyOf(selector, property) {
+  const escapedSelector = selector.replace(/[.[\]]/g, '\\$&');
+  const rule = tileCss.match(new RegExp(`${escapedSelector}\\s*{([^}]*)}`));
+  if (!rule) throw new Error(`no "${selector}" rule in StatTile.module.css`);
+  const decl = rule[1].match(new RegExp(`${property}\\s*:\\s*var\\(--([a-z0-9-]+)\\)`));
+  if (!decl) throw new Error(`no "${property}" declaration on "${selector}" in StatTile.module.css`);
+  return decl[1];
+}
+
+/** Resolves a custom-property name read from the stylesheet to its token hex value. */
+function tokenFor(cssName) {
+  const value = tokensByCssName.get(cssName);
+  if (!value) throw new Error(`--${cssName} is not a known token`);
+  return value;
+}
+
+// The surfaces these assertions measure against, read out of the stylesheet rather
+// than assumed: `.tile` is the element `.label` and `.acc .value` actually paint onto.
+const tileBg = tokenFor(customPropertyOf('.tile', 'background'));
+const labelColor = tokenFor(customPropertyOf('.label', 'color'));
+const accValueColor = tokenFor(customPropertyOf('.acc .value', 'color'));
+
 describe('StatTile', () => {
   it('renders label, value and unit', () => {
     render(<StatTile label="PEAK HP" value={412} unit="whp" />);
@@ -51,25 +97,29 @@ describe('StatTile', () => {
   it('gives the alt tone its own class, distinct from the partner it sits beside', () => {
     // `alt` marks the second quantity in a paired readout — torque beside power. If it
     // resolved to the same colour as its partner the pairing would be invisible, which
-    // is the whole reason the tone exists.
+    // is the whole reason the tone exists. A class-name check alone can't catch that:
+    // two differently-named classes can still be styled to the same colour. Compare
+    // the custom properties the stylesheet actually assigns instead.
     const { container } = render(<StatTile label="PEAK TQ" value={300} tone="alt" />);
     expect(container.querySelector(`.${tileStyles.alt}`)).toBeTruthy();
     expect(container.querySelector(`.${tileStyles.acc}`)).toBeNull();
+    expect(customPropertyOf('.alt .value', 'color')).not.toBe(customPropertyOf('.acc .value', 'color'));
   });
 
   it('keeps the label readable on the surface it sits on', () => {
-    // ~9.5px is small text: WCAG AA wants 4.5:1. This failed at 2.87:1 with --ink3,
-    // which is a hierarchy token, not a legibility one.
-    expect(Number(contrast(tokens.ink2, tokens.panel2))).toBeGreaterThanOrEqual(4.5);
+    // ~9.5px is small text: WCAG AA wants 4.5:1. This failed at 3.17:1 when `.label`
+    // used --ink3, a hierarchy token, not a legibility one; --ink2 clears 5.67:1.
+    // Measured against the property `.label` actually sets and the background `.tile`
+    // actually paints, both read out of the stylesheet above, not asserted by name.
+    expect(contrast(labelColor, tileBg)).toBeGreaterThanOrEqual(4.5);
   });
 
-  it('keeps the acc value at the brightness every call site already relied on', () => {
-    // Every acc call site passes T.accInk today. --acc alone only clears 5.86:1 —
-    // still AA for 24px large text, but a needless dim from the 8.69:1 callers expect,
-    // and it spends the interactive accent on something that isn't interactive.
-    expect(Number(contrast(tokens.accInk, tokens.panel2))).toBeGreaterThanOrEqual(
-      Number(contrast(tokens.acc, tokens.panel2)),
-    );
+  it('keeps the acc value readable on the surface it sits on', () => {
+    // `.value` renders at --fs-lg (18px) and font-weight 800 — WCAG "large text",
+    // which AA holds to 3:1 rather than 4.5:1. --acc alone clears 6.46:1; --acc-ink,
+    // what `.acc .value` actually sets, clears 9.57:1 — comfortably past the bar,
+    // and read from the stylesheet rather than assumed.
+    expect(contrast(accValueColor, tileBg)).toBeGreaterThanOrEqual(3);
   });
 });
 

--- a/tests/ui/session-store.test.jsx
+++ b/tests/ui/session-store.test.jsx
@@ -346,18 +346,16 @@ describe('the dyno load selector', () => {
 });
 
 /**
- * Seg marks its selected option by giving that one button a different background from
- * the rest, so the selected label is the odd one out of the three.
+ * Seg marks its selected option with `aria-pressed="true"`, so the selected label is
+ * whichever of the three carries it.
  * @returns {string}
  */
 function selectedLoad() {
   const buttons = ['100 kPa', '70 kPa', '40 kPa']
     .map((name) => screen.getByRole('button', { name }));
-  const tally = {};
-  buttons.forEach((b) => { tally[b.style.background] = (tally[b.style.background] || 0) + 1; });
-  const odd = buttons.filter((b) => tally[b.style.background] === 1);
-  expect(odd).toHaveLength(1);
-  return odd[0].textContent;
+  const pressed = buttons.filter((b) => b.getAttribute('aria-pressed') === 'true');
+  expect(pressed).toHaveLength(1);
+  return pressed[0].textContent;
 }
 
 describe('the guided first run', () => {

--- a/tests/ui/surfaces.test.jsx
+++ b/tests/ui/surfaces.test.jsx
@@ -34,6 +34,15 @@ describe('Panel', () => {
     render(<Panel aria-label="Build summary">x</Panel>);
     expect(screen.getByLabelText('Build summary')).toBeTruthy();
   });
+
+  it('lets a caller supply the layout the panel does not own', () => {
+    // Fourteen of the fifteen call sites pass a `style` for margins and flex. They
+    // live in a file with @ts-nocheck, so a props type that rejected `style` would
+    // never have failed there — it would only have surfaced the first time a typed
+    // screen tried the same thing, which is exactly what the next PR does.
+    const { container } = render(<Panel style={{ marginBottom: 13 }}>x</Panel>);
+    expect(/** @type {HTMLElement} */ (container.firstChild).style.marginBottom).toBe('13px');
+  });
 });
 
 describe('Eyebrow', () => {


### PR DESCRIPTION
Closes #74. Part of #6. **#59 depends on this** — see "Deliberately left for #59" below.

An earlier PR built nine UI primitives under `src/ui/primitives/`. `EcuLab.jsx`
imported none of them and carried its own older copies of eight. This PR adopts them,
one primitive per commit.

## What was adopted

| Primitive | Local copy deleted | Call sites now on the primitive |
|---|---|---|
| `Eyebrow` | yes | 11 |
| `Note` | yes | 8 |
| `Panel` | yes | 19 (15 in the first sweep, 4 hand-rolled copies found later) |
| `StatTile` | yes | 10 |
| `Bar` | yes (`HealthBar`) | 4 |
| `Seg` | yes | 8 |
| `Select` | yes (`GroupedSelect`) | 1 |
| `Toggle` | yes (`ToggleRow`) | 2 |
| `Button` | n/a — there was no local copy, just raw `<button>` markup | 18 |

`PickList` stays hand-rolled: no primitive covers it. Some dense grid buttons stayed raw
too — the tuning-grid cells, the tab bar, the sub-tab pickers and the steppers are not
`Button` shapes, and forcing them would have been a worse fit than leaving them.

## Every visual change

**Nothing in this repo catches a visual regression, and nobody has loaded the app in a
browser during the entire overhaul.** The suites pin behaviour, not appearance. This list
is the only record of what was meant to change. **Please do a manual pass before merging.**

### The ones a reviewer will see immediately

1. **START ENGINE is blue, not green.** The most visible change on HOME. The button reads
   START precisely when the engine is *off*, so the green reported the opposite of the
   state — decoration, not status.
2. **BUILD HISTOGRAM is accent, not cyan.** Cyan is documented in `tokens.js` as a chart
   *series* hue; it was borrowed here and on the intercooler toggle.
3. **RUN DYNO PULL loses its accent glow** and is no longer the width of the window.
   `Button` has no elevation, and adding one for a single call site would mean a new token.
4. **The overwrite confirm (LOAD *&lt;preset&gt;*) is red.** New emphasis where there was
   none, and the one place the design system says red belongs.
5. **The AFR/timing chart's two series go green/amber → cyan/violet**, and the **TIMING
   live gauge is no longer permanently amber**. Both were unconditional: on screen in that
   colour for every pull, reporting a health neither measures. TIMING's real caution is its
   `warn` prop, which turns the whole tile red on knock.
6. **Both steppers' `+` buttons go green → `accInk`**, matching the `-` buttons they sit
   beside. Raising a VE cell by one is not *good*, it is positive; the sign is in the label.
7. **The intercooler toggle's checked track goes cyan → accent blue**, and both toggles get
   a smaller switch, a state-dependent knob colour (it was a constant bright white dot), a
   checked-border, a focus ring, and a whole-row hit target where only the nub was clickable.
8. **`StatTile` renders as a visibly darker card.** The primitive's `.tile` background is a
   darker token than the containers these tiles sit in, so tiles that used to blend flush
   with their `panel2` parent now sit on top of it. Its headline figure also drops 24px →
   18px and its unit 11.5px → 9px, so the numbers read noticeably smaller.
9. **`Bar` (health + injector duty) loses its glow and border**, gains a lighter track, and
   its label shrinks 10.5px → 9px and changes weight; the figure moves from sans to mono.
   The three stacked health bars kept their 10px gap via an explicit flex column, since
   `Bar` has no wrapper margin and removing `HealthBar` verbatim would have collapsed them.
10. **Warn-toned `Note` text and icon go `#ffb020` → `#ffd07a`** — a lighter, softer amber.
11. **`Button`'s `quiet` variant goes `--ink3` → `--ink2`** (see defects below), so SKIP
    GUIDE, tutorial SKIP and RESET ALL TO STOCK all get slightly brighter labels.

### The rest, collected

- **Padding lands on the scale everywhere.** Default `Panel` 14px → 13px (`--sp-lg`) on
  every panel on screen; `tight` panels 12px → 13px horizontally. `StatTile` 13px → 10px.
  `Toggle` 13px → `10px 13px`.
- **Radii land on the scale.** The four hand-rolled panels converted in the final sweep were
  at 9, 10, 10 and 12; all are now 12. `StatTile` 11px → 9px, `Toggle` 10px → 9px, and nine
  of the eighteen button sites shift by 1-3px.
- **Type shifts by 0.5-2.5px at nine button sites** and gains `letter-spacing: 0.05em` and
  `font-weight: 800` where they varied before. `Toggle`'s sub-label shrinks 11.5px → 10.5px.
- **Ghost buttons lose their `panel2` fill** — transparent is what `ghost` is. DONE, STOP,
  CANCEL, DISCARD, the two header icons and the three boost-curve presets are all affected.
- **Three buttons stop being full-width** (RUN DYNO PULL, BUILD HISTOGRAM, ACCEPT RE-LOGGED
  VALUES) and RESCALE ECU gained a block parent so it does not run on from the sentence
  above it.

### Two pre-existing bugs fixed on the way past, not introduced here

- `stroke={i > 9 ? T.danger : T.line === T.line ? T.ink3 : T.line}` on the tach's minor
  ticks. The middle comparison is always true, so the third branch was unreachable and the
  ticks have always drawn in `ink3`. Reduced to `i > 9 ? T.danger : T.ink3`. **What it was
  meant to compare is not recoverable from the code**, so nothing was guessed at: the
  rendered output is identical.
- The cylinder bars set the `animation` shorthand and `animationDelay` in the same style
  object. The shorthand resets `animation-delay`, so the per-cylinder stagger was
  order-dependent and React warned on every rerender of the tach. Folding the delay in as
  the shorthand's second time value silences the warning and pins the stagger.

## Defects found in the primitives themselves

These only surfaced because something finally rendered them. All three are the same class:
a token picked for hierarchy without checking it against the surface it lands on.

- **`StatTile`'s label failed AA at 3.17:1** (`--ink3` at ~9.5px). Raised to `--ink2`,
  5.67:1. Its `acc` value also used the interactive accent for a readout; it now uses
  `--acc-ink`, which is what all four call sites passed before the migration.
- **`Select`'s docstring instructed callers to size the control themselves, while the
  component accepted no props to do it with.** It now spreads `...rest` onto its wrapper.
- **`Button`'s disabled state halved its own contrast.** `opacity` over `--bg` compresses
  fill and label toward the same backdrop, dragging contrast to 2.24:1. The disabled colours
  are now named (`--panel3` / `--ink2`, 4.59:1) so they move together for real.
- **`Button`'s `quiet` variant measured 2.87-3.47:1** — under AA for its 10.5px text, and
  the variant has no fill and no border, so the label *is* the control. Raised to `--ink2`
  (4.59-6.21:1); hover moves to `--ink` since `--ink2` is now the resting colour. Adoption
  spread this rather than causing it: RESET ALL TO STOCK went from 6.21:1 to 3.47:1 when it
  took the variant.

Contrast is now asserted, not just fixed — `tests/ui/readouts.test.jsx` reads the real
stylesheets and measures. There was no contrast helper anywhere in this repo before; every
finding above was caught by a human reading a diff.

## Deliberately left for #59

These came out of the task reviews. They belong to the shell rebuild, not here.

1. **The app has no content width cap.** Nothing in `EcuLab.jsx`, `index.html` or
   `tokens.css` sets a `max-width`; the root is `height: 100dvh` with unconstrained width,
   so every container *is* the viewport. This is the actual root of "buttons span the whole
   screen", and it is why `Button`'s `block` prop ships with **zero adopters** — using it
   anywhere today reproduces the complaint. #59 must add the cap first; three or four sites
   then become honest `block` candidates.
2. **Two hand-rolled disclosures want a primitive.** `ExpandableInfo` and `BuildSection` are
   both expand/collapse rows and **neither carries `aria-expanded`** — the state is conveyed
   only by a rotated chevron, so a screen-reader user cannot tell open from shut.
3. **`Seg` needs two things before three more call sites can adopt it:** a stacked
   (icon-over-label) layout for the TUNE sub-tabs, and a badge slot for the DYNO sub-tabs'
   unread dot. Both groups are `Seg` in all but name today.
4. **The sound toggle has no `aria-pressed`**, and its accessible name is the glyph `♪`/`✕`.

Also noted and deliberately not changed: the bolt-on mod cards use the `ok` scale for their
installed state (`okBg` fill, `okLine` border, `ok` label). That is an on/off state wearing
a status colour, the same shape as the START ENGINE finding — but unwinding it means
redesigning the card, which is #59's territory, not a token swap.

## Verification

- `npm test` — 548 tests, 22 files, all green. `tests/fingerprint.test.js` included and
  **never regenerated**.
- `npm run lint`, `npm run typecheck`, `npm run build` — all exit 0.
- `git diff origin/main -- src/sim/ tests/fixtures/ tests/fingerprint.test.js package.json
  package-lock.json` — **empty**. No new dependencies.
- `git diff origin/main -- tests/ui/characterisation.test.jsx` — **empty**. It is
  byte-identical to `main`, and it pins the flows this PR touches.
- No existing assertion in any UI test was changed. Setup in `build-store.test.jsx` and
  `session-store.test.jsx` adapted to changed accessible names and DOM shape; assertions
  did not. `tests/ui/` is now 193 tests across 12 files, including one new file,
  `button-call-sites.test.jsx`, which drives the real screens and asserts the labels it
  reached rather than a count.
- One test in `tests/theme.test.js` was replaced rather than kept: deriving `statusColor`
  from `statusTone` made it tautological (`T[x] === T[x]`, true for any implementation).
  Its replacement pins the failure mode the restructure actually introduced — a renamed
  token now makes `statusColor` return `undefined` instead of failing at the reference.
- Branch is already on top of `origin/main` (3544b11); the rebase was a no-op, no conflicts.

**Known local flake, not a defect in this work:** on this macOS machine `npx vitest run
tests/ui/` intermittently loses a `tinypool` worker, and the full `npm test` segfaulted once
in four runs. It is always in the worker pool, never in an assertion. `--pool=forks
--poolOptions.forks.singleFork` avoids it locally, and CI on Ubuntu passes (confirmed with a
manual `workflow_dispatch` run against this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd
