### PR TITLE
Give the bearing event a tone, and make Seg's options readable

### DIFF
--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -2213,9 +2213,19 @@ export function EcuLabApp() {
                     ) : (
                       <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
                         {result.events.map((e, i) => {
-                          const isDanger = e.type === 'knock' || e.type === 'valve' || e.type === 'rich' || e.type === 'injscale' || e.type === 'float' || e.type === 'pressure';
-                          const isWarn = e.type === 'lean' || e.type === 'fuel' || e.type === 'compressor' || e.type === 'cam';
+                          // The tone comes from the severity the sim already assigns, not from a
+                          // hand-kept list of type names. Those lists named eleven of the twelve
+                          // types `src/sim` emits: `bearing` matched none of them and fell through
+                          // to the chart-series cyan, so the one warning about accumulating
+                          // bottom-end stress rendered as decoration while `pressure`, its acute
+                          // sibling, rendered red. Deriving it means a thirteenth event type gets a
+                          // tone the day it is added instead of silently becoming a chart colour.
+                          //
+                          // `maf` is the one genuine special case: it is a calibration observation
+                          // rather than damage, and violet is the token reserved for that.
                           const isViolet = e.type === 'maf';
+                          const isDanger = !isViolet && e.severity >= 3;
+                          const isWarn = !isViolet && !isDanger;
                           const bg = isDanger ? T.dangerBg : isWarn ? T.warnBg : isViolet ? T.violetBg : T.panel2;
                           const bd = isDanger ? T.dangerLine : isWarn ? T.warnLine : isViolet ? T.violetLine : T.line;
                           const fg = isDanger ? T.dangerInk : isWarn ? T.warnInk : isViolet ? T.violet : T.cyan;

--- a/src/ui/primitives/Seg.module.css
+++ b/src/ui/primitives/Seg.module.css
@@ -16,7 +16,7 @@
   border: none;
   border-radius: var(--r-sm);
   background: transparent;
-  color: var(--ink3);
+  color: var(--ink2);
   font-family: var(--sans);
   font-size: var(--fs-xs);
   font-weight: 800;
@@ -25,7 +25,7 @@
   transition: background-color 0.14s ease, color 0.14s ease;
 }
 
-.item:hover { color: var(--ink2); }
+.item:hover { color: var(--ink); }
 .item:focus-visible { outline: 2px solid var(--acc); outline-offset: 2px; }
 
 .item[aria-pressed='true'] {

--- a/tests/theme.test.js
+++ b/tests/theme.test.js
@@ -6,6 +6,9 @@
  * that turn a number into a colour.
  */
 
+import { readFileSync } from 'node:fs';
+import { URL as NodeURL } from 'node:url';
+
 import { describe, expect, it } from 'vitest';
 
 import { tokens } from '../src/ui/tokens.js';
@@ -108,5 +111,39 @@ describe('heat', () => {
     const hue = (v) => Number(heat(v, 0, 100).match(/hsl\((-?[\d.]+)/)[1]);
     expect(hue(0)).toBeGreaterThan(hue(50));
     expect(hue(50)).toBeGreaterThan(hue(100));
+  });
+});
+
+describe('pull-log event tones', () => {
+  it('derives the tone from severity instead of listing event types', () => {
+    // EcuLab used to classify pull-log events with three hand-kept lists of type names.
+    // They covered eleven of the twelve types `src/sim` emits — `bearing` matched none,
+    // fell through to the default, and rendered in `T.cyan`, the chart-series hue. A
+    // warning about accumulating bottom-end stress was drawn as decoration while
+    // `pressure`, its acute sibling, was drawn red.
+    //
+    // It now reads `e.severity`, which every event already carries, so no type can fall
+    // through and a thirteenth needs no edit here at all.
+    //
+    // That makes the obvious test — "every emitted type gets a non-cyan tone" — a
+    // tautology: the derivation is total, so it cannot fail. I wrote that version first
+    // and only caught it by breaking it. What is actually worth guarding is the
+    // approach, because reverting to enumerated type names reopens the hole exactly as
+    // it was.
+    const source = readFileSync(new NodeURL('../src/ui/EcuLab.jsx', import.meta.url), 'utf8');
+    const classification = source
+      .split('\n')
+      .filter((l) => /const is(Danger|Warn|Violet) =/.test(l));
+
+    expect(classification.length).toBe(3);
+
+    const derivesFromSeverity = classification.some((l) => /e\.severity/.test(l));
+    expect(derivesFromSeverity).toBe(true);
+
+    // `maf` is the one legitimate name check: it is a calibration observation rather
+    // than damage, so it takes violet on identity, not on severity. Any OTHER type name
+    // appearing here means the lists are back.
+    const named = classification.flatMap((l) => [...l.matchAll(/e\.type === '([a-z]+)'/g)].map((m) => m[1]));
+    expect(named).toEqual(['maf']);
   });
 });

--- a/tests/ui/readouts.test.jsx
+++ b/tests/ui/readouts.test.jsx
@@ -180,6 +180,20 @@ describe('Button, quiet variant', () => {
   });
 });
 
+describe('Seg legibility', () => {
+  it('keeps an unselected option readable on the control it sits in', () => {
+    // The same defect this suite already pins for StatTile's label and Button's quiet
+    // variant, in a third place: --ink3 is a hierarchy token, and on --panel at 10.5px
+    // it measures 3.17:1 against AA's 4.5:1 for small text. It affects roughly thirty
+    // option labels — every unselected option in all eight segmented controls — so it
+    // was the widest of the three and the last one measured.
+    const css = readFileSync(new NodeURL('../../src/ui/primitives/Seg.module.css', import.meta.url), 'utf8');
+    const itemColor = css.match(/\.item \{[^}]*color:\s*var\(--([a-z0-9-]+)\)/)[1];
+    const segBg = css.match(/\.seg \{[^}]*background:\s*var\(--([a-z0-9-]+)\)/)[1];
+    expect(contrast(tokenFor(itemColor), tokenFor(segBg))).toBeGreaterThanOrEqual(4.5);
+  });
+});
+
 describe('Bar', () => {
   it('exposes itself as a meter with its current value', () => {
     render(<Bar label="Pistons" value={86} />);


### PR DESCRIPTION
Two findings from the whole-branch review of #77. That review was started before the PR merged, died on a session limit, and was completed afterwards — so #77 merged without it. These are the two things worth fixing now; the rest are filed as #78, #79, #80 and #81.

## The `bearing` pull-log event rendered as decoration

`src/sim` emits twelve event types. The pull log classified them with three hand-kept lists of type names, which covered eleven — `bearing` matched none, fell through to the default, and rendered in `T.cyan`, the chart-series hue.

So the one warning about accumulating bottom-end stress was drawn as decoration, while `pressure` — its acute sibling, the same failure mode further along — was drawn red. `bearing` carries a 3–9 point score impact and is reachable by any boosted or high-compression build. That is the rule this overhaul exists to enforce, broken by omission rather than by choice.

**The tone now derives from the `severity` every event already carries**, so no type can fall through and a thirteenth needs no edit here at all. `maf` stays a name check: it is a calibration observation rather than damage, and violet is the token reserved for that.

Verified the derivation reproduces the existing tone for **all eleven** previously-classified types. `bearing` lands on `warn`, matching its severity 1 — not the red that would overstate it against `pressure`'s severity 3.

## Seg's unselected options failed AA

`.item` used `--ink3`: **3.17:1** on the control's own `--panel` at 10.5px, against AA's 4.5:1 for small text. Roughly thirty option labels — every unselected option in all eight segmented controls.

Same token pair and the same ratio as the `StatTile` label defect this project already fixed, and the same class as `Button`'s `quiet` variant. Third instance, widest blast radius, and the one the earlier sweep never measured. Now `--ink2` at **5.67:1**, with hover raised to `--ink` so it stays a visible change rather than becoming a no-op.

## A note on the first test I wrote for this

The obvious assertion — *every emitted type gets a non-cyan tone* — is a **tautology** once the derivation is total, and it re-implemented that derivation rather than exercising `EcuLab`'s. I shipped it and only caught it by breaking it.

It now asserts the *approach*: reverting to enumerated type names fails it. Worth recording because it is the sixth unfailable assertion found in this overhaul and the third I authored — the pattern is not rare, and breaking a new test before trusting it is the only thing that has reliably caught it.

## Verification

```
$ npm test            → 22 files, 554 tests passed (fingerprint green, never regenerated)
$ npm run lint        → 0
$ npm run typecheck   → 0
$ npm run build       → 0
```

`src/sim/`, `tests/fixtures/` and `tests/fingerprint.test.js` untouched. Both fixes break-verified: reverting `Seg` to `--ink3` fails with `expected 3.165… to be greater than or equal to 4.5`, and reverting the classification to type lists fails the approach assertion.

**Still unverified, as throughout this overhaul: nobody has loaded the app in a browser.** Nothing here catches a visual regression. A manual pass over the pull log and any segmented control is worth five minutes before merge.

Refs #74, #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd
