### PR TITLE
The contextual advisor panel on TUNE

### DIFF
--- a/docs/superpowers/plans/2026-08-24-tune-advisor-panel.md
+++ b/docs/superpowers/plans/2026-08-24-tune-advisor-panel.md
@@ -187,7 +187,22 @@ function AdvisorPanelImpl({ headline, tone, children }) {
 export const AdvisorPanel = React.memo(AdvisorPanelImpl);
 ```
 
-**Note on the accessible name:** the toggle's name comes from its text content, which begins with "ADVISOR" — that is what `getByRole('button', { name: /advisor/i })` matches. If you change the eyebrow text, change the test's query with it.
+**CORRECTION, applied during Task 1's review.** The markup above shipped and was then
+fixed, because it was wrong in a way the plan did not foresee. Wrapping the eyebrow and
+headline in the toggle button, and neutralising that button at >=560px with
+`pointer-events: none`, meant that on every desktop viewport the panel announced
+`aria-expanded="false"` while its body was fully visible — the wrong state, which is worse
+than the missing state issue #81 was filed about. It also left a focusable button that did
+nothing. jsdom applies no CSS, so the task's own accessibility test never reached the width
+where its claim became false.
+
+The shipped shape: eyebrow, headline and chevron live in an always-rendered `.head`; the
+toggle is a transparent button positioned over it (`inset: 0`) carrying an `aria-label` and
+`aria-expanded`; at >=560px that button gets `display: none`, which removes it from the
+accessibility tree along with its now-meaningless state. The headline text therefore exists
+in the DOM exactly once at every width. Later tasks depend only on the props
+(`headline`, `tone`, `children`) and on `data-testid="advisor-panel"`, neither of which
+changed.
 
 - [ ] **Step 4: Write the stylesheet**
 

--- a/docs/superpowers/plans/2026-08-24-tune-advisor-panel.md
+++ b/docs/superpowers/plans/2026-08-24-tune-advisor-panel.md
@@ -608,7 +608,11 @@ git commit -m "Add sparkReport: narrow the knock advisor to the current selectio
 
 ### Task 4: `TuneAdvisory` renders the spark report, and SPARK's banner moves in
 
-Two commits, in this order. **Stage 1 moves the markup verbatim; stage 2 converts it to the new stylesheet.** That is the technique the screen split used, and it is what makes a fidelity slip visible: hand-audit stage 2's diff against stage 1 before committing it, because no test in this repo sees a className.
+Two commits, in this order. **Stage 1 moves the markup verbatim; stage 2 converts it to the new stylesheet.** No test in this repo sees a className, so the audit between them is the only thing standing between a "verbatim" move and a silent visual regression.
+
+**AUDIT AGAINST THE PRE-TASK FILE, NOT AGAINST STAGE 1.** Task 4 shipped a real regression through the naive version of this check. Its `table-clean` state used `.okBanner` (`color: var(--ok)`, green — an unambiguous all-clear) before the move; the supposedly-verbatim stage-1 commit wrote `.advisoryPanel`, the warn-tier class, so the message lost its green and now inherits neutral gray from the panel body. The substitution happened INSIDE stage 1, which makes stage 2's audit — whose baseline IS stage 1 — structurally incapable of seeing it. The implementer's hand-audit then repeated the error by listing the state under the wrong source class, so the check never once ran against the real original.
+
+For every element that moved, re-derive from the original screen file which class it carried, then confirm the rule it now resolves to has the same colour token, size, weight and spacing — **including whatever it inherits** from `AdvisorPanel.module.css`'s `.body`, which supplies `font-size`, `color` and `line-height` to any element that stops declaring them. Build that mapping yourself from the original; never accept one someone else wrote.
 
 **Files:**
 - Create: `src/ui/components/TuneAdvisory.jsx`, `src/ui/components/TuneAdvisory.module.css`

--- a/docs/superpowers/plans/2026-08-24-tune-advisor-panel.md
+++ b/docs/superpowers/plans/2026-08-24-tune-advisor-panel.md
@@ -285,12 +285,23 @@ Add to `tests/ui/tune-screens.test.jsx`, inside the existing describes:
 
 ```jsx
 it('mounts exactly one advisor panel', () => {
-  mount(<SparkScreen calAdvice={emptyCalAdvice} />);
+  mount(<SparkScreen calAdvice={QUIET_CAL_ADVICE} />);
   expect(screen.getAllByTestId('advisor-panel')).toHaveLength(1);
 });
 ```
 
-Use the file's existing `mount` helper and its existing fabricated advice objects. Write the equivalent in the `AirflowScreen` and `FuelScreen` describes.
+`QUIET_CAL_ADVICE` is the file's existing blank fixture (`tests/ui/tune-screens.test.jsx:78`) — use it and the existing `mount` helper, and write the equivalent in the `AirflowScreen` and `FuelScreen` describes.
+
+**Extend that fixture in this task.** It is currently
+`{ overAdvanced: [], underAdvanced: [], pastMbt: [], wrongMix: [] }` — the four
+category arrays and nothing else, which was sufficient while the screens only read
+those four. `sparkReport` and `fuelReport` also read `spark` and `fuelAdv`, so add
+`spark: []` and `fuelAdv: []` to it now, matching the real shape
+`calibrationAdvice` returns. Do this by growing the fixture, **not** by making the
+report functions tolerate a missing array: a report that quietly copes with
+`calAdvice.spark === undefined` would also quietly cope with the shell forgetting to
+pass it, and the panel would show "never reached by this build" for every cell in a
+correctly-built table.
 
 - [ ] **Step 4: Run and verify**
 

--- a/docs/superpowers/plans/2026-08-24-tune-advisor-panel.md
+++ b/docs/superpowers/plans/2026-08-24-tune-advisor-panel.md
@@ -1,0 +1,791 @@
+# TUNE Advisor Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give TUNE's three grid screens a single contextual advisor surface that reports the gap for whatever the player has selected, and becomes the only home for advisor output on the tab.
+
+**Architecture:** A generic responsive chrome component (`AdvisorPanel`) renders as a right-hand rail at >=560px and a collapsed disclosure below it. A pure report module (`advisorReports.js`) turns `calAdvice`/`veAdvice` plus the current `selection` into a `{tone, headline, state, detail}` record, classifying **only by membership in the advisor's own output arrays** — never by re-deriving a threshold. A single renderer (`TuneAdvisory`) maps that record to prose. The three screens' existing inline banners move into the panel and are deleted from the screen bodies.
+
+**Tech Stack:** React 18, CSS Modules, vitest + @testing-library/react, JSDoc-typed JS checked by `tsc --noEmit`.
+
+## Global Constraints
+
+These bind every task. Copy the exact values.
+
+- **An advisor reports the gap; it never closes it.** No predicted outcomes, no fix-it buttons. The one exception already sanctioned by the codebase is `ACCEPT RE-LOGGED VALUES` on VE, because VE is a *measurement of the hardware*, not a calibration judgement — see the explainer in `SparkScreen.jsx`.
+- **Never re-derive an advisor threshold in the UI.** `advisors.js` documents that a spark advisor disagreeing with the generator is the false alarm issue #34 removed. Classify a cell by asking whether it appears in `calAdvice.overAdvanced` / `pastMbt` / `underAdvanced` / `wrongMix`, matching on `ri`/`ci`. Do not compare against `knockCeiling`, `mbt`, or any tolerance yourself.
+- **560px is the project's only breakpoint.** `src/ui/tokens.css:83-87` carries a hand-maintained list of every file that uses it. Any new stylesheet with a `@media` query must be added to that list in the same commit.
+- **No hard-coded colours.** Every colour resolves to a token. `tests/no-hardcoded-colours.test.js` generates one test per source file and will fail the build otherwise.
+- **The store is a single React context.** Every consumer re-renders on every dispatch, including `LIVE_STEP` at 20Hz. `AdvisorPanel`, `TuneAdvisory` and the report functions **read no store at all** — they take props only, and the components are wrapped in `React.memo`.
+- **Node 20 or 22 only.** Never run `npm run test:fingerprint:update`.
+- **No form of `git stash`**, with or without pathspecs, and never `git rebase --autostash`. `node_modules` is tracked; every stash variant destroys it. Never `git add node_modules` — a ` D node_modules` line in `git status` is a known pre-existing condition.
+- Full check suite: `npm test`, `npm run lint`, `npm run typecheck`, `npm run build`. All four must pass before a task is done.
+
+## File Structure
+
+**Create:**
+- `src/ui/components/AdvisorPanel.jsx` — responsive chrome only. Props: `headline`, `tone`, `children`. Knows nothing about tuning.
+- `src/ui/components/AdvisorPanel.module.css` — rail at >=560px, disclosure below. **Add to the tokens.css breakpoint list.**
+- `src/ui/components/advisorReports.js` — pure: `sparkReport`, `fuelReport`, `veReport`. No React import.
+- `src/ui/components/TuneAdvisory.jsx` — maps a report record to prose. All three kinds, one file, because they share a stylesheet.
+- `src/ui/components/TuneAdvisory.module.css` — the banner/label/body/cell styling, lifted from the three screens' existing modules.
+- `tests/ui/advisor-reports.test.js` — the pure functions, in isolation.
+- `tests/ui/advisor-panel.test.jsx` — chrome mechanics and the rendered bodies.
+
+**Modify:**
+- `src/ui/screens/tune/AirflowScreen.jsx`, `SparkScreen.jsx`, `FuelScreen.jsx` — two-column layout, mount the panel, delete the inline banners.
+- Their three `.module.css` files — remove the now-dead banner classes, add the layout.
+- `src/sim/advisors.js` — export `OPEN_LOOP_KPA` (one keyword; see Task 5).
+- `src/ui/tokens.css` — breakpoint list.
+- `src/ui/components/README.md` — describe the new files, and fix the stale "TUNE's ECU screen" references (that screen was split into `InjectorsScreen`/`SensorsScreen` by PR #86).
+- `tests/ui/tune-screens.test.jsx` — re-point the banner assertions at the panel.
+
+## The report record
+
+Every report function returns this shape. `state` selects the prose; `detail` carries the numbers. It is **declared in `advisorReports.js`** (Task 3) and imported by `TuneAdvisory.jsx` (Task 4).
+
+```js
+/**
+ * @typedef {object} AdvisorReport
+ * @property {'ok'|'warn'|'danger'|'info'} tone
+ * @property {string} headline plain text, shown on the collapsed summary at <560px
+ * @property {string} state which body the renderer should show
+ * @property {object} detail numbers and cell records the body needs
+ */
+```
+
+---
+
+### Task 1: `AdvisorPanel` — the responsive chrome
+
+Build the container and nothing else. It renders a heading, a tone-coloured headline, and `children`. At >=560px it is a right-hand rail; below that it is a disclosure the player taps open, with the headline visible while closed.
+
+**Files:**
+- Create: `src/ui/components/AdvisorPanel.jsx`
+- Create: `src/ui/components/AdvisorPanel.module.css`
+- Modify: `src/ui/tokens.css:83-87` (breakpoint list)
+- Test: `tests/ui/advisor-panel.test.jsx`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `export function AdvisorPanel({ headline, tone, children })` where `tone` is `'ok'|'warn'|'danger'|'info'`. Renders `data-testid="advisor-panel"` on the root and `data-open="true"|"false"` on it too. The root is a `<section aria-label="Advisor">`. Later tasks mount this and pass a body as `children`.
+
+**Why `data-open` and not a real `<details>`:** vitest applies no CSS, so a CSS-collapsed body is still in the DOM and still found by `getByText` — the repo has shipped eight assertions that could not fail for exactly this reason. Tests must assert on the `data-open` attribute, never on whether the body is queryable. A controlled `useState` + attribute also lets one CSS rule force the rail permanently open at >=560px without any JS breakpoint or `matchMedia` stub.
+
+- [ ] **Step 1: Write the failing test**
+
+```jsx
+// tests/ui/advisor-panel.test.jsx
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { AdvisorPanel } from '../../src/ui/components/AdvisorPanel.jsx';
+
+afterEach(cleanup);
+
+describe('AdvisorPanel', () => {
+  it('starts collapsed and shows the headline while closed', () => {
+    render(<AdvisorPanel headline="3.5 deg past the knock limit" tone="danger"><p>body</p></AdvisorPanel>);
+    const panel = screen.getByTestId('advisor-panel');
+    expect(panel.getAttribute('data-open')).toBe('false');
+    expect(screen.getByText('3.5 deg past the knock limit')).toBeTruthy();
+  });
+
+  it('toggles data-open when the summary is clicked', () => {
+    render(<AdvisorPanel headline="h" tone="ok"><p>body</p></AdvisorPanel>);
+    const panel = screen.getByTestId('advisor-panel');
+    fireEvent.click(screen.getByRole('button', { name: /advisor/i }));
+    expect(panel.getAttribute('data-open')).toBe('true');
+    fireEvent.click(screen.getByRole('button', { name: /advisor/i }));
+    expect(panel.getAttribute('data-open')).toBe('false');
+  });
+
+  it('reports its open state to a screen reader', () => {
+    // #81 is open precisely because BuildSection and ExpandableInfo do NOT do this.
+    // A component added after that issue was filed must not repeat the omission.
+    render(<AdvisorPanel headline="h" tone="ok"><p>body</p></AdvisorPanel>);
+    const toggle = screen.getByRole('button', { name: /advisor/i });
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('carries the tone as an attribute rather than a colour', () => {
+    render(<AdvisorPanel headline="h" tone="warn"><p>body</p></AdvisorPanel>);
+    expect(screen.getByTestId('advisor-panel').getAttribute('data-tone')).toBe('warn');
+  });
+});
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+Run: `npx vitest run tests/ui/advisor-panel.test.jsx --pool=forks --poolOptions.forks.singleFork`
+Expected: FAIL — cannot resolve `../../src/ui/components/AdvisorPanel.jsx`.
+
+- [ ] **Step 3: Write the component**
+
+```jsx
+/**
+ * The advisor surface for TUNE's grid screens: a right-hand rail on anything
+ * wider than a phone, a tap-to-open disclosure below that.
+ *
+ * Chrome only. It holds no opinion about tuning — `TuneAdvisory` supplies the
+ * body and `advisorReports.js` decides what that body says. Split that way so
+ * the responsive mechanics can be tested without fabricating advice objects.
+ *
+ * Reads no store. The store is one context and every consumer re-renders on
+ * every dispatch, `LIVE_STEP` at 20Hz included, so this takes props and is
+ * memoised — the panel re-renders when the selection or the advice changes and
+ * not when the engine ticks.
+ */
+
+import React, { useState } from 'react';
+
+import { ChevronDown } from 'lucide-react';
+
+import styles from './AdvisorPanel.module.css';
+
+/**
+ * @param {object} props
+ * @param {string} props.headline plain text; the only thing visible while collapsed
+ * @param {'ok'|'warn'|'danger'|'info'} props.tone
+ * @param {React.ReactNode} props.children
+ * @returns {React.ReactElement}
+ */
+function AdvisorPanelImpl({ headline, tone, children }) {
+  // Open state is deliberately NOT width-aware. At >=560px the stylesheet shows
+  // the body unconditionally and hides the toggle, so this flag only governs the
+  // narrow layout. Doing it in CSS keeps 560px out of the JavaScript, where it
+  // would be a second copy of the breakpoint that tokens.css could not track.
+  const [open, setOpen] = useState(false);
+
+  return (
+    <section
+      aria-label="Advisor"
+      className={styles.panel}
+      data-testid="advisor-panel"
+      data-open={open ? 'true' : 'false'}
+      data-tone={tone}
+    >
+      <button
+        type="button"
+        className={styles.summary}
+        aria-expanded={open ? 'true' : 'false'}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className={styles.eyebrow}>ADVISOR</span>
+        <span className={styles.headline}>{headline}</span>
+        <ChevronDown size={15} className={styles.chevron} aria-hidden="true" />
+      </button>
+      <div className={styles.body}>{children}</div>
+    </section>
+  );
+}
+
+export const AdvisorPanel = React.memo(AdvisorPanelImpl);
+```
+
+**Note on the accessible name:** the toggle's name comes from its text content, which begins with "ADVISOR" — that is what `getByRole('button', { name: /advisor/i })` matches. If you change the eyebrow text, change the test's query with it.
+
+- [ ] **Step 4: Write the stylesheet**
+
+Requirements, in tokens only:
+- `.panel` — bordered surface, `var(--panel-2)` background, `var(--line)` border, `10px` radius, matching the banner treatment already in `SparkScreen.module.css`.
+- `.summary` — a full-width unstyled button row: eyebrow, headline, chevron. `.chevron` rotates 180deg when the panel is open.
+- `.body` — `display: none` by default; `[data-open="true"] .body { display: block; }`.
+- `[data-tone="danger"]` / `"warn"` / `"ok"` / `"info"` set `--advisor-accent` to `var(--danger)` / `var(--warn)` / `var(--ok)` / `var(--cyan)`; `.headline` and the panel's left border read that variable. **A local custom property is the only place tone becomes a colour** — do not write four copies of the headline rule.
+- At `@media (min-width: 560px)`: `.summary` gets `pointer-events: none` and the chevron is `display: none`; `.body` is `display: block` regardless of `data-open`; the panel becomes the rail (`position: sticky; top: var(--sp-xl);`).
+
+Head the media query with the same cross-reference comment `AppShell.module.css:221-227` uses, then add this file to the list in `src/ui/tokens.css:86-87`.
+
+- [ ] **Step 5: Run the tests**
+
+Run: `npx vitest run tests/ui/advisor-panel.test.jsx --pool=forks --poolOptions.forks.singleFork`
+Expected: PASS, 4/4.
+
+- [ ] **Step 6: Full suite**
+
+Run: `npm test && npm run lint && npm run typecheck && npm run build`
+Expected: all green. `no-hardcoded-colours` gains two tests (one per new source file) — that is expected; a raw test total is not a stable baseline in this repo, so compare per-file counts.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui/components/AdvisorPanel.jsx src/ui/components/AdvisorPanel.module.css src/ui/tokens.css tests/ui/advisor-panel.test.jsx
+git commit -m "Add the advisor panel chrome: rail above 560px, disclosure below"
+```
+
+---
+
+### Task 2: The two-column TUNE layout
+
+Give AIRFLOW, SPARK and FUEL a left column (eyebrow, intro, grid, explainers) and a right column that holds the panel. Mount an `AdvisorPanel` with placeholder content on all three. **Do not move any banner content yet** — that is Tasks 3-5, and keeping the layout change on its own commit is what makes those diffs readable.
+
+**Files:**
+- Modify: `src/ui/screens/tune/AirflowScreen.jsx`, `SparkScreen.jsx`, `FuelScreen.jsx`
+- Modify: `src/ui/screens/tune/AirflowScreen.module.css`, `SparkScreen.module.css`, `FuelScreen.module.css`
+- Test: `tests/ui/tune-screens.test.jsx`
+
+**Interfaces:**
+- Consumes: `AdvisorPanel` from Task 1.
+- Produces: each of the three screens renders exactly one `data-testid="advisor-panel"`. The existing `data-testid="tuning-grid"` and `data-testid="selection-dock"` stay exactly where they are — `characterisation.test.jsx` and `button-call-sites.test.jsx` query both, and neither test may need to change in this task.
+
+- [ ] **Step 1: Restructure the markup**
+
+In each screen, wrap the existing children of `.wrap` in a new `<div className={styles.main}>`, then add the panel as `.main`'s sibling:
+
+```jsx
+<div className={styles.wrap}>
+  <div className={styles.main}>
+    {/* everything that was directly inside .wrap before, unchanged */}
+  </div>
+  <AdvisorPanel headline="Advisor" tone="info">
+    <p>Placeholder — filled in by the next task.</p>
+  </AdvisorPanel>
+</div>
+```
+
+The `<div className={styles.spacer} />` and the `<SelectionDock …>` stay OUTSIDE `.wrap`, exactly where they are now. The dock is a sticky bottom editor and must not enter the grid.
+
+- [ ] **Step 2: Layout CSS, in each of the three modules**
+
+```css
+@media (min-width: 560px) {
+  .wrap {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 280px;
+    gap: var(--sp-xl);
+    align-items: start;
+  }
+}
+```
+
+`minmax(0, 1fr)` rather than `1fr` on purpose: the tuning grid is a wide fixed-width child, and a bare `1fr` refuses to shrink below its content, which pushes the rail off the cap. Add the media-query cross-reference comment and add all three stylesheets to the `tokens.css` breakpoint list.
+
+- [ ] **Step 3: Test that all three mount exactly one panel**
+
+Add to `tests/ui/tune-screens.test.jsx`, inside the existing describes:
+
+```jsx
+it('mounts exactly one advisor panel', () => {
+  mount(<SparkScreen calAdvice={emptyCalAdvice} />);
+  expect(screen.getAllByTestId('advisor-panel')).toHaveLength(1);
+});
+```
+
+Use the file's existing `mount` helper and its existing fabricated advice objects. Write the equivalent in the `AirflowScreen` and `FuelScreen` describes.
+
+- [ ] **Step 4: Run and verify**
+
+Run: `npx vitest run tests/ui/tune-screens.test.jsx tests/ui/characterisation.test.jsx tests/ui/button-call-sites.test.jsx --pool=forks --poolOptions.forks.singleFork`
+Expected: PASS. **If `characterisation.test.jsx` fails, the layout change broke something real — fix the code, not the test.** That file changed for the first time in seven PRs during #83 and is not entitled to change here.
+
+- [ ] **Step 5: Full suite, then commit**
+
+```bash
+git add src/ui/screens/tune src/ui/tokens.css tests/ui/tune-screens.test.jsx
+git commit -m "Give TUNE's grid screens a two-column layout with an advisor rail"
+```
+
+---
+
+### Task 3: `sparkReport` — the pure classifier
+
+The heart of the feature. Turns `calAdvice` plus a selection into a report record. **Pure JS, no React, no store.**
+
+**Files:**
+- Create: `src/ui/components/advisorReports.js`
+- Test: `tests/ui/advisor-reports.test.js`
+
+**Interfaces:**
+- Consumes: the shape `calibrationAdvice` already returns — `{spark, fuelAdv, overAdvanced, underAdvanced, pastMbt, wrongMix}`, where every entry in `spark`/`fuelAdv` carries `ri`, `ci`, `rpm`, `map`, `current`, `suggested`, `delta`, and spark entries additionally carry `mbt`, `knockCeiling`, `knocking`, `knockLimited`.
+- Produces: `export function sparkReport(calAdvice, selection)` returning an `AdvisorReport`. Tasks 5 and 6 add `fuelReport` and `veReport` to the same file.
+
+**The rule this task exists to enforce:** classification is membership in the advisor's own arrays, matched on `ri`/`ci`. Never a threshold comparison. `advisors.js` documents that the classification is subtle — a cell past both ceilings with MBT the lower of the two is *detonating*, and ordering the checks by which ceiling is lower would report it as merely wasteful. Asking the arrays cannot get that wrong; re-deriving it can, and did, before issue #34.
+
+**The precedence order is the screen's existing fall-through and must be preserved exactly:** over-advanced, then under-advanced (only when there are more than four), then past-MBT, then clean.
+
+- [ ] **Step 1: Write the failing tests**
+
+```js
+// tests/ui/advisor-reports.test.js
+import { describe, expect, it } from 'vitest';
+
+import { sparkReport } from '../../src/ui/components/advisorReports.js';
+
+/** A spark entry; only the fields the report reads. */
+const cell = (ri, ci, over) => ({
+  ri, ci, rpm: 1000 * (ci + 1), map: 100 + ri * 20,
+  current: over ? 24 : 18, suggested: 18, delta: over ? -6 : 0,
+  mbt: 22, knockCeiling: 20,
+});
+
+/** Assembles a calAdvice whose category arrays genuinely contain the cells named. */
+function advice({ over = [], under = [], past = [] } = {}) {
+  const all = [...over, ...under, ...past];
+  return { spark: all, fuelAdv: [], overAdvanced: over, underAdvanced: under, pastMbt: past, wrongMix: [] };
+}
+
+describe('sparkReport, no selection', () => {
+  it('leads with the knock limit when any cell is past it', () => {
+    const r = sparkReport(advice({ over: [cell(3, 4, true)] }), null);
+    expect(r.state).toBe('table-over');
+    expect(r.tone).toBe('danger');
+    expect(r.headline).toBe('1 cell beyond the knock limit');
+  });
+
+  it('pluralises the headline', () => {
+    const r = sparkReport(advice({ over: [cell(3, 4, true), cell(3, 5, true)] }), null);
+    expect(r.headline).toBe('2 cells beyond the knock limit');
+  });
+
+  it('reports timing left on the table only past the four-cell floor', () => {
+    const four = [cell(0, 0), cell(0, 1), cell(0, 2), cell(0, 3)];
+    expect(sparkReport(advice({ under: four }), null).state).toBe('table-clean');
+    expect(sparkReport(advice({ under: [...four, cell(0, 4)] }), null).state).toBe('table-under');
+  });
+
+  it('ranks the knock limit above every other finding', () => {
+    // A table that is simultaneously over-advanced somewhere and under-advanced
+    // in six places leads with the danger, never with the opportunity.
+    const under = [cell(0, 0), cell(0, 1), cell(0, 2), cell(0, 3), cell(0, 4), cell(0, 5)];
+    const r = sparkReport(advice({ over: [cell(3, 4, true)], under }), null);
+    expect(r.state).toBe('table-over');
+  });
+
+  it('is clean when every category is empty', () => {
+    const r = sparkReport(advice(), null);
+    expect(r.state).toBe('table-clean');
+    expect(r.tone).toBe('ok');
+  });
+});
+
+describe('sparkReport, one cell selected', () => {
+  it('classifies by membership, not by comparing against the ceilings itself', () => {
+    // This cell's own numbers say it is inside both ceilings (current 18 < mbt 22,
+    // < knockCeiling 20). The advisor nonetheless filed it as over-advanced. The
+    // report must follow the advisor, because the advisor is the single source of
+    // truth for what counts as over-advanced — a UI that recomputed the answer is
+    // exactly the disagreement advisors.js warns about.
+    const c = { ...cell(3, 4), current: 18 };
+    const r = sparkReport(advice({ over: [c] }), { type: 'cell', row: 3, col: 4 });
+    expect(r.state).toBe('cell-over');
+    expect(r.tone).toBe('danger');
+  });
+
+  it('names the gap to the ceiling that bound it', () => {
+    const c = { ...cell(3, 4), current: 24, knockCeiling: 20 };
+    const r = sparkReport(advice({ over: [c] }), { type: 'cell', row: 3, col: 4 });
+    expect(r.headline).toBe('4.0 deg past the knock limit');
+    expect(r.detail.cell).toBe(c);
+  });
+
+  it('says a cell the engine never reaches is unreachable, not clean', () => {
+    // calibrationAdvice skips unreachable cells entirely (its rule 2), so the
+    // lookup misses. Reporting that as "inside both ceilings" would tell the
+    // player their 200 kPa cell at 800 RPM is fine, when it simply never happens.
+    const r = sparkReport(advice({ over: [cell(3, 4, true)] }), { type: 'cell', row: 0, col: 0 });
+    expect(r.state).toBe('cell-unreachable');
+    expect(r.tone).toBe('info');
+  });
+
+  it('reports a cell in no category as inside both ceilings', () => {
+    const c = cell(2, 2);
+    const r = sparkReport({ ...advice(), spark: [c] }, { type: 'cell', row: 2, col: 2 });
+    expect(r.state).toBe('cell-ok');
+    expect(r.tone).toBe('ok');
+  });
+});
+
+describe('sparkReport, a row or column selected', () => {
+  it('counts the flagged cells inside the selected row', () => {
+    const r = sparkReport(
+      advice({ over: [cell(3, 1, true), cell(3, 2, true), cell(1, 5, true)] }),
+      { type: 'row', row: 3 },
+    );
+    expect(r.state).toBe('group-over');
+    expect(r.headline).toBe('2 of these cells are past the knock limit');
+  });
+
+  it('counts down the column when a column is selected', () => {
+    const r = sparkReport(
+      advice({ over: [cell(1, 4, true), cell(3, 4, true), cell(3, 0, true)] }),
+      { type: 'col', col: 4 },
+    );
+    expect(r.headline).toBe('2 of these cells are past the knock limit');
+  });
+
+  it('is clean when nothing in the group is flagged', () => {
+    const r = sparkReport(advice({ over: [cell(1, 5, true)] }), { type: 'row', row: 3 });
+    expect(r.state).toBe('group-clean');
+  });
+});
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `npx vitest run tests/ui/advisor-reports.test.js --pool=forks --poolOptions.forks.singleFork`
+Expected: FAIL — cannot resolve `advisorReports.js`.
+
+- [ ] **Step 3: Implement**
+
+```js
+/**
+ * Advisor reports: what the simulation's advisors already concluded, narrowed to
+ * whatever the player currently has selected.
+ *
+ * These invent no analysis. `calibrationAdvice` and `veRecommendations` in
+ * `src/sim/advisors.js` decide what is wrong with a table; these functions only
+ * decide which part of that answer is relevant right now, and how to say it.
+ *
+ * THE ONE RULE: a cell's category is looked up in the advisor's own output
+ * arrays. It is never re-derived by comparing the cell against a threshold. The
+ * classification in `calibrationAdvice` is subtle on purpose — a cell past both
+ * ceilings with MBT the lower of the two is detonating, not merely wasteful, and
+ * getting that backwards tells a player a dangerous cell is safe. Asking the
+ * arrays cannot get it wrong. Recomputing can, and that is the false alarm
+ * issue #34 removed.
+ */
+
+/** @typedef {import('./TuningGrid.jsx').Selection} Selection */
+
+/**
+ * @typedef {object} AdvisorReport
+ * @property {'ok'|'warn'|'danger'|'info'} tone
+ * @property {string} headline plain text, shown on the collapsed summary at <560px
+ * @property {string} state which body the renderer should show
+ * @property {object} detail numbers and cell records the body needs
+ */
+
+/** English, not a template with a stray "1 cells" in it. */
+const plural = (n, word) => `${n} ${word}${n === 1 ? '' : 's'}`;
+
+/** Does this category contain the cell at (ri, ci)? */
+const holds = (arr, ri, ci) => arr.some((c) => c.ri === ri && c.ci === ci);
+
+/** How many of a category fall inside the selected row or column? */
+function countIn(arr, selection) {
+  if (selection.type === 'row') return arr.filter((c) => c.ri === selection.row).length;
+  return arr.filter((c) => c.ci === selection.col).length;
+}
+
+/**
+ * @param {object} calAdvice as returned by `calibrationAdvice`
+ * @param {Selection|null} selection
+ * @returns {AdvisorReport}
+ */
+export function sparkReport(calAdvice, selection) {
+  const { spark, overAdvanced, underAdvanced, pastMbt } = calAdvice;
+
+  if (selection && selection.type === 'cell') {
+    const cell = spark.find((c) => c.ri === selection.row && c.ci === selection.col);
+    // No entry means `calibrationAdvice` filtered the cell out as unreachable
+    // (its rule 2): a turbo build never sees 200 kPa at 800 RPM. That is not the
+    // same as a clean cell and must not be reported as one.
+    if (!cell) return { tone: 'info', headline: 'Never reached by this build', state: 'cell-unreachable', detail: {} };
+
+    if (holds(overAdvanced, cell.ri, cell.ci)) {
+      return {
+        tone: 'danger',
+        headline: `${(cell.current - cell.knockCeiling).toFixed(1)} deg past the knock limit`,
+        state: 'cell-over',
+        detail: { cell },
+      };
+    }
+    if (holds(pastMbt, cell.ri, cell.ci)) {
+      return {
+        tone: 'warn',
+        headline: `${(cell.current - cell.mbt).toFixed(1)} deg past MBT`,
+        state: 'cell-past-mbt',
+        detail: { cell },
+      };
+    }
+    if (holds(underAdvanced, cell.ri, cell.ci)) {
+      return {
+        tone: 'warn',
+        headline: `${cell.delta.toFixed(1)} deg below what this build allows`,
+        state: 'cell-under',
+        detail: { cell },
+      };
+    }
+    return { tone: 'ok', headline: 'Inside both ceilings', state: 'cell-ok', detail: { cell } };
+  }
+
+  if (selection) {
+    // A row or column. Same precedence as the table-wide report, scoped to the band.
+    const over = countIn(overAdvanced, selection);
+    if (over > 0) {
+      return {
+        tone: 'danger',
+        headline: `${over} of these cells are past the knock limit`,
+        state: 'group-over',
+        detail: { count: over },
+      };
+    }
+    const under = countIn(underAdvanced, selection);
+    const past = countIn(pastMbt, selection);
+    if (past > 0) {
+      return { tone: 'warn', headline: `${past} of these cells are past MBT`, state: 'group-past-mbt', detail: { count: past } };
+    }
+    if (under > 0) {
+      return { tone: 'warn', headline: `${under} of these cells have advance left`, state: 'group-under', detail: { count: under } };
+    }
+    return { tone: 'ok', headline: 'Nothing flagged in this band', state: 'group-clean', detail: {} };
+  }
+
+  // Table-wide. This precedence IS the fall-through the SPARK screen rendered
+  // before the panel existed, preserved exactly: danger first, then the
+  // opportunity, then the wasted advance, then the all-clear.
+  if (overAdvanced.length > 0) {
+    return {
+      tone: 'danger',
+      headline: `${plural(overAdvanced.length, 'cell')} beyond the knock limit`,
+      state: 'table-over',
+      detail: { count: overAdvanced.length, cells: overAdvanced.slice(0, 5), more: Math.max(0, overAdvanced.length - 5) },
+    };
+  }
+  if (underAdvanced.length > 4) {
+    return { tone: 'warn', headline: 'Timing left on the table', state: 'table-under', detail: { count: underAdvanced.length } };
+  }
+  if (pastMbt.length > 0) {
+    return { tone: 'warn', headline: 'Past peak torque', state: 'table-past-mbt', detail: { count: pastMbt.length } };
+  }
+  return { tone: 'ok', headline: 'Within the knock limit', state: 'table-clean', detail: {} };
+}
+```
+
+**Careful:** the group branch checks `pastMbt` before `underAdvanced` while the table branch checks `underAdvanced` before `pastMbt`. That is not a slip to "fix" — the table ordering is the screen's historical fall-through and is preserved for fidelity, and the group ordering puts the two warnings in severity order for a band the player is actively looking at. If a reviewer flags the inconsistency, this note is the answer.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx vitest run tests/ui/advisor-reports.test.js --pool=forks --poolOptions.forks.singleFork`
+Expected: PASS, 13/13.
+
+- [ ] **Step 5: Prove the membership test is load-bearing**
+
+Temporarily change `holds` to compare thresholds instead:
+```js
+const holds = (arr, ri, ci) => false;
+```
+Run the tests. `classifies by membership` and `names the gap` must FAIL. Revert. Paste the failure output into the task report — a classification test that passes with the classifier stubbed out is not a test.
+
+- [ ] **Step 6: Full suite, then commit**
+
+```bash
+git add src/ui/components/advisorReports.js tests/ui/advisor-reports.test.js
+git commit -m "Add sparkReport: narrow the knock advisor to the current selection"
+```
+
+---
+
+### Task 4: `TuneAdvisory` renders the spark report, and SPARK's banner moves in
+
+Two commits, in this order. **Stage 1 moves the markup verbatim; stage 2 converts it to the new stylesheet.** That is the technique the screen split used, and it is what makes a fidelity slip visible: hand-audit stage 2's diff against stage 1 before committing it, because no test in this repo sees a className.
+
+**Files:**
+- Create: `src/ui/components/TuneAdvisory.jsx`, `src/ui/components/TuneAdvisory.module.css`
+- Modify: `src/ui/screens/tune/SparkScreen.jsx`, `SparkScreen.module.css`
+- Modify: `tests/ui/tune-screens.test.jsx`, `src/ui/components/README.md`
+
+**Interfaces:**
+- Consumes: `sparkReport` (Task 3), `AdvisorPanel` (Task 1), the layout (Task 2).
+- Produces: `export function TuneAdvisory({ kind, report, onAcceptVe })` where `kind` is `'ve'|'timing'|'afr'`. Tasks 5 and 6 extend it. It imports the `AdvisorReport` typedef **from `advisorReports.js`** — the module that produces a type owns it, and Task 3 ships before this one, so the arrow cannot point the other way.
+
+- [ ] **Step 1: Move SPARK's four advisory states into `TuneAdvisory`, verbatim**
+
+Every string, every `<b>`, every number format from `SparkScreen.jsx:52-82` moves across unchanged, keyed by `report.state`:
+
+| `report.state` | body |
+|---|---|
+| `table-over` | the whole `.dangerBanner` block: the count label, the "Your current hardware will not tolerate…" paragraph, up to five `map kPa / rpm RPM: current deg -> suggested deg` lines from `detail.cells`, the "…and N more" line from `detail.more`, and the "Edit them yourself — a calibration is yours to make, not something the app should silently rewrite." footer |
+| `table-under` | "**Timing left on the table.** N cells are more than 3 deg below…" |
+| `table-past-mbt` | "**Past peak torque.** N cells command more advance than the burn can use…" |
+| `table-clean` | "Spark table sits within the knock limit for this hardware." |
+
+The panel supplies the surrounding box, so the outer banner `<div>` does not move — its border, background and radius become the panel's `data-tone`. Everything inside it does.
+
+New bodies, for the states that did not exist before:
+
+| `report.state` | body |
+|---|---|
+| `cell-over` | the cell's `map`/`rpm`, then `Your value`, `Knock limit`, `MBT` and `Suggested` as a small definition list, then: "Past the knock limit the engine is damaging itself. Pull this cell back to the suggested value, or lower." |
+| `cell-past-mbt` | same list, then: "The burn already lands where it should, so the extra degrees are pushing against the piston on the way up rather than making torque. Not dangerous — this cell is inside the knock limit — but pulling it back gains a little power and buys margin." |
+| `cell-under` | same list, then: "This cell is leaving advance on the table. Add it a degree at a time and run a pull between each change." |
+| `cell-ok` | same list, then: "Inside both the knock limit and MBT. Nothing to correct here." |
+| `cell-unreachable` | "This build never reaches this manifold pressure at this engine speed, so the advisor has nothing to say about the cell. It is still yours to edit — it just will not be used." |
+| `group-*` | the headline's count and one line naming what to do: select a single cell to see its numbers. |
+
+- [ ] **Step 2: Delete the banner from `SparkScreen.jsx`, mount the advisory**
+
+```jsx
+const report = sparkReport(calAdvice, selection);
+…
+<AdvisorPanel headline={report.headline} tone={report.tone}>
+  <TuneAdvisory kind="timing" report={report} />
+</AdvisorPanel>
+```
+
+`sparkReport` is called on every render. It is a handful of `.some()` scans over at most 96 cells with no allocation in the hot path — do not memoise it. A `useMemo` here would need `calAdvice` and `selection` in its dependency array and would buy nothing measurable.
+
+- [ ] **Step 3: Re-point the existing tests**
+
+`tests/ui/tune-screens.test.jsx:127-143` has two tests that must keep testing what they test today — that the screen shows **the shell's** advice rather than one it derived. They keep their fabricated `calAdvice`; only the expected strings move to the panel's phrasing. Assert inside the panel:
+
+```jsx
+const panel = within(screen.getByTestId('advisor-panel'));
+expect(panel.getByText('1 cell beyond the knock limit')).toBeTruthy();
+```
+
+Note `1 cell`, singular — the old assertion read `1 CELLS BEYOND THE KNOCK LIMIT`, which was a latent copy bug the plural helper fixes.
+
+- [ ] **Step 4: Add a test for the selection-scoped path through the real component**
+
+```jsx
+it('narrows to the selected cell rather than the whole table', () => {
+  // Set a selection, then assert the panel reports THAT cell and not the table count.
+});
+```
+
+Use the store the `mount` helper already provides; dispatch `SET_TUNE_FIELD` with `field: 'selection'`.
+
+- [ ] **Step 5: Delete the dead CSS**
+
+`.dangerBanner`, `.dangerLabel`, `.dangerBody`, `.dangerCell`, `.dangerMore`, `.dangerFooter`, `.advisoryPanel` and `.okBanner` leave `SparkScreen.module.css`. `.em` and `.emInk` **stay** — the `ExpandableInfo` blocks still use them. Check each class with `grep -n 'styles\.' src/ui/screens/tune/SparkScreen.jsx` before deleting; an unused CSS Modules class is silent, so removing one that is still referenced only shows up as an unstyled element in a browser nobody has opened.
+
+- [ ] **Step 6: Full suite, then two commits**
+
+```bash
+git commit -m "Move SPARK's knock advisory into the advisor panel, markup unchanged"
+# then, after converting to TuneAdvisory.module.css and hand-auditing the diff:
+git commit -m "Convert the spark advisory to its own stylesheet"
+```
+
+---
+
+### Task 5: `fuelReport`, and FUEL's mixture advisory moves in
+
+**Files:**
+- Modify: `src/sim/advisors.js` (one keyword — see below)
+- Modify: `src/ui/components/advisorReports.js`, `TuneAdvisory.jsx`, `TuneAdvisory.module.css`
+- Modify: `src/ui/screens/tune/FuelScreen.jsx`, `FuelScreen.module.css`
+- Modify: `tests/ui/advisor-reports.test.js`, `tests/ui/tune-screens.test.jsx`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-4.
+- Produces: `export function fuelReport(calAdvice, selection)`.
+
+**The one `src/sim` change in this plan.** `OPEN_LOOP_KPA` (`src/sim/advisors.js:47`) is currently a private const. Add the `export` keyword — nothing else:
+
+```js
+export const OPEN_LOOP_KPA = 85;
+```
+
+`src/sim/index.js:29` already does `export * from './advisors.js'`, so it becomes available without a second edit. Why it is needed: `wrongMix` only ever contains cells at or above that pressure, so a closed-loop cell and an on-target open-loop cell are both simply *absent* from it. Without the constant the panel cannot tell them apart, and would have to say something vague about a cell whose mixture the trims own outright. **Do not copy the literal `85` into the UI** — that is a second copy of a physics threshold, and it will drift.
+
+This is additive, changes no value, and cannot move the fingerprint. Run `npm test` and confirm `tests/fingerprint.test.js` still passes before committing, and say so in the report.
+
+- [ ] **Step 1: Tests for `fuelReport`**
+
+Cover, in `tests/ui/advisor-reports.test.js`:
+- no selection, `wrongMix` non-empty → `table-off`, tone `warn`, headline `N high-load cells off best power` (pluralised).
+- no selection, `wrongMix` empty → `table-clean`, tone `ok`, headline `High-load mixture is on best power`.
+- cell selected, present in `wrongMix` → `cell-off`, tone `warn`, headline names the direction: `0.8 AFR lean of best power` or `0.8 AFR rich of best power`. `delta` is `suggested - current`, so a **negative** delta means the suggestion is richer, i.e. the cell is currently **lean**. Test both signs; getting this backwards tells a player to lean out a cell that is already burning a piston.
+- cell selected, `map < OPEN_LOOP_KPA` → `cell-closed-loop`, tone `info`, headline `Closed loop — the trims own this cell`. Assert this is chosen **even when the cell's delta is large**, since a big closed-loop error is still not the player's to fix in this table.
+- cell selected, open loop but not in `wrongMix` → `cell-ok`, tone `ok`, headline `On best power`.
+- cell not in `fuelAdv` at all → `cell-unreachable`, tone `info`.
+- row/col selection → count of `wrongMix` cells in the band.
+
+- [ ] **Step 2: Implement, then Steps 3-6 mirror Task 4**
+
+Move `FuelScreen.jsx:41-56` verbatim into `TuneAdvisory` under `state: 'table-off'` — the count label, the long "Best-power mixture shifts with boost…" paragraph including its `<b>delivered</b>`, the five `data-richen` cell lines with their `(richen)`/`(lean out)` suffixes and `delivered X, wants Y` tails, and the "…and N more" line. The `data-richen` attribute stays: `FuelScreen.module.css` colours the two directions differently and that distinction must survive the move.
+
+**New content:** FUEL had no clean state at all — its banner simply did not render when `wrongMix` was empty. The panel always renders something, so `table-clean` is genuinely new prose. That is deliberate: AIRFLOW and SPARK both already say when a table is fine, and a panel that goes blank reads as broken.
+
+Delete the banner classes from `FuelScreen.module.css`; keep `.em`, which the `ExpandableInfo` block still uses.
+
+---
+
+### Task 6: `veReport`, and AIRFLOW's sync advisory moves in
+
+**Files:** as Task 5, for `AirflowScreen`.
+
+**Interfaces:**
+- Produces: `export function veReport(veAdvice, selection)`.
+
+**The honesty problem this task exists to get right.** `veRecommendations` returns `deltas` indexed **by RPM column, at the wide-open-throttle row only** — there is no per-cell VE gap to report, and `WOT_ROW` is a private constant this plan does not export. So:
+
+- **Never** claim a gap for an arbitrary selected cell. For a `cell` or `col` selection, report the **column's** delta and say plainly which quantity it is: "Measured at wide-open throttle. This gap belongs to the RPM column, not to this one cell."
+- For a `row` selection, there is nothing column-scoped to say: fall back to the table-wide report.
+- `veAdvice` can be `null` — `AirflowScreen` already guards with `{veAdvice && (…)}`. Return a `no-advice` state rather than throwing, and keep the panel mounted.
+
+States:
+- `table-sync` — tone `ok`, headline `VE matches your hardware`, body "VE table matches your current hardware. Nothing to correct." (verbatim from the existing `.inSyncBanner`).
+- `table-stale` — tone `warn`, headline `VE out of sync — N% max gap`, body: the whole existing `.staleBanner` content, every `rec` with its `rpmText`, `text` and joined `cells`, the `ACCEPT RE-LOGGED VALUES` button, and the "Or type them in yourself — these are the measured targets, not a suggestion." note.
+- `col-gap` / `cell-gap` — tone from the sign and size of the column delta, headline `` `${pct.toFixed(0)}% ${pct > 0 ? 'more' : 'less'} air here than your table assumes` ``, body carrying `from`/`to` and the wide-open-throttle caveat above.
+- `no-advice` — tone `info`, "No airflow comparison available for this build yet."
+
+**The `ACCEPT RE-LOGGED VALUES` button must keep working.** It is the one advisor action the design rule permits, and three separate test files reach it:
+- `tests/ui/tune-screens.test.jsx:107-119` clicks it on a mounted `AirflowScreen`
+- `tests/ui/build-store.test.jsx:370-401` drives it through the whole app
+- `tests/ui/button-call-sites.test.jsx:149` lists its label in an allow-list, and `:297` counts its call sites
+
+Pass the existing `recalcVE` handler down as `onAcceptVe`. **Run all three files and paste the output** — `build-store.test.jsx` is the one that proves the button still reaches the store through the real shell.
+
+**A trap specific to this task:** `button-call-sites.test.jsx:297` counts call sites. Moving the button from `AirflowScreen` to `TuneAdvisory` does not change the count, but it does change the file the count is attributed to. Read that test before touching the button and check whether it asserts on location as well as number.
+
+---
+
+### Task 7: Sweep, verify, open the PR
+
+- [ ] **Step 1: Prove no user-visible string was lost**
+
+Do this with an AST parse, not a regex — the same check that caught nothing in PR 3c and would have caught the missing branding in PR 3b. Walk `src/ui/` at `origin/main` and at `HEAD` with the Babel parser already in `node_modules`, collect every string and JSX text node, and diff the two sets. Every string present on main and absent on HEAD must be traceable to a deliberate rewrite named in this plan. List them in the PR body.
+
+- [ ] **Step 2: Confirm the simulation is untouched apart from one keyword**
+
+```bash
+git diff origin/main --stat -- src/sim/ tests/fixtures/ tests/fingerprint.test.js package.json package-lock.json
+```
+Expected: exactly one file, `src/sim/advisors.js`, one insertion and one deletion. Anything else is a bug in this branch.
+
+- [ ] **Step 3: Confirm `characterisation.test.jsx` is byte-identical to main**
+
+```bash
+git diff origin/main --stat -- tests/ui/characterisation.test.jsx
+```
+Expected: empty. That file earned its one change in #83; this PR moves content between components without changing what the app does, so it has no claim on another.
+
+- [ ] **Step 4: Check the dead-class sweep**
+
+For each of the three screen stylesheets, confirm every remaining class is still referenced:
+```bash
+for f in Airflow Spark Fuel; do
+  echo "== $f"
+  grep -o '^\.[a-zA-Z0-9_]*' "src/ui/screens/tune/${f}Screen.module.css" | tr -d '.' | while read -r c; do
+    grep -q "styles\.$c\b" "src/ui/screens/tune/${f}Screen.jsx" || echo "  UNUSED: $c"
+  done
+done
+```
+Expected: no output. An orphaned class is invisible to every test in this repo.
+
+- [ ] **Step 5: Full suite, rebase, full suite again**
+
+```bash
+npm test && npm run lint && npm run typecheck && npm run build
+git fetch origin
+git update-index --skip-worktree node_modules
+git rebase origin/main
+git update-index --no-skip-worktree node_modules
+git ls-files -v node_modules   # MUST print uppercase "H"; lowercase "h" means git is silently ignoring it
+npm test && npm run lint && npm run typecheck && npm run build
+```
+
+The `--skip-worktree` pair is how a rebase gets past the standing ` D node_modules` dirty tree. It is index-only: it touches nothing on disk, stages nothing, commits nothing. **It is not a substitute for stash and stash is still forbidden.** Clear the flag immediately and verify it cleared.
+
+- [ ] **Step 6: Push and open the PR — do not merge it**
+
+The body states what moved, what is genuinely new prose (FUEL's clean state), the one-keyword `src/sim` change and why, the string-sweep result, and `Closes #85`. It must also record that **nobody has loaded this in a browser** — the two-column layout at 560-700px, where a 452px grid and a 280px rail have to share the width, is the most likely thing to look wrong.
+
+Then stop. The Iron Rule: the workflow ends at "PR is open and awaiting review."

--- a/docs/superpowers/plans/2026-08-24-tune-advisor-panel.md
+++ b/docs/superpowers/plans/2026-08-24-tune-advisor-panel.md
@@ -192,7 +192,7 @@ export const AdvisorPanel = React.memo(AdvisorPanelImpl);
 - [ ] **Step 4: Write the stylesheet**
 
 Requirements, in tokens only:
-- `.panel` — bordered surface, `var(--panel-2)` background, `var(--line)` border, `10px` radius, matching the banner treatment already in `SparkScreen.module.css`.
+- `.panel` — bordered surface, `var(--panel2)` background, `var(--line)` border, `10px` radius, matching the banner treatment already in `SparkScreen.module.css`.
 - `.summary` — a full-width unstyled button row: eyebrow, headline, chevron. `.chevron` rotates 180deg when the panel is open.
 - `.body` — `display: none` by default; `[data-open="true"] .body { display: block; }`.
 - `[data-tone="danger"]` / `"warn"` / `"ok"` / `"info"` set `--advisor-accent` to `var(--danger)` / `var(--warn)` / `var(--ok)` / `var(--cyan)`; `.headline` and the panel's left border read that variable. **A local custom property is the only place tone becomes a colour** — do not write four copies of the headline rule.

--- a/src/sim/advisors.js
+++ b/src/sim/advisors.js
@@ -21,7 +21,7 @@ import { LOAD, RPM, SPARK_MAX_DEG, SPARK_MIN_DEG } from './tables.js';
 const WOT_ROW = 2;
 
 /** A cell delta below this (percent) is not worth reporting. */
-const VE_NOTABLE_PCT = 2.5;
+export const VE_NOTABLE_PCT = 2.5;
 
 /** Safety left under the calculated knock limit when advising, degrees. */
 const KNOCK_SAFETY_DEG = 1.5;

--- a/src/sim/advisors.js
+++ b/src/sim/advisors.js
@@ -40,7 +40,7 @@ const MIX_NOTABLE_AFR = 0.45;
  * to these rows: below it the target is stoichiometric and the trims own it, so
  * best-power advice would be actively wrong.
  */
-const OPEN_LOOP_KPA = 85;
+export const OPEN_LOOP_KPA = 85;
 
 /**
  * Slack above the boost target when deciding whether a row is reachable, kPa. Enough to

--- a/src/ui/components/AdvisorPanel.jsx
+++ b/src/ui/components/AdvisorPanel.jsx
@@ -40,16 +40,18 @@ function AdvisorPanelImpl({ headline, tone, children }) {
       data-open={open ? 'true' : 'false'}
       data-tone={tone}
     >
-      <button
-        type="button"
-        className={styles.summary}
-        aria-expanded={open ? 'true' : 'false'}
-        onClick={() => setOpen((v) => !v)}
-      >
+      <div className={styles.head}>
         <span className={styles.eyebrow}>ADVISOR</span>
         <span className={styles.headline}>{headline}</span>
         <ChevronDown size={15} className={styles.chevron} aria-hidden="true" />
-      </button>
+        <button
+          type="button"
+          className={styles.toggle}
+          aria-expanded={open ? 'true' : 'false'}
+          aria-label={open ? 'Hide advisor detail' : 'Show advisor detail'}
+          onClick={() => setOpen((v) => !v)}
+        />
+      </div>
       <div className={styles.body}>{children}</div>
     </section>
   );

--- a/src/ui/components/AdvisorPanel.jsx
+++ b/src/ui/components/AdvisorPanel.jsx
@@ -1,0 +1,58 @@
+/**
+ * The advisor surface for TUNE's grid screens: a right-hand rail on anything
+ * wider than a phone, a tap-to-open disclosure below that.
+ *
+ * Chrome only. It holds no opinion about tuning — `TuneAdvisory` supplies the
+ * body and `advisorReports.js` decides what that body says. Split that way so
+ * the responsive mechanics can be tested without fabricating advice objects.
+ *
+ * Reads no store. The store is one context and every consumer re-renders on
+ * every dispatch, `LIVE_STEP` at 20Hz included, so this takes props and is
+ * memoised — the panel re-renders when the selection or the advice changes and
+ * not when the engine ticks.
+ */
+
+import React, { useState } from 'react';
+
+import { ChevronDown } from 'lucide-react';
+
+import styles from './AdvisorPanel.module.css';
+
+/**
+ * @param {object} props
+ * @param {string} props.headline plain text; the only thing visible while collapsed
+ * @param {'ok'|'warn'|'danger'|'info'} props.tone
+ * @param {React.ReactNode} props.children
+ * @returns {React.ReactElement}
+ */
+function AdvisorPanelImpl({ headline, tone, children }) {
+  // Open state is deliberately NOT width-aware. At >=560px the stylesheet shows
+  // the body unconditionally and hides the toggle, so this flag only governs the
+  // narrow layout. Doing it in CSS keeps 560px out of the JavaScript, where it
+  // would be a second copy of the breakpoint that tokens.css could not track.
+  const [open, setOpen] = useState(false);
+
+  return (
+    <section
+      aria-label="Advisor"
+      className={styles.panel}
+      data-testid="advisor-panel"
+      data-open={open ? 'true' : 'false'}
+      data-tone={tone}
+    >
+      <button
+        type="button"
+        className={styles.summary}
+        aria-expanded={open ? 'true' : 'false'}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className={styles.eyebrow}>ADVISOR</span>
+        <span className={styles.headline}>{headline}</span>
+        <ChevronDown size={15} className={styles.chevron} aria-hidden="true" />
+      </button>
+      <div className={styles.body}>{children}</div>
+    </section>
+  );
+}
+
+export const AdvisorPanel = React.memo(AdvisorPanelImpl);

--- a/src/ui/components/AdvisorPanel.jsx
+++ b/src/ui/components/AdvisorPanel.jsx
@@ -7,9 +7,14 @@
  * the responsive mechanics can be tested without fabricating advice objects.
  *
  * Reads no store. The store is one context and every consumer re-renders on
- * every dispatch, `LIVE_STEP` at 20Hz included, so this takes props and is
- * memoised — the panel re-renders when the selection or the advice changes and
- * not when the engine ticks.
+ * every dispatch, `LIVE_STEP` at 20Hz included, so this takes props rather than
+ * reading the store itself and is wrapped in `React.memo`. That memoisation
+ * does not currently stop a re-render on every tick — each screen constructs
+ * a fresh `<TuneAdvisory …>` element inline on every render, so the `children`
+ * prop is never referentially equal and the shallow comparison never hits.
+ * `React.memo` and the prop-only design are still the right call: they are
+ * what would make a future memoised `<TuneAdvisory>` element actually skip a
+ * re-render, and they keep this component ignorant of the store either way.
  */
 
 import React, { useState } from 'react';

--- a/src/ui/components/AdvisorPanel.module.css
+++ b/src/ui/components/AdvisorPanel.module.css
@@ -1,0 +1,97 @@
+/* AdvisorPanel: a right-hand rail at >=560px, a tap-to-open disclosure below
+   that. Chrome only — see the header comment in AdvisorPanel.jsx. */
+
+.panel {
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--advisor-accent);
+  border-radius: 10px;
+  background: var(--panel2);
+  padding: 12px 13px;
+}
+
+.summary {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-sm);
+  width: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.eyebrow {
+  font-size: 10px;
+  letter-spacing: 1px;
+  font-weight: 800;
+  color: var(--ink3);
+}
+
+.headline {
+  flex: 1;
+  font-size: var(--fs-sm);
+  color: var(--advisor-accent);
+}
+
+.chevron {
+  flex-shrink: 0;
+  color: var(--ink3);
+  transition: transform 0.15s ease;
+}
+
+[data-open='true'] .chevron {
+  transform: rotate(180deg);
+}
+
+.body {
+  display: none;
+  margin-top: var(--sp-md);
+  font-size: var(--fs-sm);
+  color: var(--ink2);
+  line-height: 1.55;
+}
+
+[data-open='true'] .body {
+  display: block;
+}
+
+[data-tone='danger'] {
+  --advisor-accent: var(--danger);
+}
+
+[data-tone='warn'] {
+  --advisor-accent: var(--warn);
+}
+
+[data-tone='ok'] {
+  --advisor-accent: var(--ok);
+}
+
+[data-tone='info'] {
+  --advisor-accent: var(--cyan);
+}
+
+/* 560px is the project's one breakpoint — see the note beside the scale in
+   tokens.css, which lists every file that uses it. Kept in sync by hand with
+   StartScreen.module.css, TutorialScreen.module.css and AppShell.module.css. */
+@media (min-width: 560px) {
+  .panel {
+    position: sticky;
+    top: var(--sp-xl);
+  }
+
+  .summary {
+    pointer-events: none;
+  }
+
+  .chevron {
+    display: none;
+  }
+
+  .body {
+    display: block;
+  }
+}

--- a/src/ui/components/AdvisorPanel.module.css
+++ b/src/ui/components/AdvisorPanel.module.css
@@ -2,6 +2,7 @@
    that. Chrome only — see the header comment in AdvisorPanel.jsx. */
 
 .panel {
+  --advisor-accent: var(--ink2);
   border: 1px solid var(--line);
   border-left: 3px solid var(--advisor-accent);
   border-radius: 10px;
@@ -9,18 +10,27 @@
   padding: 12px 13px;
 }
 
-.summary {
+.head {
+  position: relative;
   display: flex;
   align-items: center;
   gap: var(--sp-sm);
   width: 100%;
+}
+
+.toggle {
+  position: absolute;
+  inset: 0;
+  width: 100%;
   padding: 0;
   border: none;
   background: none;
-  font: inherit;
-  color: inherit;
-  text-align: left;
   cursor: pointer;
+}
+
+.toggle:focus-visible {
+  outline: 2px solid var(--acc);
+  outline-offset: 2px;
 }
 
 .eyebrow {
@@ -42,7 +52,7 @@
   transition: transform 0.15s ease;
 }
 
-[data-open='true'] .chevron {
+.panel[data-open='true'] .chevron {
   transform: rotate(180deg);
 }
 
@@ -54,23 +64,23 @@
   line-height: 1.55;
 }
 
-[data-open='true'] .body {
+.panel[data-open='true'] .body {
   display: block;
 }
 
-[data-tone='danger'] {
+.panel[data-tone='danger'] {
   --advisor-accent: var(--danger);
 }
 
-[data-tone='warn'] {
+.panel[data-tone='warn'] {
   --advisor-accent: var(--warn);
 }
 
-[data-tone='ok'] {
+.panel[data-tone='ok'] {
   --advisor-accent: var(--ok);
 }
 
-[data-tone='info'] {
+.panel[data-tone='info'] {
   --advisor-accent: var(--cyan);
 }
 
@@ -83,8 +93,8 @@
     top: var(--sp-xl);
   }
 
-  .summary {
-    pointer-events: none;
+  .toggle {
+    display: none;
   }
 
   .chevron {

--- a/src/ui/components/README.md
+++ b/src/ui/components/README.md
@@ -21,13 +21,14 @@ reads it to tell an open section from a collapsed one, which is how the fully-co
 route state is pinned.
 
 `PickList` is here for the ordinary reason, not the disclosure one: BUILD's Forced
-Induction screen and TUNE's ECU screen both need a full-width descriptive row for a
+Induction screen and TUNE's Injectors screen both need a full-width descriptive row for a
 choice with a subtitle (turbine housing, injector size), which is wider than `Seg`'s
 chip layout can hold without wrapping. One screen owning it and the other importing
 across tabs would be a cycle risk the moment either screen moves again.
 
 `TuningGrid` and `SelectionDock` are the same ordinary reason as `PickList`: TUNE's
-AIR, SPARK and FUEL screens each mount both, and TUNE's own ECU screen needs neither
+AIRFLOW, SPARK and FUEL screens each mount both, and TUNE's Injectors and Sensors
+screens need neither
 — so they belong to the tab as a whole rather than to any one screen inside it. Both
 still carry the `data-testid`s (`tuning-grid`, `selection-dock`) that
 `button-call-sites.test.jsx` and `characterisation.test.jsx` query, unchanged by the

--- a/src/ui/components/README.md
+++ b/src/ui/components/README.md
@@ -32,3 +32,12 @@ AIR, SPARK and FUEL screens each mount both, and TUNE's own ECU screen needs nei
 still carry the `data-testid`s (`tuning-grid`, `selection-dock`) that
 `button-call-sites.test.jsx` and `characterisation.test.jsx` query, unchanged by the
 move.
+
+`TuneAdvisory` is the ordinary reason once more, one layer up: `AdvisorPanel` is chrome
+only (see its own header comment) and `advisorReports.js` only classifies, so something
+has to turn a report into prose, and SPARK, FUEL and AIRFLOW all need one. `kind` picks
+the body; `report.state` (from `sparkReport`/`fuelReport`/`veReport` in
+`advisorReports.js`) picks which of that body's cases renders, and `report.detail`
+supplies the numbers. It is pure — no store access, no computation — so the screens stay
+the only thing in TUNE that talks to the store, and `advisorReports.js` stays the only
+thing that decides what a cell's category means.

--- a/src/ui/components/TuneAdvisory.jsx
+++ b/src/ui/components/TuneAdvisory.jsx
@@ -16,6 +16,9 @@
 
 import React from 'react';
 
+import { Button } from '../primitives/Button.jsx';
+
+import veStyles from '../screens/tune/AirflowScreen.module.css';
 import styles from './TuneAdvisory.module.css';
 
 /** @typedef {import('./advisorReports.js').AdvisorReport} AdvisorReport */
@@ -24,13 +27,13 @@ import styles from './TuneAdvisory.module.css';
  * @param {object} props
  * @param {'ve'|'timing'|'afr'} props.kind
  * @param {AdvisorReport} props.report
- * @param {() => void} [props.onAcceptVe] only read by the `'ve'` kind (Task 6)
+ * @param {() => void} [props.onAcceptVe] only read by the `'ve'` kind
  * @returns {React.ReactElement|null}
  */
-// eslint-disable-next-line no-unused-vars -- onAcceptVe is part of the interface Tasks 5/6 extend; the 've' kind lands in Task 6.
 export function TuneAdvisory({ kind, report, onAcceptVe }) {
   if (kind === 'timing') return <TimingAdvisory report={report} />;
   if (kind === 'afr') return <AfrAdvisory report={report} />;
+  if (kind === 've') return <VeAdvisory report={report} onAcceptVe={onAcceptVe} />;
   return null;
 }
 
@@ -232,6 +235,74 @@ function AfrAdvisory({ report }) {
       return <div className={styles.prose}>Select a single cell to see its numbers.</div>;
     case 'group-clean':
       return <div className={`${styles.prose} ${styles.ok}`}>Select a single cell to see its numbers.</div>;
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * @param {object} props
+ * @param {AdvisorReport} props.report
+ * @param {() => void} [props.onAcceptVe]
+ * @returns {React.ReactElement|null}
+ */
+function VeAdvisory({ report, onAcceptVe }) {
+  const { state, detail } = report;
+
+  switch (state) {
+    // Table-wide, verbatim from the old `.inSyncBanner` text — the bordered/
+    // tinted flex box and its Info icon do NOT come along, same reasoning as
+    // every other table-wide state in this file: the panel already renders and
+    // colours that surface from `report.tone`.
+    case 'table-sync':
+      return <div className={`${styles.prose} ${styles.ok}`}>VE table matches your current hardware. Nothing to correct.</div>;
+    // Table-wide, verbatim from the old `.staleBanner` body — its `.staleHead`
+    // (the "VE OUT OF SYNC WITH HARDWARE" label plus the max-gap figure) does
+    // NOT come along either: both numbers are already folded into
+    // `report.headline`, the same move SPARK's `.dangerLabel` and FUEL's
+    // `.label` made.
+    case 'table-stale':
+      return (
+        <>
+          <div className={veStyles.staleBody}>
+            Your hardware changed but this table is still the old log. Here is what re-logging airflow on the dyno would actually show:
+          </div>
+          {detail.recs.map((r, i) => (
+            <div key={i} className={veStyles.rec}>
+              <div className={veStyles.recTitle}>{r.rpmText}</div>
+              <div className={veStyles.recText}>{r.text}</div>
+              <div className={veStyles.recCells}>{r.cells.join('   ')}</div>
+            </div>
+          ))}
+          {/* Was width:100%. It is the only action in this advisory box and
+              reads as one at its own width; the box is already the full
+              content column, so stretching it only made it wider. */}
+          <Button onClick={onAcceptVe} style={{ marginTop: 4 }}>
+            ACCEPT RE-LOGGED VALUES
+          </Button>
+          <div className={veStyles.acceptNote}>Or type them in yourself — these are the measured targets, not a suggestion.</div>
+        </>
+      );
+
+    // A single cell or column. Neither state existed before the panel —
+    // AirflowScreen never narrowed to a selection — so there is no old markup
+    // to preserve. `veRecommendations` only measures at wide-open throttle, one
+    // gap per RPM column, so both states report the SAME number (the column's)
+    // and say plainly that it is the column's, never inventing a per-cell one.
+    case 'cell-gap':
+    case 'col-gap':
+      return (
+        <div className={styles.prose}>
+          <div className={styles.bannerCell}>{detail.rpm} RPM: {detail.from}% &rarr; {detail.to}%</div>
+          Measured at wide-open throttle. This gap belongs to the RPM column, not to this one cell.
+        </div>
+      );
+
+    // No shell comparison at all for this build (`veAdvice` is `null`) — keep
+    // the panel mounted rather than throwing or rendering nothing.
+    case 'no-advice':
+      return <div className={styles.prose}>No airflow comparison available for this build yet.</div>;
 
     default:
       return null;

--- a/src/ui/components/TuneAdvisory.jsx
+++ b/src/ui/components/TuneAdvisory.jsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 
-import styles from '../screens/tune/SparkScreen.module.css';
+import styles from './TuneAdvisory.module.css';
 
 /** @typedef {import('./advisorReports.js').AdvisorReport} AdvisorReport */
 
@@ -43,8 +43,8 @@ export function TuneAdvisory({ kind, report, onAcceptVe }) {
 function CellStats({ cell }) {
   return (
     <>
-      <div className={styles.dangerCell}>{cell.map} kPa / {cell.rpm} RPM</div>
-      <dl>
+      <div className={styles.bannerCell}>{cell.map} kPa / {cell.rpm} RPM</div>
+      <dl className={styles.cellStats}>
         <dt>Your value</dt><dd>{cell.current}°</dd>
         <dt>Knock limit</dt><dd>{cell.knockCeiling}°</dd>
         <dt>MBT</dt><dd>{cell.mbt}°</dd>
@@ -70,67 +70,67 @@ function TimingAdvisory({ report }) {
     case 'table-over':
       return (
         <>
-          <div className={styles.dangerBody}>
+          <div className={styles.bannerBody}>
             Your current hardware will not tolerate this much advance here. These cells are asking for more timing than the charge, octane and compression allow:
           </div>
           {detail.cells.map((c, i) => (
-            <div key={i} className={styles.dangerCell}>
+            <div key={i} className={styles.bannerCell}>
               {c.map} kPa / {c.rpm} RPM: {c.current}° → {c.suggested}°
             </div>
           ))}
-          {detail.more > 0 && <div className={styles.dangerMore}>…and {detail.more} more</div>}
-          <div className={styles.dangerFooter}>Edit them yourself — a calibration is yours to make, not something the app should silently rewrite.</div>
+          {detail.more > 0 && <div className={styles.bannerMore}>…and {detail.more} more</div>}
+          <div className={styles.bannerFooter}>Edit them yourself — a calibration is yours to make, not something the app should silently rewrite.</div>
         </>
       );
     case 'table-under':
       return (
-        <div className={styles.advisoryPanel}>
+        <div className={styles.prose}>
           <b className={styles.em}>Timing left on the table.</b> {detail.count} cells are more than 3° below what this build would tolerate. Safe, but you are giving away torque — advance them a little at a time and pull between each change.
         </div>
       );
     case 'table-past-mbt':
       return (
-        <div className={styles.advisoryPanel}>
+        <div className={styles.prose}>
           <b className={styles.em}>Past peak torque.</b> {detail.count} cells command more advance than the burn can use — the charge is already finishing where it should, so the extra degrees are working against the piston on its way up rather than adding torque. Not dangerous here — these cells are inside the knock limit — but pulling them back gains a little power and buys margin.
         </div>
       );
     case 'table-clean':
-      return <div className={styles.advisoryPanel}>Spark table sits within the knock limit for this hardware.</div>;
+      return <div className={styles.prose}>Spark table sits within the knock limit for this hardware.</div>;
 
     // A single selected cell. These states did not exist before the panel —
     // `SparkScreen` never narrowed to a selection — so there is no old markup
     // to preserve; the wording below is the brief's, verbatim.
     case 'cell-over':
       return (
-        <div className={styles.advisoryPanel}>
+        <div className={styles.prose}>
           <CellStats cell={detail.cell} />
           Past the knock limit the engine is damaging itself. Pull this cell back to the suggested value, or lower.
         </div>
       );
     case 'cell-past-mbt':
       return (
-        <div className={styles.advisoryPanel}>
+        <div className={styles.prose}>
           <CellStats cell={detail.cell} />
           The burn already lands where it should, so the extra degrees are pushing against the piston on the way up rather than making torque. Not dangerous — this cell is inside the knock limit — but pulling it back gains a little power and buys margin.
         </div>
       );
     case 'cell-under':
       return (
-        <div className={styles.advisoryPanel}>
+        <div className={styles.prose}>
           <CellStats cell={detail.cell} />
           This cell is leaving advance on the table. Add it a degree at a time and run a pull between each change.
         </div>
       );
     case 'cell-ok':
       return (
-        <div className={styles.advisoryPanel}>
+        <div className={styles.prose}>
           <CellStats cell={detail.cell} />
           Inside both the knock limit and MBT. Nothing to correct here.
         </div>
       );
     case 'cell-unreachable':
       return (
-        <div className={styles.advisoryPanel}>
+        <div className={styles.prose}>
           This build never reaches this manifold pressure at this engine speed, so the advisor has nothing to say about the cell. It is still yours to edit — it just will not be used.
         </div>
       );
@@ -141,7 +141,7 @@ function TimingAdvisory({ report }) {
     case 'group-past-mbt':
     case 'group-under':
     case 'group-clean':
-      return <div className={styles.advisoryPanel}>Select a single cell to see its numbers.</div>;
+      return <div className={styles.prose}>Select a single cell to see its numbers.</div>;
 
     default:
       return null;

--- a/src/ui/components/TuneAdvisory.jsx
+++ b/src/ui/components/TuneAdvisory.jsx
@@ -95,7 +95,7 @@ function TimingAdvisory({ report }) {
         </div>
       );
     case 'table-clean':
-      return <div className={styles.prose}>Spark table sits within the knock limit for this hardware.</div>;
+      return <div className={`${styles.prose} ${styles.ok}`}>Spark table sits within the knock limit for this hardware.</div>;
 
     // A single selected cell. These states did not exist before the panel —
     // `SparkScreen` never narrowed to a selection — so there is no old markup
@@ -123,7 +123,7 @@ function TimingAdvisory({ report }) {
       );
     case 'cell-ok':
       return (
-        <div className={styles.prose}>
+        <div className={`${styles.prose} ${styles.ok}`}>
           <CellStats cell={detail.cell} />
           Inside both the knock limit and MBT. Nothing to correct here.
         </div>
@@ -140,8 +140,9 @@ function TimingAdvisory({ report }) {
     case 'group-over':
     case 'group-past-mbt':
     case 'group-under':
-    case 'group-clean':
       return <div className={styles.prose}>Select a single cell to see its numbers.</div>;
+    case 'group-clean':
+      return <div className={`${styles.prose} ${styles.ok}`}>Select a single cell to see its numbers.</div>;
 
     default:
       return null;

--- a/src/ui/components/TuneAdvisory.jsx
+++ b/src/ui/components/TuneAdvisory.jsx
@@ -16,6 +16,7 @@
 
 import React from 'react';
 
+import fuelStyles from '../screens/tune/FuelScreen.module.css';
 import styles from './TuneAdvisory.module.css';
 
 /** @typedef {import('./advisorReports.js').AdvisorReport} AdvisorReport */
@@ -30,6 +31,7 @@ import styles from './TuneAdvisory.module.css';
 // eslint-disable-next-line no-unused-vars -- onAcceptVe is part of the interface Tasks 5/6 extend; the 've' kind lands in Task 6.
 export function TuneAdvisory({ kind, report, onAcceptVe }) {
   if (kind === 'timing') return <TimingAdvisory report={report} />;
+  if (kind === 'afr') return <AfrAdvisory report={report} />;
   return null;
 }
 
@@ -140,6 +142,94 @@ function TimingAdvisory({ report }) {
     case 'group-over':
     case 'group-past-mbt':
     case 'group-under':
+      return <div className={styles.prose}>Select a single cell to see its numbers.</div>;
+    case 'group-clean':
+      return <div className={`${styles.prose} ${styles.ok}`}>Select a single cell to see its numbers.</div>;
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * One AFR cell's coordinates and its commanded/suggested numbers, formatted
+ * exactly as `FuelScreen`'s old banner formatted a wrongMix row — `data-richen`
+ * stays on it, since `FuelScreen.module.css` colours the two directions
+ * differently and that distinction has to survive wherever this line appears.
+ * @param {object} props
+ * @param {object} props.cell a `fuelAdv` row from `calibrationAdvice`
+ * @returns {React.ReactElement}
+ */
+function AfrCellLine({ cell }) {
+  return (
+    <div className={fuelStyles.cell} data-richen={cell.delta < 0 ? 'true' : 'false'}>
+      {cell.map} kPa / {cell.rpm} RPM: {cell.current}:1 → {cell.suggested}:1 {cell.delta < 0 ? '(richen)' : '(lean out)'} · delivered {cell.delivered}, wants {cell.target}
+    </div>
+  );
+}
+
+/**
+ * @param {object} props
+ * @param {AdvisorReport} props.report
+ * @returns {React.ReactElement|null}
+ */
+function AfrAdvisory({ report }) {
+  const { state, detail } = report;
+
+  switch (state) {
+    // Table-wide. FuelScreen's old banner, moved here verbatim — the outer
+    // bordered/tinted box and the "N HIGH-LOAD CELLS..." label do NOT come
+    // along, same as SPARK: the panel already renders that surface from
+    // `report.tone` and shows the label's content as `report.headline`.
+    case 'table-off':
+      return (
+        <>
+          <div className={fuelStyles.body}>
+            Best-power mixture shifts with boost — richer as cylinder pressure rises. These cells are judged on what the engine actually <b className={fuelStyles.em}>delivered</b>, not on what the table commanded: if your MAF or injector scaling is off, the two are not the same number, and the delivered one is the one the pistons feel. The suggestion is the value to type into the cell to land on target.
+          </div>
+          {detail.cells.map((c, i) => <AfrCellLine key={i} cell={c} />)}
+          {detail.more > 0 && <div className={fuelStyles.more}>…and {detail.more} more</div>}
+        </>
+      );
+    // FUEL had no clean state at all — the old banner simply did not render
+    // when wrongMix was empty. The panel always renders something, so this is
+    // genuinely new prose, not a moved state.
+    case 'table-clean':
+      return <div className={`${styles.prose} ${styles.ok}`}>AFR table sits on best power at every high-load cell for this hardware.</div>;
+
+    // A single selected cell. None of these states existed before the panel —
+    // FuelScreen never narrowed to a selection — so there is no old markup to
+    // preserve.
+    case 'cell-off':
+      return (
+        <div className={styles.prose}>
+          <AfrCellLine cell={detail.cell} />
+          Best-power mixture shifts with boost, and this cell is judged on what the engine actually delivered, not on what the table commanded. Type the suggested value into the cell to land on target.
+        </div>
+      );
+    case 'cell-closed-loop':
+      return (
+        <div className={styles.prose}>
+          Below open-loop boost the ECU targets stoichiometric and the fuel trims correct any error live. Best-power mixture advice does not apply here — this cell belongs to the trims, not this table.
+        </div>
+      );
+    case 'cell-ok':
+      return (
+        <div className={`${styles.prose} ${styles.ok}`}>
+          <div className={styles.bannerCell}>{detail.cell.map} kPa / {detail.cell.rpm} RPM: {detail.cell.current}:1</div>
+          Delivered mixture lands on the best-power target here. Nothing to correct.
+        </div>
+      );
+    case 'cell-unreachable':
+      return (
+        <div className={styles.prose}>
+          This build never reaches this manifold pressure at this engine speed, so the advisor has nothing to say about the cell. It is still yours to edit — it just will not be used.
+        </div>
+      );
+
+    // A selected row or column. Only one category applies to FUEL, unlike
+    // SPARK's three, so the body just points at the fix.
+    case 'group-off':
       return <div className={styles.prose}>Select a single cell to see its numbers.</div>;
     case 'group-clean':
       return <div className={`${styles.prose} ${styles.ok}`}>Select a single cell to see its numbers.</div>;

--- a/src/ui/components/TuneAdvisory.jsx
+++ b/src/ui/components/TuneAdvisory.jsx
@@ -18,7 +18,6 @@ import React from 'react';
 
 import { Button } from '../primitives/Button.jsx';
 
-import veStyles from '../screens/tune/AirflowScreen.module.css';
 import styles from './TuneAdvisory.module.css';
 
 /** @typedef {import('./advisorReports.js').AdvisorReport} AdvisorReport */
@@ -265,14 +264,14 @@ function VeAdvisory({ report, onAcceptVe }) {
     case 'table-stale':
       return (
         <>
-          <div className={veStyles.staleBody}>
+          <div className={styles.staleBody}>
             Your hardware changed but this table is still the old log. Here is what re-logging airflow on the dyno would actually show:
           </div>
           {detail.recs.map((r, i) => (
-            <div key={i} className={veStyles.rec}>
-              <div className={veStyles.recTitle}>{r.rpmText}</div>
-              <div className={veStyles.recText}>{r.text}</div>
-              <div className={veStyles.recCells}>{r.cells.join('   ')}</div>
+            <div key={i} className={styles.rec}>
+              <div className={styles.recTitle}>{r.rpmText}</div>
+              <div className={styles.recText}>{r.text}</div>
+              <div className={styles.recCells}>{r.cells.join('   ')}</div>
             </div>
           ))}
           {/* Was width:100%. It is the only action in this advisory box and
@@ -281,7 +280,7 @@ function VeAdvisory({ report, onAcceptVe }) {
           <Button onClick={onAcceptVe} style={{ marginTop: 4 }}>
             ACCEPT RE-LOGGED VALUES
           </Button>
-          <div className={veStyles.acceptNote}>Or type them in yourself — these are the measured targets, not a suggestion.</div>
+          <div className={styles.acceptNote}>Or type them in yourself — these are the measured targets, not a suggestion.</div>
         </>
       );
 

--- a/src/ui/components/TuneAdvisory.jsx
+++ b/src/ui/components/TuneAdvisory.jsx
@@ -1,0 +1,149 @@
+/**
+ * TUNE's advisor panel body: turns an `AdvisorReport` (`advisorReports.js`)
+ * into prose.
+ *
+ * Pure by design — no store access, no computation of its own. `report.state`
+ * picks which body renders and `report.detail` supplies the numbers that go
+ * in it; every classification decision already happened in `advisorReports.js`
+ * (which itself only reads what the sim's advisors concluded — see that
+ * file's header for why re-deriving a category here would be a bug, not a
+ * convenience).
+ *
+ * `kind` distinguishes the three grid screens sharing this component: SPARK
+ * (`'timing'`, this task), FUEL (`'afr'`) and AIRFLOW (`'ve'`), the latter two
+ * arriving in Tasks 5 and 6.
+ */
+
+import React from 'react';
+
+import styles from '../screens/tune/SparkScreen.module.css';
+
+/** @typedef {import('./advisorReports.js').AdvisorReport} AdvisorReport */
+
+/**
+ * @param {object} props
+ * @param {'ve'|'timing'|'afr'} props.kind
+ * @param {AdvisorReport} props.report
+ * @param {() => void} [props.onAcceptVe] only read by the `'ve'` kind (Task 6)
+ * @returns {React.ReactElement|null}
+ */
+// eslint-disable-next-line no-unused-vars -- onAcceptVe is part of the interface Tasks 5/6 extend; the 've' kind lands in Task 6.
+export function TuneAdvisory({ kind, report, onAcceptVe }) {
+  if (kind === 'timing') return <TimingAdvisory report={report} />;
+  return null;
+}
+
+/**
+ * The cell's coordinates and its four numbers, as a small definition list.
+ * Shared by every `cell-*` state below.
+ * @param {object} props
+ * @param {object} props.cell a `spark` row from `calibrationAdvice`
+ * @returns {React.ReactElement}
+ */
+function CellStats({ cell }) {
+  return (
+    <>
+      <div className={styles.dangerCell}>{cell.map} kPa / {cell.rpm} RPM</div>
+      <dl>
+        <dt>Your value</dt><dd>{cell.current}°</dd>
+        <dt>Knock limit</dt><dd>{cell.knockCeiling}°</dd>
+        <dt>MBT</dt><dd>{cell.mbt}°</dd>
+        <dt>Suggested</dt><dd>{cell.suggested}°</dd>
+      </dl>
+    </>
+  );
+}
+
+/**
+ * @param {object} props
+ * @param {AdvisorReport} props.report
+ * @returns {React.ReactElement|null}
+ */
+function TimingAdvisory({ report }) {
+  const { state, detail } = report;
+
+  switch (state) {
+    // Table-wide, mutually exclusive — the same four states SparkScreen used
+    // to fall through to, moved here verbatim. The outer bordered/tinted box
+    // does NOT come along: the panel already renders and colours that surface
+    // from `report.tone`, so nesting a second one here would double it up.
+    case 'table-over':
+      return (
+        <>
+          <div className={styles.dangerBody}>
+            Your current hardware will not tolerate this much advance here. These cells are asking for more timing than the charge, octane and compression allow:
+          </div>
+          {detail.cells.map((c, i) => (
+            <div key={i} className={styles.dangerCell}>
+              {c.map} kPa / {c.rpm} RPM: {c.current}° → {c.suggested}°
+            </div>
+          ))}
+          {detail.more > 0 && <div className={styles.dangerMore}>…and {detail.more} more</div>}
+          <div className={styles.dangerFooter}>Edit them yourself — a calibration is yours to make, not something the app should silently rewrite.</div>
+        </>
+      );
+    case 'table-under':
+      return (
+        <div className={styles.advisoryPanel}>
+          <b className={styles.em}>Timing left on the table.</b> {detail.count} cells are more than 3° below what this build would tolerate. Safe, but you are giving away torque — advance them a little at a time and pull between each change.
+        </div>
+      );
+    case 'table-past-mbt':
+      return (
+        <div className={styles.advisoryPanel}>
+          <b className={styles.em}>Past peak torque.</b> {detail.count} cells command more advance than the burn can use — the charge is already finishing where it should, so the extra degrees are working against the piston on its way up rather than adding torque. Not dangerous here — these cells are inside the knock limit — but pulling them back gains a little power and buys margin.
+        </div>
+      );
+    case 'table-clean':
+      return <div className={styles.advisoryPanel}>Spark table sits within the knock limit for this hardware.</div>;
+
+    // A single selected cell. These states did not exist before the panel —
+    // `SparkScreen` never narrowed to a selection — so there is no old markup
+    // to preserve; the wording below is the brief's, verbatim.
+    case 'cell-over':
+      return (
+        <div className={styles.advisoryPanel}>
+          <CellStats cell={detail.cell} />
+          Past the knock limit the engine is damaging itself. Pull this cell back to the suggested value, or lower.
+        </div>
+      );
+    case 'cell-past-mbt':
+      return (
+        <div className={styles.advisoryPanel}>
+          <CellStats cell={detail.cell} />
+          The burn already lands where it should, so the extra degrees are pushing against the piston on the way up rather than making torque. Not dangerous — this cell is inside the knock limit — but pulling it back gains a little power and buys margin.
+        </div>
+      );
+    case 'cell-under':
+      return (
+        <div className={styles.advisoryPanel}>
+          <CellStats cell={detail.cell} />
+          This cell is leaving advance on the table. Add it a degree at a time and run a pull between each change.
+        </div>
+      );
+    case 'cell-ok':
+      return (
+        <div className={styles.advisoryPanel}>
+          <CellStats cell={detail.cell} />
+          Inside both the knock limit and MBT. Nothing to correct here.
+        </div>
+      );
+    case 'cell-unreachable':
+      return (
+        <div className={styles.advisoryPanel}>
+          This build never reaches this manifold pressure at this engine speed, so the advisor has nothing to say about the cell. It is still yours to edit — it just will not be used.
+        </div>
+      );
+
+    // A selected row or column. Severity already picked the tone and headline
+    // (Task 3); the body just points at the fix.
+    case 'group-over':
+    case 'group-past-mbt':
+    case 'group-under':
+    case 'group-clean':
+      return <div className={styles.advisoryPanel}>Select a single cell to see its numbers.</div>;
+
+    default:
+      return null;
+  }
+}

--- a/src/ui/components/TuneAdvisory.jsx
+++ b/src/ui/components/TuneAdvisory.jsx
@@ -10,8 +10,7 @@
  * convenience).
  *
  * `kind` distinguishes the three grid screens sharing this component: SPARK
- * (`'timing'`, this task), FUEL (`'afr'`) and AIRFLOW (`'ve'`), the latter two
- * arriving in Tasks 5 and 6.
+ * (`'timing'`), FUEL (`'afr'`) and AIRFLOW (`'ve'`).
  */
 
 import React from 'react';
@@ -38,7 +37,9 @@ export function TuneAdvisory({ kind, report, onAcceptVe }) {
 
 /**
  * The cell's coordinates and its four numbers, as a small definition list.
- * Shared by every `cell-*` state below.
+ * Shared by the four timing states below (`cell-over`, `cell-past-mbt`,
+ * `cell-under`, `cell-ok`) — AFR's `cell-ok` hand-rolls its own line instead,
+ * since a fuel cell has no knock ceiling or MBT to show.
  * @param {object} props
  * @param {object} props.cell a `spark` row from `calibrationAdvice`
  * @returns {React.ReactElement}
@@ -155,7 +156,7 @@ function TimingAdvisory({ report }) {
 /**
  * One AFR cell's coordinates and its commanded/suggested numbers, formatted
  * exactly as `FuelScreen`'s old banner formatted a wrongMix row — `data-richen`
- * stays on it, since `FuelScreen.module.css` colours the two directions
+ * stays on it, since `TuneAdvisory.module.css:24` colours the two directions
  * differently and that distinction has to survive wherever this line appears.
  * @param {object} props
  * @param {object} props.cell a `fuelAdv` row from `calibrationAdvice`
@@ -295,6 +296,32 @@ function VeAdvisory({ report, onAcceptVe }) {
         <div className={styles.prose}>
           <div className={styles.bannerCell}>{detail.rpm} RPM: {detail.from}% &rarr; {detail.to}%</div>
           Measured at wide-open throttle. This gap belongs to the RPM column, not to this one cell.
+        </div>
+      );
+    // The below-threshold counterpart to cell-gap/col-gap — the column's gap
+    // is smaller than `VE_NOTABLE_PCT`, the same cutoff `veRecommendations`
+    // itself uses to decide a column is not worth flagging, so this reads as
+    // an all-clear rather than a muted warning.
+    case 'cell-sync':
+    case 'col-sync':
+      return (
+        <div className={`${styles.prose} ${styles.ok}`}>
+          <div className={styles.bannerCell}>{detail.rpm} RPM: {detail.from}% &rarr; {detail.to}%</div>
+          Measured at wide-open throttle. This column matches your hardware.
+        </div>
+      );
+
+    // A selected row. `veRecommendations` reports one gap per RPM column, never
+    // per row, so there is no row-scoped number to narrow to — unlike SPARK and
+    // FUEL's `group-*` states, which count flagged cells inside the band. This
+    // deliberately does NOT fall through to `table-stale`: that body carries
+    // the ACCEPT RE-LOGGED VALUES button, which writes every row in the table,
+    // and a player who selected one row must never be shown a button that
+    // silently overwrites the other five.
+    case 'group-ve':
+      return (
+        <div className={styles.prose}>
+          VE is measured per RPM column, at wide-open throttle — a row has no gap of its own to report. Select a column header, or a single cell, to see the gap for that RPM.
         </div>
       );
 

--- a/src/ui/components/TuneAdvisory.jsx
+++ b/src/ui/components/TuneAdvisory.jsx
@@ -16,7 +16,6 @@
 
 import React from 'react';
 
-import fuelStyles from '../screens/tune/FuelScreen.module.css';
 import styles from './TuneAdvisory.module.css';
 
 /** @typedef {import('./advisorReports.js').AdvisorReport} AdvisorReport */
@@ -162,7 +161,7 @@ function TimingAdvisory({ report }) {
  */
 function AfrCellLine({ cell }) {
   return (
-    <div className={fuelStyles.cell} data-richen={cell.delta < 0 ? 'true' : 'false'}>
+    <div className={styles.bannerCell} data-richen={cell.delta < 0 ? 'true' : 'false'}>
       {cell.map} kPa / {cell.rpm} RPM: {cell.current}:1 → {cell.suggested}:1 {cell.delta < 0 ? '(richen)' : '(lean out)'} · delivered {cell.delivered}, wants {cell.target}
     </div>
   );
@@ -184,11 +183,11 @@ function AfrAdvisory({ report }) {
     case 'table-off':
       return (
         <>
-          <div className={fuelStyles.body}>
-            Best-power mixture shifts with boost — richer as cylinder pressure rises. These cells are judged on what the engine actually <b className={fuelStyles.em}>delivered</b>, not on what the table commanded: if your MAF or injector scaling is off, the two are not the same number, and the delivered one is the one the pistons feel. The suggestion is the value to type into the cell to land on target.
+          <div className={styles.bannerBody}>
+            Best-power mixture shifts with boost — richer as cylinder pressure rises. These cells are judged on what the engine actually <b className={styles.emInk}>delivered</b>, not on what the table commanded: if your MAF or injector scaling is off, the two are not the same number, and the delivered one is the one the pistons feel. The suggestion is the value to type into the cell to land on target.
           </div>
           {detail.cells.map((c, i) => <AfrCellLine key={i} cell={c} />)}
-          {detail.more > 0 && <div className={fuelStyles.more}>…and {detail.more} more</div>}
+          {detail.more > 0 && <div className={styles.bannerMore}>…and {detail.more} more</div>}
         </>
       );
     // FUEL had no clean state at all — the old banner simply did not render

--- a/src/ui/components/TuneAdvisory.module.css
+++ b/src/ui/components/TuneAdvisory.module.css
@@ -1,0 +1,49 @@
+/* TuneAdvisory: prose bodies for the advisor panel's per-state reports.
+   No border, no background, no radius here — AdvisorPanel.module.css already
+   renders and colours that surface from `data-tone`; nesting a second bordered
+   box inside it would double up the chrome the old per-screen banners used to
+   own on their own. */
+
+.bannerBody {
+  margin-bottom: 8px;
+}
+
+.bannerCell {
+  margin-bottom: 2px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--cyan);
+}
+
+.bannerMore {
+  margin-top: 3px;
+  font-size: var(--fs-xs);
+  color: var(--ink3);
+}
+
+.bannerFooter {
+  margin-top: 8px;
+  font-size: 11px;
+  color: var(--ink3);
+}
+
+/* AdvisorPanel's own .body already sets the base font-size/colour/line-height
+   every state here inherits; this class only carries the vertical rhythm
+   between states, matching the old .advisoryPanel's margin. */
+.prose {
+  margin: 0;
+}
+
+.em { color: var(--acc-ink); }
+
+.cellStats {
+  margin: 6px 0 8px;
+  display: grid;
+  grid-template-columns: auto auto;
+  column-gap: var(--sp-sm);
+  row-gap: 2px;
+  font-size: var(--fs-sm);
+}
+
+.cellStats dt { color: var(--ink3); }
+.cellStats dd { margin: 0; color: var(--ink); font-family: var(--mono); }

--- a/src/ui/components/TuneAdvisory.module.css
+++ b/src/ui/components/TuneAdvisory.module.css
@@ -36,6 +36,18 @@
 
 .em { color: var(--acc-ink); }
 
+/* All-clear tint, layered onto `.prose` (never replacing it — margin still
+   comes from there). `table-clean` restores the green the old `.okBanner`
+   carried before this state moved into the panel and lost its colour by
+   inheriting `.body`'s neutral `--ink2` instead.
+   `cell-ok` and `group-clean` are new states this PR introduced with no prior
+   styling to restore — but they are also all-clear tone='ok' states, and it
+   would read as a bug for a player to see a green all-clear on the whole
+   table yet a gray one on the single cell or row/column they just selected.
+   So all three share this class rather than only the one with history. Do not
+   split them back apart without re-litigating that. */
+.ok { color: var(--ok); }
+
 .cellStats {
   margin: 6px 0 8px;
   display: grid;

--- a/src/ui/components/TuneAdvisory.module.css
+++ b/src/ui/components/TuneAdvisory.module.css
@@ -15,6 +15,14 @@
   color: var(--cyan);
 }
 
+/* FUEL's two mixture directions, coloured differently — carried over from
+   FuelScreen.module.css's `.cell[data-richen='true']`. Richen (this cell is
+   lean) is the dangerous direction; lean-out is an ordinary cyan readout, so
+   only 'true' gets a rule. Scoped to .bannerCell so it only ever applies to
+   the AFR cell lines that carry the attribute — SPARK's cell lines never set
+   data-richen at all. */
+.bannerCell[data-richen='true'] { color: var(--danger-ink); }
+
 .bannerMore {
   margin-top: 3px;
   font-size: var(--fs-xs);
@@ -35,6 +43,13 @@
 }
 
 .em { color: var(--acc-ink); }
+
+/* A second emphasis token, not a duplicate of `.em`: SPARK's moved banners
+   used var(--acc-ink) for emphasis, but FuelScreen.module.css's own `.em`
+   (used by the mixture banner's <b>delivered</b>) was var(--ink) — a
+   different colour. Reusing `.em` here would have silently recoloured that
+   emphasis on the move; this class preserves the token it actually carried. */
+.emInk { color: var(--ink); }
 
 /* All-clear tint, layered onto `.prose` (never replacing it — margin still
    comes from there). `table-clean` restores the green the old `.okBanner`

--- a/src/ui/components/TuneAdvisory.module.css
+++ b/src/ui/components/TuneAdvisory.module.css
@@ -74,3 +74,44 @@
 
 .cellStats dt { color: var(--ink3); }
 .cellStats dd { margin: 0; color: var(--ink); font-family: var(--mono); }
+
+/* AIRFLOW's stale-VE recommendations, carried over unchanged from
+   AirflowScreen.module.css's own .staleBody/.rec/.recTitle/.recText/
+   .recCells/.acceptNote. None of these collide with an existing class here —
+   unlike .body/.em, which needed the .bannerBody/.emInk split in Tasks 4/5 —
+   so the names moved across verbatim. */
+.staleBody {
+  margin-bottom: 9px;
+  font-size: var(--fs-sm);
+  color: var(--ink2);
+  line-height: 1.55;
+}
+
+.rec { margin-bottom: 9px; }
+
+.recTitle {
+  font-size: var(--fs-sm);
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.recText {
+  margin-top: 2px;
+  font-size: 11.5px;
+  color: var(--ink2);
+  line-height: 1.5;
+}
+
+.recCells {
+  margin-top: 3px;
+  font-family: var(--mono);
+  font-size: var(--fs-xs);
+  color: var(--cyan);
+}
+
+.acceptNote {
+  margin-top: 6px;
+  font-size: var(--fs-xs);
+  color: var(--ink3);
+  text-align: center;
+}

--- a/src/ui/components/advisorReports.js
+++ b/src/ui/components/advisorReports.js
@@ -184,3 +184,63 @@ export function fuelReport(calAdvice, selection) {
   }
   return { tone: 'ok', headline: 'High-load mixture is on best power', state: 'table-clean', detail: {} };
 }
+
+/**
+ * @param {{inSync: boolean, recs: object[], deltas?: object[], maxAbs: number}|null} veAdvice
+ *   as returned by `veRecommendations`, or `null` — the shell has no VE comparison
+ *   to offer for every build (see `AirflowScreen`'s existing `{veAdvice && (…)}` guard).
+ *   `deltas` is optional only in the type — a `cell`/`col` selection reads it and
+ *   would throw if it were genuinely missing; the real shell's value always has it.
+ * @param {Selection|null} selection
+ * @returns {AdvisorReport}
+ */
+export function veReport(veAdvice, selection) {
+  if (!veAdvice) {
+    return { tone: 'info', headline: 'No airflow comparison available for this build yet.', state: 'no-advice', detail: {} };
+  }
+
+  // `veRecommendations` measures every delta at the wide-open-throttle row only
+  // (WOT_ROW, private to src/sim/advisors.js) — there is no per-cell VE gap to
+  // report, only one gap per RPM column. `deltas` is indexed by that column
+  // position directly (RPM.map's own index), the same index TuningGrid uses for
+  // its columns, so a `cell` or `col` selection can look the column up by
+  // `selection.col`. A `row` selection has nothing column-scoped to say — it
+  // falls through to the table-wide states below, same as no selection at all.
+  if (selection && (selection.type === 'cell' || selection.type === 'col')) {
+    const delta = veAdvice.deltas[selection.col];
+    const pct = delta.pct;
+    // Every category lookup elsewhere in this file is membership in an
+    // advisor-computed array (the ONE RULE, see the file header) — there is no
+    // such array here to look a column up in, only a continuous percentage, so
+    // this is the one place in the file allowed to threshold a number itself.
+    // 'ok' is reserved for a delta that would display as 0%; anything that
+    // would render "N% more/less air" with a nonzero N is worth a warn tone.
+    // Never 'danger': a VE mismatch by itself is not a hazard — it is the
+    // fuel/spark tables computed from it that would need correcting, and
+    // those are their own screens' job, not this one's.
+    const tone = Math.round(pct) === 0 ? 'ok' : 'warn';
+    // Math.abs, not a bare pct.toFixed(0): the plan's literal template keeps
+    // the sign, which would print "-15% less air" for a negative delta — a
+    // double negative that says the opposite of what it means. fuelReport's
+    // cell-off headline already established the fix for the same shape of bug
+    // (`Math.abs(cell.delta).toFixed(1)` paired with a direction word); this
+    // mirrors it rather than reproducing the sign twice.
+    return {
+      tone,
+      headline: `${Math.abs(pct).toFixed(0)}% ${pct > 0 ? 'more' : 'less'} air here than your table assumes`,
+      state: selection.type === 'cell' ? 'cell-gap' : 'col-gap',
+      detail: { rpm: delta.rpm, from: delta.from, to: delta.to, pct },
+    };
+  }
+
+  if (veAdvice.inSync) {
+    return { tone: 'ok', headline: 'VE matches your hardware', state: 'table-sync', detail: {} };
+  }
+
+  return {
+    tone: 'warn',
+    headline: `VE out of sync — ${veAdvice.maxAbs.toFixed(0)}% max gap`,
+    state: 'table-stale',
+    detail: { maxAbs: veAdvice.maxAbs, recs: veAdvice.recs },
+  };
+}

--- a/src/ui/components/advisorReports.js
+++ b/src/ui/components/advisorReports.js
@@ -80,23 +80,26 @@ export function sparkReport(calAdvice, selection) {
   }
 
   if (selection) {
-    // A row or column. Same precedence as the table-wide report, scoped to the band.
+    // A row or column. Danger first as always, then severity order — past MBT
+    // before under-advanced, the reverse of the table-wide fall-through below,
+    // and with no four-cell floor: the player picked this band deliberately, so
+    // one flagged cell in it is worth saying.
     const over = countIn(overAdvanced, selection);
     if (over > 0) {
       return {
         tone: 'danger',
-        headline: `${over} of these cells are past the knock limit`,
+        headline: `${over} of these cells ${over === 1 ? 'is' : 'are'} past the knock limit`,
         state: 'group-over',
         detail: { count: over },
       };
     }
-    const under = countIn(underAdvanced, selection);
     const past = countIn(pastMbt, selection);
     if (past > 0) {
-      return { tone: 'warn', headline: `${past} of these cells are past MBT`, state: 'group-past-mbt', detail: { count: past } };
+      return { tone: 'warn', headline: `${past} of these cells ${past === 1 ? 'is' : 'are'} past MBT`, state: 'group-past-mbt', detail: { count: past } };
     }
+    const under = countIn(underAdvanced, selection);
     if (under > 0) {
-      return { tone: 'warn', headline: `${under} of these cells have advance left`, state: 'group-under', detail: { count: under } };
+      return { tone: 'warn', headline: `${under} of these cells ${under === 1 ? 'has' : 'have'} advance left`, state: 'group-under', detail: { count: under } };
     }
     return { tone: 'ok', headline: 'Nothing flagged in this band', state: 'group-clean', detail: {} };
   }

--- a/src/ui/components/advisorReports.js
+++ b/src/ui/components/advisorReports.js
@@ -15,7 +15,7 @@
  * issue #34 removed.
  */
 
-import { OPEN_LOOP_KPA } from '../../sim/index.js';
+import { OPEN_LOOP_KPA, VE_NOTABLE_PCT } from '../../sim/index.js';
 
 /** @typedef {import('./TuningGrid.jsx').Selection} Selection */
 
@@ -189,8 +189,9 @@ export function fuelReport(calAdvice, selection) {
  * @param {{inSync: boolean, recs: object[], deltas?: object[], maxAbs: number}|null} veAdvice
  *   as returned by `veRecommendations`, or `null` — the shell has no VE comparison
  *   to offer for every build (see `AirflowScreen`'s existing `{veAdvice && (…)}` guard).
- *   `deltas` is optional only in the type — a `cell`/`col` selection reads it and
- *   would throw if it were genuinely missing; the real shell's value always has it.
+ *   `deltas` is optional in the type — a `cell`/`col` selection reads it with `?.`
+ *   and falls through to the table-wide states if it (or the selected column) is
+ *   genuinely missing; the real shell's value always has it.
  * @param {Selection|null} selection
  * @returns {AdvisorReport}
  */
@@ -204,32 +205,66 @@ export function veReport(veAdvice, selection) {
   // report, only one gap per RPM column. `deltas` is indexed by that column
   // position directly (RPM.map's own index), the same index TuningGrid uses for
   // its columns, so a `cell` or `col` selection can look the column up by
-  // `selection.col`. A `row` selection has nothing column-scoped to say — it
-  // falls through to the table-wide states below, same as no selection at all.
+  // `selection.col`. `deltas` is optional in the type (see the JSDoc above) —
+  // `?.` here means a shell that genuinely omitted it, or a selection past the
+  // end of the array, falls through to the table-wide states below rather than
+  // throwing.
   if (selection && (selection.type === 'cell' || selection.type === 'col')) {
-    const delta = veAdvice.deltas[selection.col];
-    const pct = delta.pct;
-    // Every category lookup elsewhere in this file is membership in an
-    // advisor-computed array (the ONE RULE, see the file header) — there is no
-    // such array here to look a column up in, only a continuous percentage, so
-    // this is the one place in the file allowed to threshold a number itself.
-    // 'ok' is reserved for a delta that would display as 0%; anything that
-    // would render "N% more/less air" with a nonzero N is worth a warn tone.
-    // Never 'danger': a VE mismatch by itself is not a hazard — it is the
-    // fuel/spark tables computed from it that would need correcting, and
-    // those are their own screens' job, not this one's.
-    const tone = Math.round(pct) === 0 ? 'ok' : 'warn';
-    // Math.abs, not a bare pct.toFixed(0): the plan's literal template keeps
-    // the sign, which would print "-15% less air" for a negative delta — a
-    // double negative that says the opposite of what it means. fuelReport's
-    // cell-off headline already established the fix for the same shape of bug
-    // (`Math.abs(cell.delta).toFixed(1)` paired with a direction word); this
-    // mirrors it rather than reproducing the sign twice.
+    const delta = veAdvice.deltas?.[selection.col];
+    if (delta) {
+      const pct = delta.pct;
+      // THE ONE RULE applies here too: `VE_NOTABLE_PCT` is `veRecommendations`'s
+      // own cutoff for whether a column's gap is worth reporting at all (it is
+      // the same number that decides whether the table-wide state below is
+      // 'table-sync' or 'table-stale'). Thresholding against a UI-invented
+      // number here — the fixed bug this comment used to describe — could put
+      // this branch and the table-wide one in a different mood about the same
+      // column: table-wide says nothing is wrong, then selecting the column
+      // that IS `inSync` prints a warning immediately below it.
+      // Never 'danger': a VE mismatch by itself is not a hazard — it is the
+      // fuel/spark tables computed from it that would need correcting, and
+      // those are their own screens' job, not this one's.
+      const isCell = selection.type === 'cell';
+      if (Math.abs(pct) >= VE_NOTABLE_PCT) {
+        // Math.abs, not a bare pct.toFixed(0): the plan's literal template
+        // keeps the sign, which would print "-15% less air" for a negative
+        // delta — a double negative that says the opposite of what it means.
+        // fuelReport's cell-off headline already established the fix for the
+        // same shape of bug (`Math.abs(cell.delta).toFixed(1)` paired with a
+        // direction word); this mirrors it rather than reproducing the sign
+        // twice. The RPM is named rather than "here": this headline is the
+        // only thing rendered below 560px, and "here" reads as the selected
+        // row when the number in fact belongs to the WOT row for this column.
+        return {
+          tone: 'warn',
+          headline: `${Math.abs(pct).toFixed(0)}% ${pct > 0 ? 'more' : 'less'} air at ${delta.rpm} RPM than your table assumes`,
+          state: isCell ? 'cell-gap' : 'col-gap',
+          detail: { rpm: delta.rpm, from: delta.from, to: delta.to, pct },
+        };
+      }
+      return {
+        tone: 'ok',
+        headline: `Matches your hardware at ${delta.rpm} RPM`,
+        state: isCell ? 'cell-sync' : 'col-sync',
+        detail: { rpm: delta.rpm, from: delta.from, to: delta.to, pct },
+      };
+    }
+    // No delta for this column — fall through to the table-wide states below.
+  }
+
+  // A row selection has nothing column-scoped to say — `veRecommendations`
+  // reports one gap per RPM column, never per row, so there is no per-row
+  // answer to narrow to. It falls through to `group-ve`, not to the
+  // table-wide states: the table-wide `table-stale` body carries the ACCEPT
+  // RE-LOGGED VALUES button, which writes every row, and a player who
+  // selected one row must not be shown a button that silently rewrites the
+  // other five.
+  if (selection && selection.type === 'row') {
     return {
-      tone,
-      headline: `${Math.abs(pct).toFixed(0)}% ${pct > 0 ? 'more' : 'less'} air here than your table assumes`,
-      state: selection.type === 'cell' ? 'cell-gap' : 'col-gap',
-      detail: { rpm: delta.rpm, from: delta.from, to: delta.to, pct },
+      tone: 'info',
+      headline: 'VE is measured per RPM column',
+      state: 'group-ve',
+      detail: {},
     };
   }
 

--- a/src/ui/components/advisorReports.js
+++ b/src/ui/components/advisorReports.js
@@ -1,0 +1,122 @@
+/**
+ * Advisor reports: what the simulation's advisors already concluded, narrowed to
+ * whatever the player currently has selected.
+ *
+ * These invent no analysis. `calibrationAdvice` and `veRecommendations` in
+ * `src/sim/advisors.js` decide what is wrong with a table; these functions only
+ * decide which part of that answer is relevant right now, and how to say it.
+ *
+ * THE ONE RULE: a cell's category is looked up in the advisor's own output
+ * arrays. It is never re-derived by comparing the cell against a threshold. The
+ * classification in `calibrationAdvice` is subtle on purpose — a cell past both
+ * ceilings with MBT the lower of the two is detonating, not merely wasteful, and
+ * getting that backwards tells a player a dangerous cell is safe. Asking the
+ * arrays cannot get it wrong. Recomputing can, and that is the false alarm
+ * issue #34 removed.
+ */
+
+/** @typedef {import('./TuningGrid.jsx').Selection} Selection */
+
+/**
+ * @typedef {object} AdvisorReport
+ * @property {'ok'|'warn'|'danger'|'info'} tone
+ * @property {string} headline plain text, shown on the collapsed summary at <560px
+ * @property {string} state which body the renderer should show
+ * @property {object} detail numbers and cell records the body needs
+ */
+
+/** English, not a template with a stray "1 cells" in it. */
+const plural = (n, word) => `${n} ${word}${n === 1 ? '' : 's'}`;
+
+/** Does this category contain the cell at (ri, ci)? */
+const holds = (arr, ri, ci) => arr.some((c) => c.ri === ri && c.ci === ci);
+
+/** How many of a category fall inside the selected row or column? */
+function countIn(arr, selection) {
+  if (selection.type === 'row') return arr.filter((c) => c.ri === selection.row).length;
+  return arr.filter((c) => c.ci === selection.col).length;
+}
+
+/**
+ * @param {object} calAdvice as returned by `calibrationAdvice`
+ * @param {Selection|null} selection
+ * @returns {AdvisorReport}
+ */
+export function sparkReport(calAdvice, selection) {
+  const { spark, overAdvanced, underAdvanced, pastMbt } = calAdvice;
+
+  if (selection && selection.type === 'cell') {
+    const cell = spark.find((c) => c.ri === selection.row && c.ci === selection.col);
+    // No entry means `calibrationAdvice` filtered the cell out as unreachable
+    // (its rule 2): a turbo build never sees 200 kPa at 800 RPM. That is not the
+    // same as a clean cell and must not be reported as one.
+    if (!cell) return { tone: 'info', headline: 'Never reached by this build', state: 'cell-unreachable', detail: {} };
+
+    if (holds(overAdvanced, cell.ri, cell.ci)) {
+      return {
+        tone: 'danger',
+        headline: `${(cell.current - cell.knockCeiling).toFixed(1)} deg past the knock limit`,
+        state: 'cell-over',
+        detail: { cell },
+      };
+    }
+    if (holds(pastMbt, cell.ri, cell.ci)) {
+      return {
+        tone: 'warn',
+        headline: `${(cell.current - cell.mbt).toFixed(1)} deg past MBT`,
+        state: 'cell-past-mbt',
+        detail: { cell },
+      };
+    }
+    if (holds(underAdvanced, cell.ri, cell.ci)) {
+      return {
+        tone: 'warn',
+        headline: `${cell.delta.toFixed(1)} deg below what this build allows`,
+        state: 'cell-under',
+        detail: { cell },
+      };
+    }
+    return { tone: 'ok', headline: 'Inside both ceilings', state: 'cell-ok', detail: { cell } };
+  }
+
+  if (selection) {
+    // A row or column. Same precedence as the table-wide report, scoped to the band.
+    const over = countIn(overAdvanced, selection);
+    if (over > 0) {
+      return {
+        tone: 'danger',
+        headline: `${over} of these cells are past the knock limit`,
+        state: 'group-over',
+        detail: { count: over },
+      };
+    }
+    const under = countIn(underAdvanced, selection);
+    const past = countIn(pastMbt, selection);
+    if (past > 0) {
+      return { tone: 'warn', headline: `${past} of these cells are past MBT`, state: 'group-past-mbt', detail: { count: past } };
+    }
+    if (under > 0) {
+      return { tone: 'warn', headline: `${under} of these cells have advance left`, state: 'group-under', detail: { count: under } };
+    }
+    return { tone: 'ok', headline: 'Nothing flagged in this band', state: 'group-clean', detail: {} };
+  }
+
+  // Table-wide. This precedence IS the fall-through the SPARK screen rendered
+  // before the panel existed, preserved exactly: danger first, then the
+  // opportunity, then the wasted advance, then the all-clear.
+  if (overAdvanced.length > 0) {
+    return {
+      tone: 'danger',
+      headline: `${plural(overAdvanced.length, 'cell')} beyond the knock limit`,
+      state: 'table-over',
+      detail: { count: overAdvanced.length, cells: overAdvanced.slice(0, 5), more: Math.max(0, overAdvanced.length - 5) },
+    };
+  }
+  if (underAdvanced.length > 4) {
+    return { tone: 'warn', headline: 'Timing left on the table', state: 'table-under', detail: { count: underAdvanced.length } };
+  }
+  if (pastMbt.length > 0) {
+    return { tone: 'warn', headline: 'Past peak torque', state: 'table-past-mbt', detail: { count: pastMbt.length } };
+  }
+  return { tone: 'ok', headline: 'Within the knock limit', state: 'table-clean', detail: {} };
+}

--- a/src/ui/components/advisorReports.js
+++ b/src/ui/components/advisorReports.js
@@ -15,6 +15,8 @@
  * issue #34 removed.
  */
 
+import { OPEN_LOOP_KPA } from '../../sim/index.js';
+
 /** @typedef {import('./TuningGrid.jsx').Selection} Selection */
 
 /**
@@ -122,4 +124,63 @@ export function sparkReport(calAdvice, selection) {
     return { tone: 'warn', headline: 'Past peak torque', state: 'table-past-mbt', detail: { count: pastMbt.length } };
   }
   return { tone: 'ok', headline: 'Within the knock limit', state: 'table-clean', detail: {} };
+}
+
+/**
+ * @param {object} calAdvice as returned by `calibrationAdvice`
+ * @param {Selection|null} selection
+ * @returns {AdvisorReport}
+ */
+export function fuelReport(calAdvice, selection) {
+  const { fuelAdv, wrongMix } = calAdvice;
+
+  if (selection && selection.type === 'cell') {
+    const cell = fuelAdv.find((c) => c.ri === selection.row && c.ci === selection.col);
+    // No entry means `calibrationAdvice` filtered the cell out as unreachable
+    // (its rule 2), the same reason `sparkReport` can miss a lookup — not the
+    // same thing as a cell that is on target.
+    if (!cell) return { tone: 'info', headline: 'Never reached by this build', state: 'cell-unreachable', detail: {} };
+
+    // Closed loop binds before membership, and unconditionally: the trims own
+    // this cell regardless of how large its delta is, so a big number here is
+    // not a reason to override the rule and report it anyway.
+    if (cell.map < OPEN_LOOP_KPA) {
+      return { tone: 'info', headline: 'Closed loop — the trims own this cell', state: 'cell-closed-loop', detail: { cell } };
+    }
+
+    if (holds(wrongMix, cell.ri, cell.ci)) {
+      const direction = cell.delta < 0 ? 'lean' : 'rich';
+      return {
+        tone: 'warn',
+        headline: `${Math.abs(cell.delta).toFixed(1)} AFR ${direction} of best power`,
+        state: 'cell-off',
+        detail: { cell },
+      };
+    }
+    return { tone: 'ok', headline: 'On best power', state: 'cell-ok', detail: { cell } };
+  }
+
+  if (selection) {
+    // A row or column. Only one category here, unlike sparkReport's three, so
+    // there is no severity order to preserve — just the count in the band.
+    const off = countIn(wrongMix, selection);
+    if (off > 0) {
+      return { tone: 'warn', headline: `${off} of these cells ${off === 1 ? 'is' : 'are'} off best power`, state: 'group-off', detail: { count: off } };
+    }
+    return { tone: 'ok', headline: 'Nothing flagged in this band', state: 'group-clean', detail: {} };
+  }
+
+  // Table-wide. FUEL never had a fall-through order to preserve — the old
+  // banner only ever showed one thing, the wrongMix count, and simply did not
+  // render when it was empty. table-clean is new prose the panel needs
+  // because, unlike the old banner, it always renders something.
+  if (wrongMix.length > 0) {
+    return {
+      tone: 'warn',
+      headline: `${plural(wrongMix.length, 'high-load cell')} off best power`,
+      state: 'table-off',
+      detail: { count: wrongMix.length, cells: wrongMix.slice(0, 5), more: Math.max(0, wrongMix.length - 5) },
+    };
+  }
+  return { tone: 'ok', headline: 'High-load mixture is on best power', state: 'table-clean', detail: {} };
 }

--- a/src/ui/screens/tune/AirflowScreen.jsx
+++ b/src/ui/screens/tune/AirflowScreen.jsx
@@ -10,13 +10,14 @@
 
 import React from 'react';
 
-import { Grid3x3, Info } from 'lucide-react';
+import { Grid3x3 } from 'lucide-react';
 
 import { AdvisorPanel } from '../../components/AdvisorPanel.jsx';
+import { veReport } from '../../components/advisorReports.js';
 import { SelectionDock } from '../../components/SelectionDock.jsx';
+import { TuneAdvisory } from '../../components/TuneAdvisory.jsx';
 import { TuningGrid } from '../../components/TuningGrid.jsx';
 import { ExpandableInfo } from '../../components/ExpandableInfo.jsx';
-import { Button } from '../../primitives/Button.jsx';
 import { Eyebrow } from '../../primitives/Eyebrow.jsx';
 import { ACTIONS } from '../../state/reducer.js';
 import { useTune } from '../../state/StoreProvider.jsx';
@@ -30,6 +31,12 @@ import styles from './AirflowScreen.module.css';
  * @property {boolean} inSync
  * @property {number} maxAbs
  * @property {Array<{rpmText: string, text: string, cells: string[]}>} recs
+ * @property {Array<{rpm: number, pct: number, from: number, to: number}>} [deltas]
+ *   one per RPM column, measured at the wide-open-throttle row only — read by
+ *   `veReport` for a cell/col selection, never by this screen directly.
+ *   Optional here only because a handful of pre-existing tests fabricate a
+ *   `VeAdvice` that never exercises a cell/col selection; the real shell's
+ *   value (`veRecommendations`' return) always has it.
  */
 
 /**
@@ -46,6 +53,9 @@ export function AirflowScreen({ veAdvice, veTruth }) {
   /** @param {Selection|null} value */
   const setSelection = (value) => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value });
   const recalcVE = () => dispatch({ type: ACTIONS.SET_TABLE, table: 've', value: veTruth });
+  // A handful of `.some()`-free array reads, no allocation in the hot path —
+  // plainly on every render, matching SparkScreen/FuelScreen.
+  const report = veReport(veAdvice, selection);
 
   return (
     <>
@@ -55,46 +65,13 @@ export function AirflowScreen({ veAdvice, veTruth }) {
           <div className={styles.intro}>How completely the cylinder fills at each engine speed and load. Rows are manifold pressure (MAP kPa &mdash; about 100 is wide open, higher is boost); columns are RPM. Tap any cell for reference data.</div>
           <TuningGrid data={ve} min={10} max={130} decimals={0} selection={selection} setSelection={setSelection} />
 
-          {veAdvice && (
-            veAdvice.inSync ? (
-              <div className={styles.inSyncBanner}>
-                <Info size={15} className={styles.inSyncIcon} />
-                <div>VE table matches your current hardware. Nothing to correct.</div>
-              </div>
-            ) : (
-              <div className={styles.staleBanner}>
-                <div className={styles.staleHead}>
-                  <div className={styles.staleLabel}>VE OUT OF SYNC WITH HARDWARE</div>
-                  <div className={styles.staleGap}>{veAdvice.maxAbs.toFixed(0)}% max gap</div>
-                </div>
-                <div className={styles.staleBody}>
-                  Your hardware changed but this table is still the old log. Here is what re-logging airflow on the dyno would actually show:
-                </div>
-                {veAdvice.recs.map((r, i) => (
-                  <div key={i} className={styles.rec}>
-                    <div className={styles.recTitle}>{r.rpmText}</div>
-                    <div className={styles.recText}>{r.text}</div>
-                    <div className={styles.recCells}>{r.cells.join('   ')}</div>
-                  </div>
-                ))}
-                {/* Was width:100%. It is the only action in this advisory box and
-                    reads as one at its own width; the box is already the full
-                    content column, so stretching it only made it wider. */}
-                <Button onClick={recalcVE} style={{ marginTop: 4 }}>
-                  ACCEPT RE-LOGGED VALUES
-                </Button>
-                <div className={styles.acceptNote}>Or type them in yourself — these are the measured targets, not a suggestion.</div>
-              </div>
-            )
-          )}
-
           <ExpandableInfo title="What VE actually means">
             VE compares the air trapped in the cylinder to the theoretical maximum the swept volume could hold. It rises with RPM as intake tuning matches resonance, then falls as the valves cannot flow fast enough — that fall is why every N/A engine has a torque peak. More air here means more fuel needed to hit a given AFR and more potential torque; VE is really the master variable, and timing/AFR are how you extract power from whatever air is already there.
             <br /><br /><b className={styles.em}>As a beginner:</b> leave VE alone at first. It is set by real hardware (intake, heads, cams) — the Bolt-Ons on BUILD already move it for you when you install parts. Spend your early pulls learning TIMING and AFR before you start hand-editing VE.
           </ExpandableInfo>
         </div>
-        <AdvisorPanel headline="Advisor" tone="info">
-          <p>Placeholder — filled in by the next task.</p>
+        <AdvisorPanel headline={report.headline} tone={report.tone}>
+          <TuneAdvisory kind="ve" report={report} onAcceptVe={recalcVE} />
         </AdvisorPanel>
       </div>
       <div className={styles.spacer} />

--- a/src/ui/screens/tune/AirflowScreen.jsx
+++ b/src/ui/screens/tune/AirflowScreen.jsx
@@ -12,6 +12,7 @@ import React from 'react';
 
 import { Grid3x3, Info } from 'lucide-react';
 
+import { AdvisorPanel } from '../../components/AdvisorPanel.jsx';
 import { SelectionDock } from '../../components/SelectionDock.jsx';
 import { TuningGrid } from '../../components/TuningGrid.jsx';
 import { ExpandableInfo } from '../../components/ExpandableInfo.jsx';
@@ -49,47 +50,52 @@ export function AirflowScreen({ veAdvice, veTruth }) {
   return (
     <>
       <div className={styles.wrap}>
-        <Eyebrow icon={Grid3x3}>Volumetric Efficiency</Eyebrow>
-        <div className={styles.intro}>How completely the cylinder fills at each engine speed and load. Rows are manifold pressure (MAP kPa &mdash; about 100 is wide open, higher is boost); columns are RPM. Tap any cell for reference data.</div>
-        <TuningGrid data={ve} min={10} max={130} decimals={0} selection={selection} setSelection={setSelection} />
+        <div className={styles.main}>
+          <Eyebrow icon={Grid3x3}>Volumetric Efficiency</Eyebrow>
+          <div className={styles.intro}>How completely the cylinder fills at each engine speed and load. Rows are manifold pressure (MAP kPa &mdash; about 100 is wide open, higher is boost); columns are RPM. Tap any cell for reference data.</div>
+          <TuningGrid data={ve} min={10} max={130} decimals={0} selection={selection} setSelection={setSelection} />
 
-        {veAdvice && (
-          veAdvice.inSync ? (
-            <div className={styles.inSyncBanner}>
-              <Info size={15} className={styles.inSyncIcon} />
-              <div>VE table matches your current hardware. Nothing to correct.</div>
-            </div>
-          ) : (
-            <div className={styles.staleBanner}>
-              <div className={styles.staleHead}>
-                <div className={styles.staleLabel}>VE OUT OF SYNC WITH HARDWARE</div>
-                <div className={styles.staleGap}>{veAdvice.maxAbs.toFixed(0)}% max gap</div>
+          {veAdvice && (
+            veAdvice.inSync ? (
+              <div className={styles.inSyncBanner}>
+                <Info size={15} className={styles.inSyncIcon} />
+                <div>VE table matches your current hardware. Nothing to correct.</div>
               </div>
-              <div className={styles.staleBody}>
-                Your hardware changed but this table is still the old log. Here is what re-logging airflow on the dyno would actually show:
-              </div>
-              {veAdvice.recs.map((r, i) => (
-                <div key={i} className={styles.rec}>
-                  <div className={styles.recTitle}>{r.rpmText}</div>
-                  <div className={styles.recText}>{r.text}</div>
-                  <div className={styles.recCells}>{r.cells.join('   ')}</div>
+            ) : (
+              <div className={styles.staleBanner}>
+                <div className={styles.staleHead}>
+                  <div className={styles.staleLabel}>VE OUT OF SYNC WITH HARDWARE</div>
+                  <div className={styles.staleGap}>{veAdvice.maxAbs.toFixed(0)}% max gap</div>
                 </div>
-              ))}
-              {/* Was width:100%. It is the only action in this advisory box and
-                  reads as one at its own width; the box is already the full
-                  content column, so stretching it only made it wider. */}
-              <Button onClick={recalcVE} style={{ marginTop: 4 }}>
-                ACCEPT RE-LOGGED VALUES
-              </Button>
-              <div className={styles.acceptNote}>Or type them in yourself — these are the measured targets, not a suggestion.</div>
-            </div>
-          )
-        )}
+                <div className={styles.staleBody}>
+                  Your hardware changed but this table is still the old log. Here is what re-logging airflow on the dyno would actually show:
+                </div>
+                {veAdvice.recs.map((r, i) => (
+                  <div key={i} className={styles.rec}>
+                    <div className={styles.recTitle}>{r.rpmText}</div>
+                    <div className={styles.recText}>{r.text}</div>
+                    <div className={styles.recCells}>{r.cells.join('   ')}</div>
+                  </div>
+                ))}
+                {/* Was width:100%. It is the only action in this advisory box and
+                    reads as one at its own width; the box is already the full
+                    content column, so stretching it only made it wider. */}
+                <Button onClick={recalcVE} style={{ marginTop: 4 }}>
+                  ACCEPT RE-LOGGED VALUES
+                </Button>
+                <div className={styles.acceptNote}>Or type them in yourself — these are the measured targets, not a suggestion.</div>
+              </div>
+            )
+          )}
 
-        <ExpandableInfo title="What VE actually means">
-          VE compares the air trapped in the cylinder to the theoretical maximum the swept volume could hold. It rises with RPM as intake tuning matches resonance, then falls as the valves cannot flow fast enough — that fall is why every N/A engine has a torque peak. More air here means more fuel needed to hit a given AFR and more potential torque; VE is really the master variable, and timing/AFR are how you extract power from whatever air is already there.
-          <br /><br /><b className={styles.em}>As a beginner:</b> leave VE alone at first. It is set by real hardware (intake, heads, cams) — the Bolt-Ons on BUILD already move it for you when you install parts. Spend your early pulls learning TIMING and AFR before you start hand-editing VE.
-        </ExpandableInfo>
+          <ExpandableInfo title="What VE actually means">
+            VE compares the air trapped in the cylinder to the theoretical maximum the swept volume could hold. It rises with RPM as intake tuning matches resonance, then falls as the valves cannot flow fast enough — that fall is why every N/A engine has a torque peak. More air here means more fuel needed to hit a given AFR and more potential torque; VE is really the master variable, and timing/AFR are how you extract power from whatever air is already there.
+            <br /><br /><b className={styles.em}>As a beginner:</b> leave VE alone at first. It is set by real hardware (intake, heads, cams) — the Bolt-Ons on BUILD already move it for you when you install parts. Spend your early pulls learning TIMING and AFR before you start hand-editing VE.
+          </ExpandableInfo>
+        </div>
+        <AdvisorPanel headline="Advisor" tone="info">
+          <p>Placeholder — filled in by the next task.</p>
+        </AdvisorPanel>
       </div>
       <div className={styles.spacer} />
       <SelectionDock data={ve} setData={(value) => dispatch({ type: ACTIONS.SET_TABLE, table: 've', value })} selection={selection} min={10} max={130} decimals={0} unit="%" onClose={() => setSelection(null)} kind="ve" />

--- a/src/ui/screens/tune/AirflowScreen.module.css
+++ b/src/ui/screens/tune/AirflowScreen.module.css
@@ -41,92 +41,9 @@
 
 .spacer { flex: 1; }
 
-/* The two advisory banners are mutually exclusive — only one of `inSyncBanner` or
-   `staleBanner` is ever mounted, so each gets its own fixed class rather than a
-   shared one switched by a data attribute. */
-
-.inSyncBanner {
-  display: flex;
-  gap: 8px;
-  margin: 10px 0;
-  padding: 11px 13px;
-  border: 1px solid var(--ok-line);
-  border-radius: 10px;
-  background: var(--ok-bg);
-  color: var(--ok);
-  font-size: 12.5px;
-  line-height: 1.5;
-}
-
-.inSyncIcon {
-  flex-shrink: 0;
-  margin-top: 1px;
-}
-
-.staleBanner {
-  margin: 10px 0;
-  padding: 12px 13px;
-  border: 1px solid var(--acc);
-  border-radius: 10px;
-  background: var(--panel2);
-}
-
-.staleHead {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 8px;
-}
-
-.staleLabel {
-  font-size: 10px;
-  letter-spacing: 1px;
-  font-weight: 800;
-  color: var(--acc-ink);
-}
-
-.staleGap {
-  font-family: var(--mono);
-  font-size: 11px;
-  font-weight: 700;
-  color: var(--acc-ink);
-}
-
-.staleBody {
-  margin-bottom: 9px;
-  font-size: var(--fs-sm);
-  color: var(--ink2);
-  line-height: 1.55;
-}
-
-.rec { margin-bottom: 9px; }
-
-.recTitle {
-  font-size: var(--fs-sm);
-  font-weight: 700;
-  color: var(--ink);
-}
-
-.recText {
-  margin-top: 2px;
-  font-size: 11.5px;
-  color: var(--ink2);
-  line-height: 1.5;
-}
-
-.recCells {
-  margin-top: 3px;
-  font-family: var(--mono);
-  font-size: var(--fs-xs);
-  color: var(--cyan);
-}
-
-.acceptNote {
-  margin-top: 6px;
-  font-size: var(--fs-xs);
-  color: var(--ink3);
-  text-align: center;
-}
-
-/* Prose emphasis inside the ExpandableInfo panel. */
+/* Prose emphasis inside the ExpandableInfo panel. The VE-sync advisory that
+   used to live in this file (and the sibling .inSyncBanner/.inSyncIcon/
+   .staleBanner/.staleHead/.staleLabel/.staleGap/.staleBody/.rec/.recTitle/
+   .recText/.recCells/.acceptNote classes it used) moved into
+   TuneAdvisory.module.css along with the markup — see TuneAdvisory.jsx. */
 .em { color: var(--ink); }

--- a/src/ui/screens/tune/AirflowScreen.module.css
+++ b/src/ui/screens/tune/AirflowScreen.module.css
@@ -4,6 +4,24 @@
   padding: var(--sp-xl) var(--sp-xl) 0;
 }
 
+/* 560px is the project's one breakpoint — see the note beside the scale in
+   tokens.css, which lists every file that uses it. Kept in sync by hand with
+   StartScreen.module.css, TutorialScreen.module.css, AppShell.module.css and
+   AdvisorPanel.module.css.
+
+   `minmax(0, 1fr)` rather than a bare `1fr`: the tuning grid is a wide
+   fixed-width child, and a bare `1fr` track refuses to shrink below its
+   content's intrinsic width, which would push the advisor rail past the
+   content cap and off the screen. */
+@media (min-width: 560px) {
+  .wrap {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 280px;
+    gap: var(--sp-xl);
+    align-items: start;
+  }
+}
+
 .intro {
   margin-bottom: 12px;
   font-size: 12.5px;

--- a/src/ui/screens/tune/AirflowScreen.module.css
+++ b/src/ui/screens/tune/AirflowScreen.module.css
@@ -20,6 +20,16 @@
     gap: var(--sp-xl);
     align-items: start;
   }
+
+  /* A grid item's automatic minimum size is its content's, not zero, so a wide
+     child could still push this track past the content cap even though the
+     track itself is sized `minmax(0, 1fr)`. The tuning grid carries its own
+     `overflow-x: auto` wrapper, which should already zero that contribution —
+     this makes it unconditional rather than dependent on a descendant's
+     styling two levels down. */
+  .main {
+    min-width: 0;
+  }
 }
 
 .intro {

--- a/src/ui/screens/tune/FuelScreen.jsx
+++ b/src/ui/screens/tune/FuelScreen.jsx
@@ -9,6 +9,7 @@ import React from 'react';
 
 import { Droplets } from 'lucide-react';
 
+import { AdvisorPanel } from '../../components/AdvisorPanel.jsx';
 import { SelectionDock } from '../../components/SelectionDock.jsx';
 import { TuningGrid } from '../../components/TuningGrid.jsx';
 import { ExpandableInfo } from '../../components/ExpandableInfo.jsx';
@@ -35,32 +36,37 @@ export function FuelScreen({ calAdvice }) {
   return (
     <>
       <div className={styles.wrap}>
-        <Eyebrow icon={Droplets}>Air-Fuel Ratio Target</Eyebrow>
-        <div className={styles.intro}>Target air:fuel ratio the ECU aims for. Divide by 14.7 to read it as lambda.</div>
-        <TuningGrid data={afr} min={10} max={18} decimals={1} selection={selection} setSelection={setSelection} />
-        {calAdvice.wrongMix.length > 0 && (
-          <div className={styles.banner}>
-            <div className={styles.label}>
-              {calAdvice.wrongMix.length} HIGH-LOAD CELLS OFF BEST POWER
-            </div>
-            <div className={styles.body}>
-              Best-power mixture shifts with boost — richer as cylinder pressure rises. These cells are judged on what the engine actually <b className={styles.em}>delivered</b>, not on what the table commanded: if your MAF or injector scaling is off, the two are not the same number, and the delivered one is the one the pistons feel. The suggestion is the value to type into the cell to land on target.
-            </div>
-            {calAdvice.wrongMix.slice(0, 5).map((c, i) => (
-              <div key={i} className={styles.cell} data-richen={c.delta < 0 ? 'true' : 'false'}>
-                {c.map} kPa / {c.rpm} RPM: {c.current}:1 → {c.suggested}:1 {c.delta < 0 ? '(richen)' : '(lean out)'} · delivered {c.delivered}, wants {c.target}
+        <div className={styles.main}>
+          <Eyebrow icon={Droplets}>Air-Fuel Ratio Target</Eyebrow>
+          <div className={styles.intro}>Target air:fuel ratio the ECU aims for. Divide by 14.7 to read it as lambda.</div>
+          <TuningGrid data={afr} min={10} max={18} decimals={1} selection={selection} setSelection={setSelection} />
+          {calAdvice.wrongMix.length > 0 && (
+            <div className={styles.banner}>
+              <div className={styles.label}>
+                {calAdvice.wrongMix.length} HIGH-LOAD CELLS OFF BEST POWER
               </div>
-            ))}
-            {calAdvice.wrongMix.length > 5 && <div className={styles.more}>…and {calAdvice.wrongMix.length - 5} more</div>}
-          </div>
-        )}
+              <div className={styles.body}>
+                Best-power mixture shifts with boost — richer as cylinder pressure rises. These cells are judged on what the engine actually <b className={styles.em}>delivered</b>, not on what the table commanded: if your MAF or injector scaling is off, the two are not the same number, and the delivered one is the one the pistons feel. The suggestion is the value to type into the cell to land on target.
+              </div>
+              {calAdvice.wrongMix.slice(0, 5).map((c, i) => (
+                <div key={i} className={styles.cell} data-richen={c.delta < 0 ? 'true' : 'false'}>
+                  {c.map} kPa / {c.rpm} RPM: {c.current}:1 → {c.suggested}:1 {c.delta < 0 ? '(richen)' : '(lean out)'} · delivered {c.delivered}, wants {c.target}
+                </div>
+              ))}
+              {calAdvice.wrongMix.length > 5 && <div className={styles.more}>…and {calAdvice.wrongMix.length - 5} more</div>}
+            </div>
+          )}
 
-        <ExpandableInfo title="Why AFR trades power for safety">
-          14.7:1 is stoichiometric — burns all the fuel and oxygen with nothing left over, great for emissions and cruise. Peak power sits richer, because the extra fuel absorbs heat as it vaporizes, cooling combustion enough to make more power before knock becomes the limit. Go leaner than that under load and you lose power and raise both knock risk and exhaust gas temperature at once — which is why lean-under-boost is especially dangerous to valves and pistons.
-          <br /><br /><b className={styles.em}>Best power is not one number.</b> Naturally aspirated engines make best torque near lambda 0.85-0.92 (about 12.5-13.5:1 on gasoline). Under boost, best power moves richer — near lambda 0.82-0.85 (about 12.0-12.5:1) — because you are deliberately buying charge cooling to hold off knock. This sandbox moves its best-power target with your boost level, so the same AFR table that was ideal naturally aspirated reads genuinely lean once you are on 8 psi.
-          <br /><br /><b className={styles.em}>Reading it in lambda:</b> lambda is AFR divided by the fuel's stoichiometric point, so lambda 0.85 means the same relative richness on any fuel. That is why tuners talk in lambda once E85 enters the picture — 12.5:1 means something completely different on E85 than on pump gas.
-          <br /><br /><b className={styles.em}>As a beginner:</b> when in doubt, go richer (a lower number), not leaner. A rich cell costs a little power; a lean cell under load is how you actually damage something.
-        </ExpandableInfo>
+          <ExpandableInfo title="Why AFR trades power for safety">
+            14.7:1 is stoichiometric — burns all the fuel and oxygen with nothing left over, great for emissions and cruise. Peak power sits richer, because the extra fuel absorbs heat as it vaporizes, cooling combustion enough to make more power before knock becomes the limit. Go leaner than that under load and you lose power and raise both knock risk and exhaust gas temperature at once — which is why lean-under-boost is especially dangerous to valves and pistons.
+            <br /><br /><b className={styles.em}>Best power is not one number.</b> Naturally aspirated engines make best torque near lambda 0.85-0.92 (about 12.5-13.5:1 on gasoline). Under boost, best power moves richer — near lambda 0.82-0.85 (about 12.0-12.5:1) — because you are deliberately buying charge cooling to hold off knock. This sandbox moves its best-power target with your boost level, so the same AFR table that was ideal naturally aspirated reads genuinely lean once you are on 8 psi.
+            <br /><br /><b className={styles.em}>Reading it in lambda:</b> lambda is AFR divided by the fuel's stoichiometric point, so lambda 0.85 means the same relative richness on any fuel. That is why tuners talk in lambda once E85 enters the picture — 12.5:1 means something completely different on E85 than on pump gas.
+            <br /><br /><b className={styles.em}>As a beginner:</b> when in doubt, go richer (a lower number), not leaner. A rich cell costs a little power; a lean cell under load is how you actually damage something.
+          </ExpandableInfo>
+        </div>
+        <AdvisorPanel headline="Advisor" tone="info">
+          <p>Placeholder — filled in by the next task.</p>
+        </AdvisorPanel>
       </div>
       <div className={styles.spacer} />
       <SelectionDock data={afr} setData={(value) => dispatch({ type: ACTIONS.SET_TABLE, table: 'afr', value })} selection={selection} min={10} max={18} decimals={1} unit=":1" onClose={() => setSelection(null)} kind="afr" />

--- a/src/ui/screens/tune/FuelScreen.jsx
+++ b/src/ui/screens/tune/FuelScreen.jsx
@@ -10,7 +10,9 @@ import React from 'react';
 import { Droplets } from 'lucide-react';
 
 import { AdvisorPanel } from '../../components/AdvisorPanel.jsx';
+import { fuelReport } from '../../components/advisorReports.js';
 import { SelectionDock } from '../../components/SelectionDock.jsx';
+import { TuneAdvisory } from '../../components/TuneAdvisory.jsx';
 import { TuningGrid } from '../../components/TuningGrid.jsx';
 import { ExpandableInfo } from '../../components/ExpandableInfo.jsx';
 import { Eyebrow } from '../../primitives/Eyebrow.jsx';
@@ -32,6 +34,9 @@ export function FuelScreen({ calAdvice }) {
   const { afr, selection } = tune;
   /** @param {Selection|null} value */
   const setSelection = (value) => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value });
+  // A handful of `.some()` scans over at most 96 cells, no allocation in the
+  // hot path — plainly on every render, not memoised.
+  const report = fuelReport(calAdvice, selection);
 
   return (
     <>
@@ -40,22 +45,6 @@ export function FuelScreen({ calAdvice }) {
           <Eyebrow icon={Droplets}>Air-Fuel Ratio Target</Eyebrow>
           <div className={styles.intro}>Target air:fuel ratio the ECU aims for. Divide by 14.7 to read it as lambda.</div>
           <TuningGrid data={afr} min={10} max={18} decimals={1} selection={selection} setSelection={setSelection} />
-          {calAdvice.wrongMix.length > 0 && (
-            <div className={styles.banner}>
-              <div className={styles.label}>
-                {calAdvice.wrongMix.length} HIGH-LOAD CELLS OFF BEST POWER
-              </div>
-              <div className={styles.body}>
-                Best-power mixture shifts with boost — richer as cylinder pressure rises. These cells are judged on what the engine actually <b className={styles.em}>delivered</b>, not on what the table commanded: if your MAF or injector scaling is off, the two are not the same number, and the delivered one is the one the pistons feel. The suggestion is the value to type into the cell to land on target.
-              </div>
-              {calAdvice.wrongMix.slice(0, 5).map((c, i) => (
-                <div key={i} className={styles.cell} data-richen={c.delta < 0 ? 'true' : 'false'}>
-                  {c.map} kPa / {c.rpm} RPM: {c.current}:1 → {c.suggested}:1 {c.delta < 0 ? '(richen)' : '(lean out)'} · delivered {c.delivered}, wants {c.target}
-                </div>
-              ))}
-              {calAdvice.wrongMix.length > 5 && <div className={styles.more}>…and {calAdvice.wrongMix.length - 5} more</div>}
-            </div>
-          )}
 
           <ExpandableInfo title="Why AFR trades power for safety">
             14.7:1 is stoichiometric — burns all the fuel and oxygen with nothing left over, great for emissions and cruise. Peak power sits richer, because the extra fuel absorbs heat as it vaporizes, cooling combustion enough to make more power before knock becomes the limit. Go leaner than that under load and you lose power and raise both knock risk and exhaust gas temperature at once — which is why lean-under-boost is especially dangerous to valves and pistons.
@@ -64,8 +53,8 @@ export function FuelScreen({ calAdvice }) {
             <br /><br /><b className={styles.em}>As a beginner:</b> when in doubt, go richer (a lower number), not leaner. A rich cell costs a little power; a lean cell under load is how you actually damage something.
           </ExpandableInfo>
         </div>
-        <AdvisorPanel headline="Advisor" tone="info">
-          <p>Placeholder — filled in by the next task.</p>
+        <AdvisorPanel headline={report.headline} tone={report.tone}>
+          <TuneAdvisory kind="afr" report={report} />
         </AdvisorPanel>
       </div>
       <div className={styles.spacer} />

--- a/src/ui/screens/tune/FuelScreen.module.css
+++ b/src/ui/screens/tune/FuelScreen.module.css
@@ -41,47 +41,8 @@
 
 .spacer { flex: 1; }
 
-.banner {
-  margin: 10px 0;
-  padding: 12px 13px;
-  border: 1px solid var(--acc);
-  border-radius: 10px;
-  background: var(--panel2);
-}
-
-.label {
-  margin-bottom: 7px;
-  font-size: 10px;
-  letter-spacing: 1px;
-  font-weight: 800;
-  color: var(--acc-ink);
-}
-
-.body {
-  margin-bottom: 8px;
-  font-size: var(--fs-sm);
-  color: var(--ink2);
-  line-height: 1.55;
-}
-
-/* One row per cell, coloured by whether the fix is to richen (danger — this cell
-   is lean) or lean out (an ordinary cyan data readout, not a warning). Cells in a
-   single render can carry either state, so this is a data attribute rather than
-   two separate elements, matching TurboScreen's boost-column convention. */
-.cell {
-  margin-bottom: 2px;
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--cyan);
-}
-
-.cell[data-richen='true'] { color: var(--danger-ink); }
-
-.more {
-  margin-top: 3px;
-  font-size: var(--fs-xs);
-  color: var(--ink3);
-}
-
-/* Prose emphasis inside the ExpandableInfo panel. */
+/* Prose emphasis inside the ExpandableInfo panel. The mixture-advisory banner
+   that used to live in this file (and the sibling .banner/.label/.body/.cell/
+   .more classes it used) moved into TuneAdvisory.module.css along with the
+   markup — see TuneAdvisory.jsx. */
 .em { color: var(--ink); }

--- a/src/ui/screens/tune/FuelScreen.module.css
+++ b/src/ui/screens/tune/FuelScreen.module.css
@@ -4,6 +4,24 @@
   padding: var(--sp-xl) var(--sp-xl) 0;
 }
 
+/* 560px is the project's one breakpoint — see the note beside the scale in
+   tokens.css, which lists every file that uses it. Kept in sync by hand with
+   StartScreen.module.css, TutorialScreen.module.css, AppShell.module.css and
+   AdvisorPanel.module.css.
+
+   `minmax(0, 1fr)` rather than a bare `1fr`: the tuning grid is a wide
+   fixed-width child, and a bare `1fr` track refuses to shrink below its
+   content's intrinsic width, which would push the advisor rail past the
+   content cap and off the screen. */
+@media (min-width: 560px) {
+  .wrap {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 280px;
+    gap: var(--sp-xl);
+    align-items: start;
+  }
+}
+
 .intro {
   margin-bottom: 12px;
   font-size: 12.5px;

--- a/src/ui/screens/tune/FuelScreen.module.css
+++ b/src/ui/screens/tune/FuelScreen.module.css
@@ -20,6 +20,16 @@
     gap: var(--sp-xl);
     align-items: start;
   }
+
+  /* A grid item's automatic minimum size is its content's, not zero, so a wide
+     child could still push this track past the content cap even though the
+     track itself is sized `minmax(0, 1fr)`. The tuning grid carries its own
+     `overflow-x: auto` wrapper, which should already zero that contribution —
+     this makes it unconditional rather than dependent on a descendant's
+     styling two levels down. */
+  .main {
+    min-width: 0;
+  }
 }
 
 .intro {

--- a/src/ui/screens/tune/SparkScreen.jsx
+++ b/src/ui/screens/tune/SparkScreen.jsx
@@ -12,11 +12,12 @@ import { Zap } from 'lucide-react';
 
 import { SPARK_MAX_DEG, SPARK_MIN_DEG } from '../../../sim/index.js';
 import { AdvisorPanel } from '../../components/AdvisorPanel.jsx';
+import { sparkReport } from '../../components/advisorReports.js';
 import { SelectionDock } from '../../components/SelectionDock.jsx';
+import { TuneAdvisory } from '../../components/TuneAdvisory.jsx';
 import { TuningGrid } from '../../components/TuningGrid.jsx';
 import { ExpandableInfo } from '../../components/ExpandableInfo.jsx';
 import { Eyebrow } from '../../primitives/Eyebrow.jsx';
-import { Panel } from '../../primitives/Panel.jsx';
 import { ACTIONS } from '../../state/reducer.js';
 import { useTune } from '../../state/StoreProvider.jsx';
 
@@ -42,6 +43,9 @@ export function SparkScreen({ calAdvice }) {
   const { timing, selection } = tune;
   /** @param {Selection|null} value */
   const setSelection = (value) => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value });
+  // A handful of `.some()` scans over at most 96 cells, no allocation in the
+  // hot path — plainly on every render, not memoised.
+  const report = sparkReport(calAdvice, selection);
 
   return (
     <>
@@ -50,35 +54,6 @@ export function SparkScreen({ calAdvice }) {
           <Eyebrow icon={Zap}>Ignition Timing</Eyebrow>
           <div className={styles.intro}>Degrees of spark advance before top dead center (° BTDC).</div>
           <TuningGrid data={timing} min={SPARK_MIN_DEG} max={SPARK_MAX_DEG} decimals={0} selection={selection} setSelection={setSelection} />
-          {calAdvice.overAdvanced.length > 0 ? (
-            <div className={styles.dangerBanner}>
-              <div className={styles.dangerLabel}>
-                {calAdvice.overAdvanced.length} CELLS BEYOND THE KNOCK LIMIT
-              </div>
-              <div className={styles.dangerBody}>
-                Your current hardware will not tolerate this much advance here. These cells are asking for more timing than the charge, octane and compression allow:
-              </div>
-              {calAdvice.overAdvanced.slice(0, 5).map((c, i) => (
-                <div key={i} className={styles.dangerCell}>
-                  {c.map} kPa / {c.rpm} RPM: {c.current}° → {c.suggested}°
-                </div>
-              ))}
-              {calAdvice.overAdvanced.length > 5 && <div className={styles.dangerMore}>…and {calAdvice.overAdvanced.length - 5} more</div>}
-              <div className={styles.dangerFooter}>Edit them yourself — a calibration is yours to make, not something the app should silently rewrite.</div>
-            </div>
-          ) : calAdvice.underAdvanced.length > 4 ? (
-            <Panel tight className={styles.advisoryPanel}>
-              <b className={styles.em}>Timing left on the table.</b> {calAdvice.underAdvanced.length} cells are more than 3° below what this build would tolerate. Safe, but you are giving away torque — advance them a little at a time and pull between each change.
-            </Panel>
-          ) : calAdvice.pastMbt.length > 0 ? (
-            <Panel tight className={styles.advisoryPanel}>
-              <b className={styles.em}>Past peak torque.</b> {calAdvice.pastMbt.length} cells command more advance than the burn can use — the charge is already finishing where it should, so the extra degrees are working against the piston on its way up rather than adding torque. Not dangerous here — these cells are inside the knock limit — but pulling them back gains a little power and buys margin.
-            </Panel>
-          ) : (
-            <div className={styles.okBanner}>
-              Spark table sits within the knock limit for this hardware.
-            </div>
-          )}
 
           <ExpandableInfo title="Why the app never rewrites your spark or fuel tables">
             The VE table auto-syncs because volumetric efficiency is a <b className={styles.emInk}>measurement of the hardware</b> — swap a cam and a tuner simply re-logs airflow, and the numbers are what they are.
@@ -91,8 +66,8 @@ export function SparkScreen({ calAdvice }) {
             <br /><br /><b className={styles.emInk}>As a beginner:</b> nudge one cell 1-2° at a time, run a pull, and read the log. If it comes back clean with no knock event, you probably still have room. If you see a knock warning, that cell is your new ceiling — back off to what the log suggests and move on.
           </ExpandableInfo>
         </div>
-        <AdvisorPanel headline="Advisor" tone="info">
-          <p>Placeholder — filled in by the next task.</p>
+        <AdvisorPanel headline={report.headline} tone={report.tone}>
+          <TuneAdvisory kind="timing" report={report} />
         </AdvisorPanel>
       </div>
       <div className={styles.spacer} />

--- a/src/ui/screens/tune/SparkScreen.jsx
+++ b/src/ui/screens/tune/SparkScreen.jsx
@@ -11,6 +11,7 @@ import React from 'react';
 import { Zap } from 'lucide-react';
 
 import { SPARK_MAX_DEG, SPARK_MIN_DEG } from '../../../sim/index.js';
+import { AdvisorPanel } from '../../components/AdvisorPanel.jsx';
 import { SelectionDock } from '../../components/SelectionDock.jsx';
 import { TuningGrid } from '../../components/TuningGrid.jsx';
 import { ExpandableInfo } from '../../components/ExpandableInfo.jsx';
@@ -45,49 +46,54 @@ export function SparkScreen({ calAdvice }) {
   return (
     <>
       <div className={styles.wrap}>
-        <Eyebrow icon={Zap}>Ignition Timing</Eyebrow>
-        <div className={styles.intro}>Degrees of spark advance before top dead center (° BTDC).</div>
-        <TuningGrid data={timing} min={SPARK_MIN_DEG} max={SPARK_MAX_DEG} decimals={0} selection={selection} setSelection={setSelection} />
-        {calAdvice.overAdvanced.length > 0 ? (
-          <div className={styles.dangerBanner}>
-            <div className={styles.dangerLabel}>
-              {calAdvice.overAdvanced.length} CELLS BEYOND THE KNOCK LIMIT
-            </div>
-            <div className={styles.dangerBody}>
-              Your current hardware will not tolerate this much advance here. These cells are asking for more timing than the charge, octane and compression allow:
-            </div>
-            {calAdvice.overAdvanced.slice(0, 5).map((c, i) => (
-              <div key={i} className={styles.dangerCell}>
-                {c.map} kPa / {c.rpm} RPM: {c.current}° → {c.suggested}°
+        <div className={styles.main}>
+          <Eyebrow icon={Zap}>Ignition Timing</Eyebrow>
+          <div className={styles.intro}>Degrees of spark advance before top dead center (° BTDC).</div>
+          <TuningGrid data={timing} min={SPARK_MIN_DEG} max={SPARK_MAX_DEG} decimals={0} selection={selection} setSelection={setSelection} />
+          {calAdvice.overAdvanced.length > 0 ? (
+            <div className={styles.dangerBanner}>
+              <div className={styles.dangerLabel}>
+                {calAdvice.overAdvanced.length} CELLS BEYOND THE KNOCK LIMIT
               </div>
-            ))}
-            {calAdvice.overAdvanced.length > 5 && <div className={styles.dangerMore}>…and {calAdvice.overAdvanced.length - 5} more</div>}
-            <div className={styles.dangerFooter}>Edit them yourself — a calibration is yours to make, not something the app should silently rewrite.</div>
-          </div>
-        ) : calAdvice.underAdvanced.length > 4 ? (
-          <Panel tight className={styles.advisoryPanel}>
-            <b className={styles.em}>Timing left on the table.</b> {calAdvice.underAdvanced.length} cells are more than 3° below what this build would tolerate. Safe, but you are giving away torque — advance them a little at a time and pull between each change.
-          </Panel>
-        ) : calAdvice.pastMbt.length > 0 ? (
-          <Panel tight className={styles.advisoryPanel}>
-            <b className={styles.em}>Past peak torque.</b> {calAdvice.pastMbt.length} cells command more advance than the burn can use — the charge is already finishing where it should, so the extra degrees are working against the piston on its way up rather than adding torque. Not dangerous here — these cells are inside the knock limit — but pulling them back gains a little power and buys margin.
-          </Panel>
-        ) : (
-          <div className={styles.okBanner}>
-            Spark table sits within the knock limit for this hardware.
-          </div>
-        )}
+              <div className={styles.dangerBody}>
+                Your current hardware will not tolerate this much advance here. These cells are asking for more timing than the charge, octane and compression allow:
+              </div>
+              {calAdvice.overAdvanced.slice(0, 5).map((c, i) => (
+                <div key={i} className={styles.dangerCell}>
+                  {c.map} kPa / {c.rpm} RPM: {c.current}° → {c.suggested}°
+                </div>
+              ))}
+              {calAdvice.overAdvanced.length > 5 && <div className={styles.dangerMore}>…and {calAdvice.overAdvanced.length - 5} more</div>}
+              <div className={styles.dangerFooter}>Edit them yourself — a calibration is yours to make, not something the app should silently rewrite.</div>
+            </div>
+          ) : calAdvice.underAdvanced.length > 4 ? (
+            <Panel tight className={styles.advisoryPanel}>
+              <b className={styles.em}>Timing left on the table.</b> {calAdvice.underAdvanced.length} cells are more than 3° below what this build would tolerate. Safe, but you are giving away torque — advance them a little at a time and pull between each change.
+            </Panel>
+          ) : calAdvice.pastMbt.length > 0 ? (
+            <Panel tight className={styles.advisoryPanel}>
+              <b className={styles.em}>Past peak torque.</b> {calAdvice.pastMbt.length} cells command more advance than the burn can use — the charge is already finishing where it should, so the extra degrees are working against the piston on its way up rather than adding torque. Not dangerous here — these cells are inside the knock limit — but pulling them back gains a little power and buys margin.
+            </Panel>
+          ) : (
+            <div className={styles.okBanner}>
+              Spark table sits within the knock limit for this hardware.
+            </div>
+          )}
 
-        <ExpandableInfo title="Why the app never rewrites your spark or fuel tables">
-          The VE table auto-syncs because volumetric efficiency is a <b className={styles.emInk}>measurement of the hardware</b> — swap a cam and a tuner simply re-logs airflow, and the numbers are what they are.
-          <br /><br />Spark and fuel are different: they are <b className={styles.emInk}>your calibration</b>, a set of judgement calls about how much risk to take for how much power. A real ECU does not retune itself when you bolt on a turbo — it keeps running the old numbers into the new hardware, which is exactly how engines get hurt.
-          <br /><br />So the app tells you what the hardware will now tolerate, and leaves the editing to you. That gap between "what the engine can take" and "what your table asks for" is the entire job.
-        </ExpandableInfo>
+          <ExpandableInfo title="Why the app never rewrites your spark or fuel tables">
+            The VE table auto-syncs because volumetric efficiency is a <b className={styles.emInk}>measurement of the hardware</b> — swap a cam and a tuner simply re-logs airflow, and the numbers are what they are.
+            <br /><br />Spark and fuel are different: they are <b className={styles.emInk}>your calibration</b>, a set of judgement calls about how much risk to take for how much power. A real ECU does not retune itself when you bolt on a turbo — it keeps running the old numbers into the new hardware, which is exactly how engines get hurt.
+            <br /><br />So the app tells you what the hardware will now tolerate, and leaves the editing to you. That gap between "what the engine can take" and "what your table asks for" is the entire job.
+          </ExpandableInfo>
 
-        <ExpandableInfo title="Why timing has a sweet spot (MBT)">
-          Combustion is not instant — the flame front takes time to burn through the mixture. Timing decides when the burn starts so peak cylinder pressure lands just after top dead center, where it does useful work. Advance too far and pressure peaks before the piston is ready, fighting the crank and risking knock; retard too far and you are burning fuel after the piston has already started down, wasting it as heat. MBT is the earliest timing that still lands the burn right — past it, more advance buys almost nothing, only risk.
-          <br /><br /><b className={styles.emInk}>As a beginner:</b> nudge one cell 1-2° at a time, run a pull, and read the log. If it comes back clean with no knock event, you probably still have room. If you see a knock warning, that cell is your new ceiling — back off to what the log suggests and move on.
-        </ExpandableInfo>
+          <ExpandableInfo title="Why timing has a sweet spot (MBT)">
+            Combustion is not instant — the flame front takes time to burn through the mixture. Timing decides when the burn starts so peak cylinder pressure lands just after top dead center, where it does useful work. Advance too far and pressure peaks before the piston is ready, fighting the crank and risking knock; retard too far and you are burning fuel after the piston has already started down, wasting it as heat. MBT is the earliest timing that still lands the burn right — past it, more advance buys almost nothing, only risk.
+            <br /><br /><b className={styles.emInk}>As a beginner:</b> nudge one cell 1-2° at a time, run a pull, and read the log. If it comes back clean with no knock event, you probably still have room. If you see a knock warning, that cell is your new ceiling — back off to what the log suggests and move on.
+          </ExpandableInfo>
+        </div>
+        <AdvisorPanel headline="Advisor" tone="info">
+          <p>Placeholder — filled in by the next task.</p>
+        </AdvisorPanel>
       </div>
       <div className={styles.spacer} />
       <SelectionDock data={timing} setData={(value) => dispatch({ type: ACTIONS.SET_TABLE, table: 'timing', value })} selection={selection} min={SPARK_MIN_DEG} max={SPARK_MAX_DEG} decimals={0} unit="°" onClose={() => setSelection(null)} kind="timing" />

--- a/src/ui/screens/tune/SparkScreen.module.css
+++ b/src/ui/screens/tune/SparkScreen.module.css
@@ -4,6 +4,24 @@
   padding: var(--sp-xl) var(--sp-xl) 0;
 }
 
+/* 560px is the project's one breakpoint — see the note beside the scale in
+   tokens.css, which lists every file that uses it. Kept in sync by hand with
+   StartScreen.module.css, TutorialScreen.module.css, AppShell.module.css and
+   AdvisorPanel.module.css.
+
+   `minmax(0, 1fr)` rather than a bare `1fr`: the tuning grid is a wide
+   fixed-width child, and a bare `1fr` track refuses to shrink below its
+   content's intrinsic width, which would push the advisor rail past the
+   content cap and off the screen. */
+@media (min-width: 560px) {
+  .wrap {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 280px;
+    gap: var(--sp-xl);
+    align-items: start;
+  }
+}
+
 .intro {
   margin-bottom: 12px;
   font-size: 12.5px;

--- a/src/ui/screens/tune/SparkScreen.module.css
+++ b/src/ui/screens/tune/SparkScreen.module.css
@@ -40,68 +40,8 @@
 
 .spacer { flex: 1; }
 
-/* The four knock-advisory states are mutually exclusive — only one ever mounts —
-   so each gets its own fixed class rather than a shared one switched at runtime. */
-
-.dangerBanner {
-  margin: 10px 0;
-  padding: 12px 13px;
-  border: 1px solid var(--danger-line);
-  border-radius: 10px;
-  background: var(--danger-bg);
-}
-
-.dangerLabel {
-  margin-bottom: 7px;
-  font-size: 10px;
-  letter-spacing: 1px;
-  font-weight: 800;
-  color: var(--danger-ink);
-}
-
-.dangerBody {
-  margin-bottom: 8px;
-  font-size: var(--fs-sm);
-  color: var(--ink2);
-  line-height: 1.55;
-}
-
-.dangerCell {
-  margin-bottom: 2px;
-  font-family: var(--mono);
-  font-size: 11px;
-  color: var(--cyan);
-}
-
-.dangerMore {
-  margin-top: 3px;
-  font-size: var(--fs-xs);
-  color: var(--ink3);
-}
-
-.dangerFooter {
-  margin-top: 8px;
-  font-size: 11px;
-  color: var(--ink3);
-}
-
-.advisoryPanel {
-  margin: 10px 0;
-  font-size: var(--fs-sm);
-  color: var(--ink2);
-  line-height: 1.5;
-}
-
-.okBanner {
-  margin: 10px 0;
-  padding: 11px 13px;
-  border: 1px solid var(--ok-line);
-  border-radius: 10px;
-  background: var(--ok-bg);
-  font-size: 12.5px;
-  color: var(--ok);
-}
-
-/* Prose emphasis, both inside the advisory Panels and the ExpandableInfo panels. */
-.em { color: var(--acc-ink); }
+/* Prose emphasis inside the ExpandableInfo panels. The knock-advisory banners
+   that used to live in this file (and the sibling .em token they used for
+   their own emphasis) moved into TuneAdvisory.module.css along with the
+   markup — see TuneAdvisory.jsx. */
 .emInk { color: var(--ink); }

--- a/src/ui/screens/tune/SparkScreen.module.css
+++ b/src/ui/screens/tune/SparkScreen.module.css
@@ -20,6 +20,16 @@
     gap: var(--sp-xl);
     align-items: start;
   }
+
+  /* A grid item's automatic minimum size is its content's, not zero, so a wide
+     child could still push this track past the content cap even though the
+     track itself is sized `minmax(0, 1fr)`. The tuning grid carries its own
+     `overflow-x: auto` wrapper, which should already zero that contribution —
+     this makes it unconditional rather than dependent on a descendant's
+     styling two levels down. */
+  .main {
+    min-width: 0;
+  }
 }
 
 .intro {

--- a/src/ui/tokens.css
+++ b/src/ui/tokens.css
@@ -84,5 +84,6 @@
      token — it is recorded here instead. 560px is the project's one
      breakpoint (small-tablet-and-up); it must be kept in sync by hand across
      every file that uses it: src/ui/screens/StartScreen.module.css,
-     src/ui/screens/TutorialScreen.module.css and src/ui/AppShell.module.css. */
+     src/ui/screens/TutorialScreen.module.css, src/ui/AppShell.module.css and
+     src/ui/components/AdvisorPanel.module.css. */
 }

--- a/src/ui/tokens.css
+++ b/src/ui/tokens.css
@@ -84,6 +84,7 @@
      token — it is recorded here instead. 560px is the project's one
      breakpoint (small-tablet-and-up); it must be kept in sync by hand across
      every file that uses it: src/ui/screens/StartScreen.module.css,
-     src/ui/screens/TutorialScreen.module.css, src/ui/AppShell.module.css and
-     src/ui/components/AdvisorPanel.module.css. */
+     src/ui/screens/TutorialScreen.module.css, src/ui/AppShell.module.css,
+     src/ui/components/AdvisorPanel.module.css, src/ui/screens/tune/AirflowScreen.module.css,
+     src/ui/screens/tune/SparkScreen.module.css and src/ui/screens/tune/FuelScreen.module.css. */
 }

--- a/tests/ui/advisor-panel.test.jsx
+++ b/tests/ui/advisor-panel.test.jsx
@@ -15,12 +15,12 @@ describe('AdvisorPanel', () => {
     expect(screen.getByText('3.5 deg past the knock limit')).toBeTruthy();
   });
 
-  it('toggles data-open when the summary is clicked', () => {
+  it('toggles data-open when the toggle is clicked', () => {
     render(<AdvisorPanel headline="h" tone="ok"><p>body</p></AdvisorPanel>);
     const panel = screen.getByTestId('advisor-panel');
-    fireEvent.click(screen.getByRole('button', { name: /advisor/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Show advisor detail' }));
     expect(panel.getAttribute('data-open')).toBe('true');
-    fireEvent.click(screen.getByRole('button', { name: /advisor/i }));
+    fireEvent.click(screen.getByRole('button', { name: 'Hide advisor detail' }));
     expect(panel.getAttribute('data-open')).toBe('false');
   });
 
@@ -28,10 +28,21 @@ describe('AdvisorPanel', () => {
     // #81 is open precisely because BuildSection and ExpandableInfo do NOT do this.
     // A component added after that issue was filed must not repeat the omission.
     render(<AdvisorPanel headline="h" tone="ok"><p>body</p></AdvisorPanel>);
-    const toggle = screen.getByRole('button', { name: /advisor/i });
+    const toggle = screen.getByRole('button', { name: 'Show advisor detail' });
     expect(toggle.getAttribute('aria-expanded')).toBe('false');
     fireEvent.click(toggle);
     expect(toggle.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('changes the toggle accessible name with open state, not just aria-expanded', () => {
+    // Pins the fix for the >=560px lie: a static label would leave aria-expanded
+    // as the only signal, and CSS alone hides the toggle from the a11y tree at
+    // desktop widths anyway — the label itself must track state, not just exist.
+    render(<AdvisorPanel headline="h" tone="ok"><p>body</p></AdvisorPanel>);
+    expect(screen.getByRole('button', { name: 'Show advisor detail' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Show advisor detail' }));
+    expect(screen.getByRole('button', { name: 'Hide advisor detail' })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Show advisor detail' })).toBeNull();
   });
 
   it('carries the tone as an attribute rather than a colour', () => {

--- a/tests/ui/advisor-panel.test.jsx
+++ b/tests/ui/advisor-panel.test.jsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { AdvisorPanel } from '../../src/ui/components/AdvisorPanel.jsx';
+
+afterEach(cleanup);
+
+describe('AdvisorPanel', () => {
+  it('starts collapsed and shows the headline while closed', () => {
+    render(<AdvisorPanel headline="3.5 deg past the knock limit" tone="danger"><p>body</p></AdvisorPanel>);
+    const panel = screen.getByTestId('advisor-panel');
+    expect(panel.getAttribute('data-open')).toBe('false');
+    expect(screen.getByText('3.5 deg past the knock limit')).toBeTruthy();
+  });
+
+  it('toggles data-open when the summary is clicked', () => {
+    render(<AdvisorPanel headline="h" tone="ok"><p>body</p></AdvisorPanel>);
+    const panel = screen.getByTestId('advisor-panel');
+    fireEvent.click(screen.getByRole('button', { name: /advisor/i }));
+    expect(panel.getAttribute('data-open')).toBe('true');
+    fireEvent.click(screen.getByRole('button', { name: /advisor/i }));
+    expect(panel.getAttribute('data-open')).toBe('false');
+  });
+
+  it('reports its open state to a screen reader', () => {
+    // #81 is open precisely because BuildSection and ExpandableInfo do NOT do this.
+    // A component added after that issue was filed must not repeat the omission.
+    render(<AdvisorPanel headline="h" tone="ok"><p>body</p></AdvisorPanel>);
+    const toggle = screen.getByRole('button', { name: /advisor/i });
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('carries the tone as an attribute rather than a colour', () => {
+    render(<AdvisorPanel headline="h" tone="warn"><p>body</p></AdvisorPanel>);
+    expect(screen.getByTestId('advisor-panel').getAttribute('data-tone')).toBe('warn');
+  });
+});

--- a/tests/ui/advisor-reports.test.js
+++ b/tests/ui/advisor-reports.test.js
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { sparkReport } from '../../src/ui/components/advisorReports.js';
+
+/** A spark entry; only the fields the report reads. */
+const cell = (ri, ci, over) => ({
+  ri, ci, rpm: 1000 * (ci + 1), map: 100 + ri * 20,
+  current: over ? 24 : 18, suggested: 18, delta: over ? -6 : 0,
+  mbt: 22, knockCeiling: 20,
+});
+
+/** Assembles a calAdvice whose category arrays genuinely contain the cells named. */
+function advice({ over = [], under = [], past = [] } = {}) {
+  const all = [...over, ...under, ...past];
+  return { spark: all, fuelAdv: [], overAdvanced: over, underAdvanced: under, pastMbt: past, wrongMix: [] };
+}
+
+describe('sparkReport, no selection', () => {
+  it('leads with the knock limit when any cell is past it', () => {
+    const r = sparkReport(advice({ over: [cell(3, 4, true)] }), null);
+    expect(r.state).toBe('table-over');
+    expect(r.tone).toBe('danger');
+    expect(r.headline).toBe('1 cell beyond the knock limit');
+  });
+
+  it('pluralises the headline', () => {
+    const r = sparkReport(advice({ over: [cell(3, 4, true), cell(3, 5, true)] }), null);
+    expect(r.headline).toBe('2 cells beyond the knock limit');
+  });
+
+  it('reports timing left on the table only past the four-cell floor', () => {
+    const four = [cell(0, 0), cell(0, 1), cell(0, 2), cell(0, 3)];
+    expect(sparkReport(advice({ under: four }), null).state).toBe('table-clean');
+    expect(sparkReport(advice({ under: [...four, cell(0, 4)] }), null).state).toBe('table-under');
+  });
+
+  it('ranks the knock limit above every other finding', () => {
+    // A table that is simultaneously over-advanced somewhere and under-advanced
+    // in six places leads with the danger, never with the opportunity.
+    const under = [cell(0, 0), cell(0, 1), cell(0, 2), cell(0, 3), cell(0, 4), cell(0, 5)];
+    const r = sparkReport(advice({ over: [cell(3, 4, true)], under }), null);
+    expect(r.state).toBe('table-over');
+  });
+
+  it('is clean when every category is empty', () => {
+    const r = sparkReport(advice(), null);
+    expect(r.state).toBe('table-clean');
+    expect(r.tone).toBe('ok');
+  });
+});
+
+describe('sparkReport, one cell selected', () => {
+  it('classifies by membership, not by comparing against the ceilings itself', () => {
+    // This cell's own numbers say it is inside both ceilings (current 18 < mbt 22,
+    // < knockCeiling 20). The advisor nonetheless filed it as over-advanced. The
+    // report must follow the advisor, because the advisor is the single source of
+    // truth for what counts as over-advanced — a UI that recomputed the answer is
+    // exactly the disagreement advisors.js warns about.
+    const c = { ...cell(3, 4), current: 18 };
+    const r = sparkReport(advice({ over: [c] }), { type: 'cell', row: 3, col: 4 });
+    expect(r.state).toBe('cell-over');
+    expect(r.tone).toBe('danger');
+  });
+
+  it('names the gap to the ceiling that bound it', () => {
+    const c = { ...cell(3, 4), current: 24, knockCeiling: 20 };
+    const r = sparkReport(advice({ over: [c] }), { type: 'cell', row: 3, col: 4 });
+    expect(r.headline).toBe('4.0 deg past the knock limit');
+    expect(r.detail.cell).toBe(c);
+  });
+
+  it('says a cell the engine never reaches is unreachable, not clean', () => {
+    // calibrationAdvice skips unreachable cells entirely (its rule 2), so the
+    // lookup misses. Reporting that as "inside both ceilings" would tell the
+    // player their 200 kPa cell at 800 RPM is fine, when it simply never happens.
+    const r = sparkReport(advice({ over: [cell(3, 4, true)] }), { type: 'cell', row: 0, col: 0 });
+    expect(r.state).toBe('cell-unreachable');
+    expect(r.tone).toBe('info');
+  });
+
+  it('reports a cell in no category as inside both ceilings', () => {
+    const c = cell(2, 2);
+    const r = sparkReport({ ...advice(), spark: [c] }, { type: 'cell', row: 2, col: 2 });
+    expect(r.state).toBe('cell-ok');
+    expect(r.tone).toBe('ok');
+  });
+});
+
+describe('sparkReport, a row or column selected', () => {
+  it('counts the flagged cells inside the selected row', () => {
+    const r = sparkReport(
+      advice({ over: [cell(3, 1, true), cell(3, 2, true), cell(1, 5, true)] }),
+      { type: 'row', row: 3 },
+    );
+    expect(r.state).toBe('group-over');
+    expect(r.headline).toBe('2 of these cells are past the knock limit');
+  });
+
+  it('counts down the column when a column is selected', () => {
+    const r = sparkReport(
+      advice({ over: [cell(1, 4, true), cell(3, 4, true), cell(3, 0, true)] }),
+      { type: 'col', col: 4 },
+    );
+    expect(r.headline).toBe('2 of these cells are past the knock limit');
+  });
+
+  it('is clean when nothing in the group is flagged', () => {
+    const r = sparkReport(advice({ over: [cell(1, 5, true)] }), { type: 'row', row: 3 });
+    expect(r.state).toBe('group-clean');
+  });
+});

--- a/tests/ui/advisor-reports.test.js
+++ b/tests/ui/advisor-reports.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { OPEN_LOOP_KPA } from '../../src/sim/index.js';
-import { fuelReport, sparkReport } from '../../src/ui/components/advisorReports.js';
+import { fuelReport, sparkReport, veReport } from '../../src/ui/components/advisorReports.js';
 
 /** A spark entry; only the fields the report reads. */
 const cell = (ri, ci, over) => ({
@@ -268,5 +268,100 @@ describe('fuelReport, a row or column selected', () => {
   it('uses singular verb agreement for a single flagged cell', () => {
     const r = fuelReport(fuelAdvice({ wrongMix: [afrCell(3, 1)] }), { type: 'row', row: 3 });
     expect(r.headline).toBe('1 of these cells is off best power');
+  });
+});
+
+/**
+ * A `deltas` entry as `veRecommendations` builds it: `RPM.map((rpm, ci) => ({rpm,
+ * pct, from, to}))`. There is no `ci` field on the object itself — the array's own
+ * index IS the column index, which is the whole reason `veReport` is allowed to
+ * read `deltas[selection.col]` without inventing a lookup.
+ */
+const delta = (rpm, pct, from = 50, to = 50) => ({ rpm, pct, from, to });
+
+describe('veReport, no selection (table-wide)', () => {
+  it('reports sync when veRecommendations found nothing notable', () => {
+    const r = veReport({ inSync: true, recs: [], deltas: [delta(800, 0.4)], maxAbs: 0.4 }, null);
+    expect(r.state).toBe('table-sync');
+    expect(r.tone).toBe('ok');
+    expect(r.headline).toBe('VE matches your hardware');
+  });
+
+  it('reports the max gap when out of sync', () => {
+    const r = veReport({ inSync: false, recs: [], deltas: [delta(800, 12.3)], maxAbs: 12.3 }, null);
+    expect(r.state).toBe('table-stale');
+    expect(r.tone).toBe('warn');
+    expect(r.headline).toBe('VE out of sync — 12% max gap');
+  });
+
+  it('carries the recs through in detail, for the panel to render one per band', () => {
+    const recs = [{ band: 'low-RPM', rpmText: '800–1500 RPM', pct: 12, text: 'Raise the low-RPM cells...', cells: ['800 RPM: 50 -> 56'] }];
+    const r = veReport({ inSync: false, recs, deltas: [delta(800, 12)], maxAbs: 12 }, null);
+    expect(r.detail.recs).toBe(recs);
+  });
+
+  it('returns a no-advice state instead of throwing when veAdvice is null', () => {
+    const r = veReport(null, null);
+    expect(r.state).toBe('no-advice');
+    expect(r.tone).toBe('info');
+    expect(r.headline).toBe('No airflow comparison available for this build yet.');
+  });
+
+  it('returns no-advice even with a selection present — there is nothing to narrow to without veAdvice', () => {
+    const r = veReport(null, { type: 'cell', row: 2, col: 3 });
+    expect(r.state).toBe('no-advice');
+  });
+});
+
+describe('veReport, a cell or column selected', () => {
+  it('reports the COLUMN delta for a cell selection, never a per-cell gap that does not exist', () => {
+    const veAdvice = { inSync: false, recs: [], maxAbs: 20, deltas: [delta(800, 2), delta(1500, 2), delta(2500, 2), delta(3500, 20.4, 60, 72)] };
+    const r = veReport(veAdvice, { type: 'cell', row: 5, col: 3 });
+    expect(r.state).toBe('cell-gap');
+    expect(r.headline).toBe('20% more air here than your table assumes');
+    expect(r.detail).toEqual({ rpm: 3500, from: 60, to: 72, pct: 20.4 });
+  });
+
+  it('reports the same column delta for a column selection', () => {
+    const veAdvice = { inSync: false, recs: [], maxAbs: 20, deltas: [delta(800, 2), delta(1500, 2), delta(2500, 2), delta(3500, 20.4, 60, 72)] };
+    const r = veReport(veAdvice, { type: 'col', col: 3 });
+    expect(r.state).toBe('col-gap');
+    expect(r.headline).toBe('20% more air here than your table assumes');
+  });
+
+  it('says "less" and reports a warn tone for a negative delta', () => {
+    const veAdvice = { inSync: false, recs: [], maxAbs: 15, deltas: [delta(800, -15.4, 60, 50)] };
+    const r = veReport(veAdvice, { type: 'col', col: 0 });
+    expect(r.tone).toBe('warn');
+    expect(r.headline).toBe('15% less air here than your table assumes');
+  });
+
+  it('is ok-toned when the column delta rounds to a 0% display, never claiming a gap that would not show', () => {
+    const veAdvice = { inSync: true, recs: [], maxAbs: 0.4, deltas: [delta(800, 0.4)] };
+    const r = veReport(veAdvice, { type: 'col', col: 0 });
+    expect(r.tone).toBe('ok');
+    expect(r.headline).toBe('0% more air here than your table assumes');
+  });
+
+  it('never indexes deltas by a row — two different rows selected with the same column agree', () => {
+    const veAdvice = { inSync: false, recs: [], maxAbs: 20, deltas: [delta(800, 5), delta(1500, 20, 60, 72)] };
+    const a = veReport(veAdvice, { type: 'cell', row: 0, col: 1 });
+    const b = veReport(veAdvice, { type: 'cell', row: 5, col: 1 });
+    expect(a).toEqual(b);
+  });
+});
+
+describe('veReport, a row selected', () => {
+  it('falls back to the table-wide report — there is no column-scoped number for a whole row', () => {
+    const veAdvice = { inSync: false, recs: [], maxAbs: 33, deltas: [delta(800, 33)] };
+    const r = veReport(veAdvice, { type: 'row', row: 2 });
+    expect(r.state).toBe('table-stale');
+    expect(r.headline).toBe('VE out of sync — 33% max gap');
+  });
+
+  it('falls back to table-sync for a row selection when the table is in sync', () => {
+    const veAdvice = { inSync: true, recs: [], maxAbs: 0.1, deltas: [delta(800, 0.1)] };
+    const r = veReport(veAdvice, { type: 'row', row: 2 });
+    expect(r.state).toBe('table-sync');
   });
 });

--- a/tests/ui/advisor-reports.test.js
+++ b/tests/ui/advisor-reports.test.js
@@ -6,7 +6,7 @@ import { sparkReport } from '../../src/ui/components/advisorReports.js';
 const cell = (ri, ci, over) => ({
   ri, ci, rpm: 1000 * (ci + 1), map: 100 + ri * 20,
   current: over ? 24 : 18, suggested: 18, delta: over ? -6 : 0,
-  mbt: 22, knockCeiling: 20,
+  mbt: 22, knockCeiling: 20, knockLimited: false,
 });
 
 /** Assembles a calAdvice whose category arrays genuinely contain the cells named. */
@@ -47,6 +47,13 @@ describe('sparkReport, no selection', () => {
     expect(r.state).toBe('table-clean');
     expect(r.tone).toBe('ok');
   });
+
+  it('keeps the table-wide fall-through order, which is the reverse', () => {
+    // Under-advanced is checked first table-wide, but only past a four-cell floor,
+    // so a single under-advanced cell loses to any past-MBT cell here.
+    const r = sparkReport(advice({ under: [cell(0, 0)], past: [cell(0, 1)] }), null);
+    expect(r.state).toBe('table-past-mbt');
+  });
 });
 
 describe('sparkReport, one cell selected', () => {
@@ -84,6 +91,29 @@ describe('sparkReport, one cell selected', () => {
     expect(r.state).toBe('cell-ok');
     expect(r.tone).toBe('ok');
   });
+
+  it('names the gap past MBT', () => {
+    const c = { ...cell(2, 2), current: 25, mbt: 22 };
+    const r = sparkReport(advice({ past: [c] }), { type: 'cell', row: 2, col: 2 });
+    expect(r.headline).toBe('3.0 deg past MBT');
+  });
+
+  it('names the gap for a cell past BOTH ceilings, with MBT the lower one', () => {
+    // The exact geometry advisors.js warns about: this cell is detonating, and a
+    // classifier that ordered by which ceiling is lower would file it as merely
+    // wasteful. The existing membership test uses mbt ABOVE knockCeiling, so it
+    // never reproduces this shape.
+    const c = { ...cell(3, 4), current: 26, mbt: 18, knockCeiling: 22, knockLimited: false };
+    const r = sparkReport(advice({ over: [c] }), { type: 'cell', row: 3, col: 4 });
+    expect(r.state).toBe('cell-over');
+    expect(r.headline).toBe('4.0 deg past the knock limit');
+  });
+
+  it('names the gap for an under-advanced cell', () => {
+    const c = { ...cell(1, 1), delta: 5 };
+    const r = sparkReport(advice({ under: [c] }), { type: 'cell', row: 1, col: 1 });
+    expect(r.headline).toBe('5.0 deg below what this build allows');
+  });
 });
 
 describe('sparkReport, a row or column selected', () => {
@@ -107,5 +137,15 @@ describe('sparkReport, a row or column selected', () => {
   it('is clean when nothing in the group is flagged', () => {
     const r = sparkReport(advice({ over: [cell(1, 5, true)] }), { type: 'row', row: 3 });
     expect(r.state).toBe('group-clean');
+  });
+
+  it('puts past-MBT ahead of under-advanced within a band', () => {
+    const r = sparkReport(advice({ under: [cell(3, 0)], past: [cell(3, 1)] }), { type: 'row', row: 3 });
+    expect(r.state).toBe('group-past-mbt');
+  });
+
+  it('uses singular verb agreement for a single flagged cell', () => {
+    const r = sparkReport(advice({ over: [cell(3, 1, true)] }), { type: 'row', row: 3 });
+    expect(r.headline).toBe('1 of these cells is past the knock limit');
   });
 });

--- a/tests/ui/advisor-reports.test.js
+++ b/tests/ui/advisor-reports.test.js
@@ -318,7 +318,7 @@ describe('veReport, a cell or column selected', () => {
     const veAdvice = { inSync: false, recs: [], maxAbs: 20, deltas: [delta(800, 2), delta(1500, 2), delta(2500, 2), delta(3500, 20.4, 60, 72)] };
     const r = veReport(veAdvice, { type: 'cell', row: 5, col: 3 });
     expect(r.state).toBe('cell-gap');
-    expect(r.headline).toBe('20% more air here than your table assumes');
+    expect(r.headline).toBe('20% more air at 3500 RPM than your table assumes');
     expect(r.detail).toEqual({ rpm: 3500, from: 60, to: 72, pct: 20.4 });
   });
 
@@ -326,21 +326,48 @@ describe('veReport, a cell or column selected', () => {
     const veAdvice = { inSync: false, recs: [], maxAbs: 20, deltas: [delta(800, 2), delta(1500, 2), delta(2500, 2), delta(3500, 20.4, 60, 72)] };
     const r = veReport(veAdvice, { type: 'col', col: 3 });
     expect(r.state).toBe('col-gap');
-    expect(r.headline).toBe('20% more air here than your table assumes');
+    expect(r.headline).toBe('20% more air at 3500 RPM than your table assumes');
   });
 
   it('says "less" and reports a warn tone for a negative delta', () => {
     const veAdvice = { inSync: false, recs: [], maxAbs: 15, deltas: [delta(800, -15.4, 60, 50)] };
     const r = veReport(veAdvice, { type: 'col', col: 0 });
     expect(r.tone).toBe('warn');
-    expect(r.headline).toBe('15% less air here than your table assumes');
+    expect(r.headline).toBe('15% less air at 800 RPM than your table assumes');
   });
 
-  it('is ok-toned when the column delta rounds to a 0% display, never claiming a gap that would not show', () => {
+  // The Critical regression test: veRecommendations' own VE_NOTABLE_PCT (2.5)
+  // is the threshold, not a UI-invented one. A pct of 0.4 rounds to a 0%
+  // display either way, but the point of this test is that the boundary is
+  // 2.5, not 0.5 — proven by the sibling test below at pct 1 (also under 2.5,
+  // and nowhere near rounding to 0% on its own).
+  it('is sync-toned when the column delta rounds to a 0% display, never claiming a gap that would not show', () => {
     const veAdvice = { inSync: true, recs: [], maxAbs: 0.4, deltas: [delta(800, 0.4)] };
     const r = veReport(veAdvice, { type: 'col', col: 0 });
+    expect(r.state).toBe('col-sync');
     expect(r.tone).toBe('ok');
-    expect(r.headline).toBe('0% more air here than your table assumes');
+    expect(r.headline).toBe('Matches your hardware at 800 RPM');
+  });
+
+  // The Critical's exact regression shape: a pct between 0.5 and 2.5 (here,
+  // -0.87 — the real default build's 800 RPM column) must be 'ok'/'col-sync',
+  // never the 'warn'/'col-gap' a 0.5%-ish threshold would have produced.
+  it('is ok/col-sync for a delta between 0.5 and 2.5, below VE_NOTABLE_PCT', () => {
+    const veAdvice = { inSync: true, recs: [], maxAbs: 0.87, deltas: [delta(800, -0.87, 60, 59.5)] };
+    const r = veReport(veAdvice, { type: 'col', col: 0 });
+    expect(r.state).toBe('col-sync');
+    expect(r.tone).toBe('ok');
+  });
+
+  // Finding 2's regression: pct === 0 must not hit the ungrammatical
+  // "0% less air" — it has to land in col-sync, whose headline has no
+  // more/less word to get wrong.
+  it('routes pct exactly 0 into col-sync, not a "0% less" headline', () => {
+    const veAdvice = { inSync: true, recs: [], maxAbs: 0, deltas: [delta(4500, 0, 60, 60)] };
+    const r = veReport(veAdvice, { type: 'col', col: 0 });
+    expect(r.state).toBe('col-sync');
+    expect(r.tone).toBe('ok');
+    expect(r.headline).toBe('Matches your hardware at 4500 RPM');
   });
 
   it('never indexes deltas by a row — two different rows selected with the same column agree', () => {
@@ -349,19 +376,30 @@ describe('veReport, a cell or column selected', () => {
     const b = veReport(veAdvice, { type: 'cell', row: 5, col: 1 });
     expect(a).toEqual(b);
   });
+
+  it('falls through to the table-wide report when deltas is missing entirely', () => {
+    const veAdvice = { inSync: false, recs: [], maxAbs: 33 };
+    const r = veReport(veAdvice, { type: 'col', col: 0 });
+    expect(r.state).toBe('table-stale');
+  });
 });
 
 describe('veReport, a row selected', () => {
-  it('falls back to the table-wide report — there is no column-scoped number for a whole row', () => {
+  // Finding 4: a row selection must never fall through to table-stale, whose
+  // body carries the whole-table ACCEPT RE-LOGGED VALUES button — a row
+  // selection has no column-scoped answer, so it gets its own state instead,
+  // with no accept button.
+  it('reports group-ve for a row selection instead of falling back to the table-wide report', () => {
     const veAdvice = { inSync: false, recs: [], maxAbs: 33, deltas: [delta(800, 33)] };
     const r = veReport(veAdvice, { type: 'row', row: 2 });
-    expect(r.state).toBe('table-stale');
-    expect(r.headline).toBe('VE out of sync — 33% max gap');
+    expect(r.state).toBe('group-ve');
+    expect(r.tone).toBe('info');
+    expect(r.headline).toBe('VE is measured per RPM column');
   });
 
-  it('falls back to table-sync for a row selection when the table is in sync', () => {
+  it('reports group-ve for a row selection even when the table is in sync', () => {
     const veAdvice = { inSync: true, recs: [], maxAbs: 0.1, deltas: [delta(800, 0.1)] };
     const r = veReport(veAdvice, { type: 'row', row: 2 });
-    expect(r.state).toBe('table-sync');
+    expect(r.state).toBe('group-ve');
   });
 });

--- a/tests/ui/advisor-reports.test.js
+++ b/tests/ui/advisor-reports.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { sparkReport } from '../../src/ui/components/advisorReports.js';
+import { OPEN_LOOP_KPA } from '../../src/sim/index.js';
+import { fuelReport, sparkReport } from '../../src/ui/components/advisorReports.js';
 
 /** A spark entry; only the fields the report reads. */
 const cell = (ri, ci, over) => ({
@@ -13,6 +14,22 @@ const cell = (ri, ci, over) => ({
 function advice({ over = [], under = [], past = [] } = {}) {
   const all = [...over, ...under, ...past];
   return { spark: all, fuelAdv: [], overAdvanced: over, underAdvanced: under, pastMbt: past, wrongMix: [] };
+}
+
+/**
+ * A fuelAdv entry; only the fields `fuelReport` reads. `map` defaults well
+ * above `OPEN_LOOP_KPA` (open loop, mixture advice applies); `delta` defaults
+ * negative (suggested is richer than current, i.e. the cell is lean).
+ */
+const afrCell = (ri, ci, { map = OPEN_LOOP_KPA + 10, delta = -0.8 } = {}) => ({
+  ri, ci, rpm: 1000 * (ci + 1), map,
+  current: 12.5, suggested: Number((12.5 + delta).toFixed(2)), delta,
+  delivered: 12.3, target: 12.0, duty: 50,
+});
+
+/** Assembles a calAdvice whose fuel arrays genuinely contain the cells named. */
+function fuelAdvice({ fuelAdv = [], wrongMix = [] } = {}) {
+  return { spark: [], overAdvanced: [], underAdvanced: [], pastMbt: [], fuelAdv, wrongMix };
 }
 
 describe('sparkReport, no selection', () => {
@@ -147,5 +164,109 @@ describe('sparkReport, a row or column selected', () => {
   it('uses singular verb agreement for a single flagged cell', () => {
     const r = sparkReport(advice({ over: [cell(3, 1, true)] }), { type: 'row', row: 3 });
     expect(r.headline).toBe('1 of these cells is past the knock limit');
+  });
+});
+
+describe('fuelReport, no selection', () => {
+  it('flags high-load cells off best power', () => {
+    const r = fuelReport(fuelAdvice({ wrongMix: [afrCell(3, 4)] }), null);
+    expect(r.state).toBe('table-off');
+    expect(r.tone).toBe('warn');
+    expect(r.headline).toBe('1 high-load cell off best power');
+  });
+
+  it('pluralises the headline', () => {
+    const r = fuelReport(fuelAdvice({ wrongMix: [afrCell(3, 4), afrCell(3, 5)] }), null);
+    expect(r.headline).toBe('2 high-load cells off best power');
+  });
+
+  it('is clean when wrongMix is empty', () => {
+    const r = fuelReport(fuelAdvice(), null);
+    expect(r.state).toBe('table-clean');
+    expect(r.tone).toBe('ok');
+    expect(r.headline).toBe('High-load mixture is on best power');
+  });
+});
+
+describe('fuelReport, one cell selected', () => {
+  it('classifies by membership in wrongMix, not by comparing delta itself', () => {
+    // This cell's own delta (0.1) is well under MIX_NOTABLE_AFR and would never
+    // land in wrongMix if the report recomputed the threshold itself. The
+    // advisor nonetheless filed it as off-target — the report must follow that,
+    // the same membership rule sparkReport pins.
+    const c = afrCell(3, 4, { delta: 0.1 });
+    const r = fuelReport(fuelAdvice({ fuelAdv: [c], wrongMix: [c] }), { type: 'cell', row: 3, col: 4 });
+    expect(r.state).toBe('cell-off');
+    expect(r.tone).toBe('warn');
+  });
+
+  it('names a negative delta as lean of best power — the suggestion is richer, so the cell is lean', () => {
+    const c = afrCell(3, 4, { delta: -0.8 });
+    const r = fuelReport(fuelAdvice({ fuelAdv: [c], wrongMix: [c] }), { type: 'cell', row: 3, col: 4 });
+    expect(r.headline).toBe('0.8 AFR lean of best power');
+  });
+
+  it('names a positive delta as rich of best power — the suggestion is leaner, so the cell is rich', () => {
+    const c = afrCell(3, 4, { delta: 0.8 });
+    const r = fuelReport(fuelAdvice({ fuelAdv: [c], wrongMix: [c] }), { type: 'cell', row: 3, col: 4 });
+    expect(r.headline).toBe('0.8 AFR rich of best power');
+  });
+
+  it('reports closed loop even when the cell has a large delta', () => {
+    // Below OPEN_LOOP_KPA the trims own the cell — this is deliberately
+    // fabricated with both a huge delta AND wrongMix membership, to prove the
+    // closed-loop check binds first and unconditionally, not because a real
+    // wrongMix could ever contain a sub-OPEN_LOOP_KPA cell (calibrationAdvice's
+    // own filter would never put one there).
+    const c = afrCell(3, 4, { map: OPEN_LOOP_KPA - 5, delta: -5 });
+    const r = fuelReport(fuelAdvice({ fuelAdv: [c], wrongMix: [c] }), { type: 'cell', row: 3, col: 4 });
+    expect(r.state).toBe('cell-closed-loop');
+    expect(r.tone).toBe('info');
+    expect(r.headline).toBe('Closed loop — the trims own this cell');
+  });
+
+  it('says a cell the engine never reaches is unreachable, not on target', () => {
+    const c = afrCell(3, 4);
+    const r = fuelReport(fuelAdvice({ fuelAdv: [c], wrongMix: [c] }), { type: 'cell', row: 0, col: 0 });
+    expect(r.state).toBe('cell-unreachable');
+    expect(r.tone).toBe('info');
+  });
+
+  it('reports an open-loop cell not in wrongMix as on target', () => {
+    const c = afrCell(2, 2);
+    const r = fuelReport(fuelAdvice({ fuelAdv: [c] }), { type: 'cell', row: 2, col: 2 });
+    expect(r.state).toBe('cell-ok');
+    expect(r.tone).toBe('ok');
+    expect(r.headline).toBe('On best power');
+  });
+});
+
+describe('fuelReport, a row or column selected', () => {
+  it('counts the flagged cells inside the selected row', () => {
+    const r = fuelReport(
+      fuelAdvice({ wrongMix: [afrCell(3, 1), afrCell(3, 2), afrCell(1, 5)] }),
+      { type: 'row', row: 3 },
+    );
+    expect(r.state).toBe('group-off');
+    expect(r.headline).toBe('2 of these cells are off best power');
+  });
+
+  it('counts down the column when a column is selected', () => {
+    const r = fuelReport(
+      fuelAdvice({ wrongMix: [afrCell(1, 4), afrCell(3, 4), afrCell(3, 0)] }),
+      { type: 'col', col: 4 },
+    );
+    expect(r.headline).toBe('2 of these cells are off best power');
+  });
+
+  it('is clean when nothing in the group is flagged', () => {
+    const r = fuelReport(fuelAdvice({ wrongMix: [afrCell(1, 5)] }), { type: 'row', row: 3 });
+    expect(r.state).toBe('group-clean');
+    expect(r.tone).toBe('ok');
+  });
+
+  it('uses singular verb agreement for a single flagged cell', () => {
+    const r = fuelReport(fuelAdvice({ wrongMix: [afrCell(3, 1)] }), { type: 'row', row: 3 });
+    expect(r.headline).toBe('1 of these cells is off best power');
   });
 });

--- a/tests/ui/tune-screens.test.jsx
+++ b/tests/ui/tune-screens.test.jsx
@@ -74,10 +74,12 @@ function OctaneProbe({ index }) {
   );
 }
 
-// A blank calAdvice — none of the four advisory arrays trip — so SparkScreen and
+// A blank calAdvice — none of the six advisory arrays trip — so SparkScreen and
 // FuelScreen tests that are not exercising the advisory itself land on each
 // screen's quiet default state instead of tripping over unrelated fixture noise.
-const QUIET_CAL_ADVICE = { overAdvanced: [], underAdvanced: [], pastMbt: [], wrongMix: [] };
+// `spark` and `fuelAdv` are here too, matching the real shape `calibrationAdvice`
+// returns, since `sparkReport` and `fuelReport` (added in later tasks) read them.
+const QUIET_CAL_ADVICE = { overAdvanced: [], underAdvanced: [], pastMbt: [], wrongMix: [], spark: [], fuelAdv: [] };
 
 describe('AirflowScreen', () => {
   it('mounts the shared TuningGrid and SelectionDock with their test ids intact', () => {
@@ -116,6 +118,11 @@ describe('AirflowScreen', () => {
     const cells = within(grid).getAllByRole('button').filter((b) => b.textContent === '77');
     expect(cells).toHaveLength(48);
   });
+
+  it('mounts exactly one advisor panel', () => {
+    mount(<AirflowScreen veAdvice={null} veTruth={[]} />);
+    expect(screen.getAllByTestId('advisor-panel')).toHaveLength(1);
+  });
 });
 
 describe('SparkScreen', () => {
@@ -140,6 +147,11 @@ describe('SparkScreen', () => {
     mount(<SparkScreen calAdvice={QUIET_CAL_ADVICE} />);
     expect(screen.getByText('Spark table sits within the knock limit for this hardware.')).toBeTruthy();
   });
+
+  it('mounts exactly one advisor panel', () => {
+    mount(<SparkScreen calAdvice={QUIET_CAL_ADVICE} />);
+    expect(screen.getAllByTestId('advisor-panel')).toHaveLength(1);
+  });
 });
 
 describe('FuelScreen', () => {
@@ -158,6 +170,11 @@ describe('FuelScreen', () => {
     mount(<FuelScreen calAdvice={calAdvice} />);
     expect(screen.getByText('1 HIGH-LOAD CELLS OFF BEST POWER')).toBeTruthy();
     expect(screen.getByText(/888 kPa \/ 7777 RPM: 12\.3:1 → 11\.1:1 \(richen\) · delivered 99, wants 88/)).toBeTruthy();
+  });
+
+  it('mounts exactly one advisor panel', () => {
+    mount(<FuelScreen calAdvice={QUIET_CAL_ADVICE} />);
+    expect(screen.getAllByTestId('advisor-panel')).toHaveLength(1);
   });
 });
 

--- a/tests/ui/tune-screens.test.jsx
+++ b/tests/ui/tune-screens.test.jsx
@@ -117,8 +117,11 @@ describe('AirflowScreen', () => {
       recs: [{ rpmText: 'FABRICATED 9999 RPM', text: 'fabricated advisory text', cells: ['9999@1 -> 2'] }],
     };
     mount(<AirflowScreen veAdvice={veAdvice} veTruth={[]} />);
-    expect(screen.getByText('42% max gap')).toBeTruthy();
-    expect(screen.getByText('FABRICATED 9999 RPM')).toBeTruthy();
+    const panel = within(screen.getByTestId('advisor-panel'));
+    // maxAbs is folded into the panel headline now (veReport's table-stale
+    // state), not a standalone '42% max gap' string.
+    expect(panel.getByText('VE out of sync — 42% max gap')).toBeTruthy();
+    expect(panel.getByText('FABRICATED 9999 RPM')).toBeTruthy();
   });
 
   it('writes the shell-computed veTruth into the store on ACCEPT RE-LOGGED VALUES, not one it derived itself', () => {
@@ -132,6 +135,50 @@ describe('AirflowScreen', () => {
     const grid = screen.getByTestId('tuning-grid');
     const cells = within(grid).getAllByRole('button').filter((b) => b.textContent === '77');
     expect(cells).toHaveLength(48);
+  });
+
+  it('narrows to the selected column rather than the whole table', () => {
+    // deltas[3] is the only column-scoped number veReport is allowed to read
+    // for a cell/col selection — arbitrary index, veReport looks it up by
+    // selection.col, it never touches TuningGrid's real geometry.
+    const veAdvice = {
+      inSync: false,
+      maxAbs: 42.3,
+      recs: [{ rpmText: 'FABRICATED 9999 RPM', text: 'fabricated advisory text', cells: ['9999@1 -> 2'] }],
+      deltas: [
+        { rpm: 800, pct: 0, from: 50, to: 50 },
+        { rpm: 1500, pct: 0, from: 50, to: 50 },
+        { rpm: 2500, pct: 0, from: 50, to: 50 },
+        { rpm: 3500, pct: 18.2, from: 60, to: 71 },
+      ],
+    };
+    mount(<><SelectionProbe value={{ type: 'col', col: 3 }} /><AirflowScreen veAdvice={veAdvice} veTruth={[]} /></>);
+    const panel = within(screen.getByTestId('advisor-panel'));
+    expect(panel.queryByText('VE out of sync — 42% max gap')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'probe-set-selection' }));
+
+    // The table-wide headline is gone; the panel now reports THIS column's
+    // measured gap instead, and says plainly it belongs to the column.
+    expect(panel.queryByText('VE out of sync — 42% max gap')).toBeNull();
+    expect(panel.getByText('18% more air here than your table assumes')).toBeTruthy();
+    expect(panel.getByText(/This gap belongs to the RPM column, not to this one cell\./)).toBeTruthy();
+  });
+
+  it('falls back to the table-wide report for a row selection — there is no column-scoped number for a row', () => {
+    const veAdvice = { inSync: false, maxAbs: 42.3, recs: [], deltas: [{ rpm: 800, pct: 18.2, from: 60, to: 71 }] };
+    mount(<><SelectionProbe value={{ type: 'row', row: 1 }} /><AirflowScreen veAdvice={veAdvice} veTruth={[]} /></>);
+    fireEvent.click(screen.getByRole('button', { name: 'probe-set-selection' }));
+    const panel = within(screen.getByTestId('advisor-panel'));
+    expect(panel.getByText('VE out of sync — 42% max gap')).toBeTruthy();
+  });
+
+  it('shows a no-advice state instead of throwing when veAdvice is null, and keeps the panel mounted', () => {
+    mount(<AirflowScreen veAdvice={null} veTruth={[]} />);
+    const panel = within(screen.getByTestId('advisor-panel'));
+    // The brief gives one string for this state, used as both the collapsed
+    // headline and the expanded body, so it legitimately appears twice.
+    expect(panel.getAllByText('No airflow comparison available for this build yet.')).toHaveLength(2);
   });
 
   it('mounts exactly one advisor panel', () => {

--- a/tests/ui/tune-screens.test.jsx
+++ b/tests/ui/tune-screens.test.jsx
@@ -161,16 +161,22 @@ describe('AirflowScreen', () => {
     // The table-wide headline is gone; the panel now reports THIS column's
     // measured gap instead, and says plainly it belongs to the column.
     expect(panel.queryByText('VE out of sync — 42% max gap')).toBeNull();
-    expect(panel.getByText('18% more air here than your table assumes')).toBeTruthy();
+    expect(panel.getByText('18% more air at 3500 RPM than your table assumes')).toBeTruthy();
     expect(panel.getByText(/This gap belongs to the RPM column, not to this one cell\./)).toBeTruthy();
   });
 
-  it('falls back to the table-wide report for a row selection — there is no column-scoped number for a row', () => {
+  it('reports group-ve for a row selection, with no whole-table accept button — there is no column-scoped number for a row', () => {
+    // Finding 4: a row selection used to fall through to table-stale, whose
+    // body renders ACCEPT RE-LOGGED VALUES — a button that writes every row,
+    // not just the one selected. A row selection now gets its own state
+    // instead, and that button must not appear.
     const veAdvice = { inSync: false, maxAbs: 42.3, recs: [], deltas: [{ rpm: 800, pct: 18.2, from: 60, to: 71 }] };
     mount(<><SelectionProbe value={{ type: 'row', row: 1 }} /><AirflowScreen veAdvice={veAdvice} veTruth={[]} /></>);
     fireEvent.click(screen.getByRole('button', { name: 'probe-set-selection' }));
     const panel = within(screen.getByTestId('advisor-panel'));
-    expect(panel.getByText('VE out of sync — 42% max gap')).toBeTruthy();
+    expect(panel.getByText('VE is measured per RPM column')).toBeTruthy();
+    expect(panel.queryByText('VE out of sync — 42% max gap')).toBeNull();
+    expect(panel.queryByRole('button', { name: 'ACCEPT RE-LOGGED VALUES' })).toBeNull();
   });
 
   it('shows a no-advice state instead of throwing when veAdvice is null, and keeps the panel mounted', () => {

--- a/tests/ui/tune-screens.test.jsx
+++ b/tests/ui/tune-screens.test.jsx
@@ -208,8 +208,32 @@ describe('FuelScreen', () => {
       wrongMix: [{ map: 888, rpm: 7777, current: 12.3, suggested: 11.1, delta: -1, delivered: 99, target: 88 }],
     };
     mount(<FuelScreen calAdvice={calAdvice} />);
-    expect(screen.getByText('1 HIGH-LOAD CELLS OFF BEST POWER')).toBeTruthy();
-    expect(screen.getByText(/888 kPa \/ 7777 RPM: 12\.3:1 → 11\.1:1 \(richen\) · delivered 99, wants 88/)).toBeTruthy();
+    const panel = within(screen.getByTestId('advisor-panel'));
+    // Singular — the pre-panel banner always read '1 HIGH-LOAD CELLS OFF BEST
+    // POWER', a latent copy bug the plural helper in `fuelReport` fixes.
+    expect(panel.getByText('1 high-load cell off best power')).toBeTruthy();
+    expect(panel.getByText(/888 kPa \/ 7777 RPM: 12\.3:1 → 11\.1:1 \(richen\) · delivered 99, wants 88/)).toBeTruthy();
+  });
+
+  it('narrows to the selected cell rather than the whole table', () => {
+    // ri/ci 2,3 is arbitrary — fuelReport looks the cell up by coordinate, it
+    // never touches TuningGrid's real geometry, so any pair works here.
+    const calAdvice = {
+      overAdvanced: [], underAdvanced: [], pastMbt: [],
+      wrongMix: [{ ri: 2, ci: 3, map: 999, rpm: 9999, current: 12.3, suggested: 11.1, delta: -1.2, delivered: 99, target: 88 }],
+      fuelAdv: [{
+        ri: 2, ci: 3, map: 999, rpm: 9999, current: 12.3, suggested: 11.1, delta: -1.2, delivered: 99, target: 88,
+      }],
+    };
+    mount(<><SelectionProbe value={{ type: 'cell', row: 2, col: 3 }} /><FuelScreen calAdvice={calAdvice} /></>);
+    const panel = within(screen.getByTestId('advisor-panel'));
+    expect(panel.getByText('1 high-load cell off best power')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'probe-set-selection' }));
+
+    // The table count is gone; the panel now reports THIS cell instead.
+    expect(panel.queryByText('1 high-load cell off best power')).toBeNull();
+    expect(panel.getByText('1.2 AFR lean of best power')).toBeTruthy();
   });
 
   it('mounts exactly one advisor panel', () => {

--- a/tests/ui/tune-screens.test.jsx
+++ b/tests/ui/tune-screens.test.jsx
@@ -30,7 +30,7 @@ import { InjectorsScreen } from '../../src/ui/screens/tune/InjectorsScreen.jsx';
 import { SensorsScreen } from '../../src/ui/screens/tune/SensorsScreen.jsx';
 import { SparkScreen } from '../../src/ui/screens/tune/SparkScreen.jsx';
 import { ACTIONS } from '../../src/ui/state/reducer.js';
-import { StoreProvider, useBuild } from '../../src/ui/state/StoreProvider.jsx';
+import { StoreProvider, useBuild, useTune } from '../../src/ui/state/StoreProvider.jsx';
 
 // jsdom has no ResizeObserver, and EcuScreen's FUEL TRIM panel mounts recharts'
 // <ResponsiveContainer> once a result exists, which throws without one. Same stub
@@ -70,6 +70,21 @@ function OctaneProbe({ index }) {
   return (
     <button onClick={() => dispatch({ type: ACTIONS.SET_BUILD_FIELD, field: 'octaneIdx', value: index })}>
       probe-set-octane
+    </button>
+  );
+}
+
+/**
+ * Dispatches `SET_TUNE_FIELD` for `selection` against whatever store it is
+ * mounted under — same pattern as `OctaneProbe` above, standing in for a
+ * `TuningGrid` click so the advisor panel's selection-scoped path can be
+ * exercised without needing real grid geometry.
+ */
+function SelectionProbe({ value }) {
+  const [, dispatch] = useTune();
+  return (
+    <button onClick={() => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value })}>
+      probe-set-selection
     </button>
   );
 }
@@ -139,13 +154,38 @@ describe('SparkScreen', () => {
       underAdvanced: [], pastMbt: [], wrongMix: [],
     };
     mount(<SparkScreen calAdvice={calAdvice} />);
-    expect(screen.getByText('1 CELLS BEYOND THE KNOCK LIMIT')).toBeTruthy();
-    expect(screen.getByText(/999 kPa \/ 9999 RPM: 11° → 22°/)).toBeTruthy();
+    const panel = within(screen.getByTestId('advisor-panel'));
+    // Singular — the pre-panel banner read '1 CELLS BEYOND THE KNOCK LIMIT',
+    // a latent copy bug the plural helper in `sparkReport` fixes.
+    expect(panel.getByText('1 cell beyond the knock limit')).toBeTruthy();
+    expect(panel.getByText(/999 kPa \/ 9999 RPM: 11° → 22°/)).toBeTruthy();
   });
 
   it('falls through the danger/under-advanced/past-MBT states to the clean-table message when every advisory is empty', () => {
     mount(<SparkScreen calAdvice={QUIET_CAL_ADVICE} />);
-    expect(screen.getByText('Spark table sits within the knock limit for this hardware.')).toBeTruthy();
+    const panel = within(screen.getByTestId('advisor-panel'));
+    expect(panel.getByText('Spark table sits within the knock limit for this hardware.')).toBeTruthy();
+  });
+
+  it('narrows to the selected cell rather than the whole table', () => {
+    // ri/ci 2,3 is arbitrary — sparkReport looks the cell up by coordinate, it
+    // never touches TuningGrid's real geometry, so any pair works here.
+    const calAdvice = {
+      overAdvanced: [{ ri: 2, ci: 3, map: 999, rpm: 9999, current: 30, suggested: 22 }],
+      underAdvanced: [], pastMbt: [], wrongMix: [],
+      spark: [{
+        ri: 2, ci: 3, map: 999, rpm: 9999, current: 30, suggested: 22, knockCeiling: 25, mbt: 20, delta: -8,
+      }],
+    };
+    mount(<><SelectionProbe value={{ type: 'cell', row: 2, col: 3 }} /><SparkScreen calAdvice={calAdvice} /></>);
+    const panel = within(screen.getByTestId('advisor-panel'));
+    expect(panel.getByText('1 cell beyond the knock limit')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'probe-set-selection' }));
+
+    // The table count is gone; the panel now reports THIS cell instead.
+    expect(panel.queryByText('1 cell beyond the knock limit')).toBeNull();
+    expect(panel.getByText('5.0 deg past the knock limit')).toBeTruthy();
   });
 
   it('mounts exactly one advisor panel', () => {


### PR DESCRIPTION
Closes #85.

TUNE's three grid screens each rendered their own inline advisory banner below the editing grid. This replaces all three with one contextual advisor panel that reports on whatever the player currently has selected — a right-hand rail above 560px, a tap-to-open disclosure below it.

## The rule this is built on

**An advisor reports the gap; it never closes it.** The panel says what an edit *means* — this cell is past the knock limit, this column flows more air than your table assumes — without predicting a result or offering a fix-it button. Only a dyno pull measures anything in this app, so a panel that predicted an outcome would be inventing a number the simulation never produced.

The one sanctioned exception is `ACCEPT RE-LOGGED VALUES` on the VE table, because VE is a *measurement of the hardware* rather than a calibration judgement. It survives, and there is now a test pinning that it does **not** appear when a single row is selected — see below.

The second rule, which is where the bugs were: **the UI never re-derives a threshold the sim already owns.** Every cell's category is looked up by membership in `calibrationAdvice`'s own output arrays, matched on `ri`/`ci`. `advisors.js` explains why: a cell past *both* ceilings with MBT the lower one is detonating, not merely wasteful, and ordering by which ceiling is lower would report it as safe. That is the false alarm #34 removed.

## What moved

| screen | advisory | now |
|---|---|---|
| SPARK | four-state knock fall-through | panel, `sparkReport` |
| FUEL | wrong-mixture banner | panel, `fuelReport` |
| AIRFLOW | VE sync / stale + ACCEPT button | panel, `veReport` |

Each screen keeps its grid, intro and explainers; the banners are gone from the screen bodies. New files: `AdvisorPanel.jsx` (chrome only), `advisorReports.js` (pure classification, no React), `TuneAdvisory.jsx` (prose).

## Genuinely new content

- **Selection-scoped reports** — cell, row and column, per screen. Previously every advisory was table-wide.
- **FUEL has a clean state.** Its banner simply did not render when nothing was wrong; a panel that goes blank reads as broken.
- **An unreachable-cell state.** `calibrationAdvice` skips cells the engine cannot reach, so a lookup can legitimately miss. Reporting that as "clean" would tell a player their 200 kPa / 800 RPM cell is fine when it simply never happens.

## Two `src/sim` exports

```
-const OPEN_LOOP_KPA = 85;          +export const OPEN_LOOP_KPA = 85;
-const VE_NOTABLE_PCT = 2.5;        +export const VE_NOTABLE_PCT = 2.5;
```

Two bare keywords, no value changes — the whole `src/sim` diff is `2 insertions, 2 deletions`. Both exist so the UI can use the sim's own number instead of copying a physics threshold that would drift. Without `OPEN_LOOP_KPA` the panel cannot tell a closed-loop cell from an on-target one, since both are simply absent from `wrongMix`. `VE_NOTABLE_PCT` is the fix for the Critical below.

Adding an export cannot move the fingerprint by construction: `buildFingerprint`'s `constants` section is an explicit list, not an enumeration of the module's exports.

## The Critical the final review caught

`veReport` re-derived its own threshold — effectively 0.5% — where `veRecommendations` uses `VE_NOTABLE_PCT = 2.5` for the same question. Verified against the real default state (`inSync: true`, `maxAbs: 0.87`), a **brand-new game** showed:

- nothing selected → green, "VE matches your hardware"
- tap any 800 RPM cell → amber, "1% less air here than your table assumes"

The table-level and cell-level advisors contradicting each other on an untouched table, arriving by exactly the route the rule above exists to block. Three related Importants came with it, all in the same function: `"0% less air"` at exactly zero (the default for 4500–7500 RPM, and below 560px that string is the *entire* panel); a headline saying "here" for a number that belongs to the RPM column rather than the selected cell; and a **row** selection falling through to the table-wide state, which put `ACCEPT RE-LOGGED VALUES` — a write to all six rows — inside a panel presenting itself as row-scoped.

All fixed in `6d14c6b`, each with a regression test.

## Verification

- **855 tests / 31 files**, lint, typecheck and build clean. Rebased onto `734cb83` (#65, the NA power-peak change) and the whole suite re-run afterwards — a pre-rebase green says nothing once the physics has moved.
- **`tests/ui/characterisation.test.jsx` is byte-identical to `main`.** This PR moves content between components without changing what the app does.
- **AST string sweep across all of `src/ui`** (44 files/878 strings on main vs 47/943 on HEAD), parsed with Babel rather than grepped. Exactly four strings absent, all the same deliberate change: each advisory's bold count label is now the panel's always-visible headline, so the fact appears once with correct grammar instead of twice with two wordings.
- **Break-proofs.** Every classification rule was verified by mutation: stubbing the membership lookup fails 8 tests; inverting the AFR lean/rich direction fails 2; removing the closed-loop guard fails 1; reverting the VE threshold fails its regression test; disabling the row branch fails 3, including the one asserting the ACCEPT button is absent.

## What is not covered

**No test can see a colour here.** vitest applies no CSS in this repo, so nothing distinguishes a working `.ok` class from a deleted one. That gap is real and it bit during this PR: SPARK's all-clear message silently lost its green in a commit that was supposed to move markup verbatim, and passed CI, lint and a self-audit before a reviewer caught it. Every all-clear state now carries `.ok` explicitly.

**Nobody has opened this in a browser.** The two-column layout between 560px and ~700px — where a 452px grid and a 280px rail share the width — is the most likely thing to look wrong.

## Follow-ups, not fixed here

- A wholly unreachable row reports green "Nothing flagged in this band" on SPARK/FUEL while every cell inside it says "Never reached by this build".
- `fuelReport` never uses the `danger` tone, so red means danger on SPARK and does not exist on FUEL. Fixing it properly needs a severity array in `src/sim`.
- The panel has no `aria-live`, so above 560px a screen-reader user gets no announcement when changing the selection changes the panel — which is the panel's entire purpose. Belongs with #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QXHAjTu429hwKhLLSRfTCd
