### PR TITLE
Release v1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ecu-lab",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ecu-lab",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "lucide-react": "^0.460.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecu-lab",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "An engine management and tuning simulator. Design an engine, edit the same three calibration tables a real tuner edits, run a dyno pull, and read a log that explains what went right or wrong.",
   "keywords": [
     "engine",

--- a/src/version.js
+++ b/src/version.js
@@ -5,4 +5,4 @@
  * GENERATED — do not edit by hand. Run `npm version <patch|minor|major>`, which
  * rewrites this file from package.json via scripts/sync-version.js.
  */
-export const BUILD_VERSION = 'v1.5.0';
+export const BUILD_VERSION = 'v1.6.0';


### PR DESCRIPTION
Version bump for **v1.6.0** — 109 commits since `v1.5.0`.

The diff is only the bump: `package.json`, `package-lock.json`, and the generated `src/version.js` (`BUILD_VERSION = 'v1.6.0'`, written by `scripts/sync-version.js` via npm's `version` hook).

Merging this publishes nothing. The `v1.6.0` tag pushed onto the merge commit is what deploys.

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLbnoKSF6YYhuDitnE266c