### PR TITLE
Undo/redo for calibration edits (#60, PR 4a of 3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,6 @@ Roughly in order of value to the project:
 - `resetToStock` resets about a third of what its label claims.
 - Bolt-ons can be installed but never uninstalled, which blocks the app's own
   "change one thing, measure, revert" method.
-- No undo/redo on table edits.
 
 **Features**
 

--- a/docs/superpowers/plans/2026-08-25-tune-undo-redo.md
+++ b/docs/superpowers/plans/2026-08-25-tune-undo-redo.md
@@ -32,7 +32,7 @@
 | `src/ui/state/reducer.js` | Existing `reducer` renamed to `baseReducer`; new `reducer` wrapper records history and handles `UNDO`/`REDO`. Owns `labelFor()`, because that needs `ACTIONS` and `presetById`. |
 | `src/ui/state/initialState.js` | Adds the `history` slice and its typedef. |
 | `src/ui/state/StoreProvider.jsx` | Adds `useHistory()` beside the three existing slice hooks. |
-| `src/ui/components/UndoControls.jsx` + `.module.css` **(new)** | The ↶ ↷ pair. Reads `history`, dispatches `UNDO`/`REDO`. `React.memo`'d. |
+| `src/ui/components/UndoControls.jsx` + `.module.css` **(new)** | The ↶ ↷ pair. Reads `history`, dispatches `UNDO`/`REDO`. |
 | `src/ui/components/SelectionDock.jsx` | Slider becomes commit-on-release. |
 | `src/ui/screens/tune/{Airflow,Spark,Fuel}Screen.jsx` + `.module.css` | Mount `UndoControls` in a `.gridHead` row beside the `Eyebrow`. |
 | `src/ui/screens/build/EngineScreen.jsx` + `.module.css` | The post-preset/post-reset UNDO `Note`. |
@@ -665,10 +665,12 @@ Create `src/ui/components/UndoControls.jsx`:
  * edit"), so the control is not a bare glyph to a screen reader, and the disabled
  * state carries its own reason ("Nothing to undo") rather than going silent.
  *
- * `React.memo` matters here: LIVE_STEP dispatches at 20 Hz and the store is a single
- * context, so every consumer re-renders on every action regardless of the slice it
- * reads (see AppShell.jsx, "THE 20 Hz PROBLEM"). Memoising bails this out whenever the
- * stacks have not moved.
+ * `React.memo` would NOT help here and is deliberately absent. The store is a single
+ * context, so every consumer re-renders on every dispatch — including LIVE_STEP at
+ * 20 Hz — regardless of the slice it reads (see AppShell.jsx, "THE 20 Hz PROBLEM").
+ * memo only blocks re-renders driven by a parent's props. Two buttons and two string
+ * reads is cheap; the fix for the 20 Hz problem is splitting the context, not
+ * memoising its consumers.
  */
 
 import { Redo2, Undo2 } from 'lucide-react';
@@ -680,7 +682,7 @@ import { useHistory } from '../state/StoreProvider.jsx';
 import styles from './UndoControls.module.css';
 
 /** @returns {React.ReactElement} */
-export const UndoControls = React.memo(function UndoControls() {
+export function UndoControls() {
   const [history, dispatch] = useHistory();
   const { past, future } = history;
   const undoLabel = past.length ? `Undo ${past[past.length - 1].label}` : 'Nothing to undo';
@@ -703,7 +705,7 @@ export const UndoControls = React.memo(function UndoControls() {
       </button>
     </div>
   );
-});
+}
 ```
 
 Create `src/ui/components/UndoControls.module.css`:

--- a/docs/superpowers/plans/2026-08-25-tune-undo-redo.md
+++ b/docs/superpowers/plans/2026-08-25-tune-undo-redo.md
@@ -1,0 +1,1251 @@
+# Undo/redo for calibration edits — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give ECU Lab an undo/redo stack covering every calibration edit, preset load and reset-to-stock, before PR 4b adds the bulk operations that make a slip catastrophic.
+
+**Architecture:** A fourth top-level store slice, `history: {past, future}`, holding uniform snapshots of the fields any undoable action can touch. The existing reducer becomes `baseReducer`; a thin `reducer` wrapper records a snapshot for the three undoable action types and handles `UNDO`/`REDO`. No `src/sim` change of any kind.
+
+**Tech Stack:** React 18, `useReducer` + one context (`StoreProvider.jsx`), CSS Modules with design tokens, vitest + @testing-library/react, jsdom per-file via `// @vitest-environment jsdom`.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-tune-undo-redo-design.md`
+
+## Global Constraints
+
+- **Node 20 or 22 only.** Currently v22.23.2. Never run `npm run test:fingerprint:update`.
+- **No `src/sim/` changes in this PR.** The behavioural fingerprint must stay untouched. If a task seems to need one, stop and escalate.
+- **No engineering maths in `src/ui/`** (`CONTRIBUTING.md:27`). A history stack is state bookkeeping, not maths, so it belongs in `src/ui/state/`. PR 4b is where `tables.js` gains grid transforms.
+- **No hard-coded colours.** Every colour resolves to a token; `tests/no-hardcoded-colours.test.js` enforces it. That test generates 2–3 cases per source file, so a raw test total is not a stable baseline — compare per-file.
+- **Scope `[data-*]` selectors to a hashed class** (`.panel[data-open='true']`, never bare `[data-open]`). Repo convention.
+- **`tests/ui/characterisation.test.jsx` must stay byte-identical.** It drives the dock's `+1` stepper, not the slider. If a change to it seems necessary, stop and escalate.
+- **History depth is 50**, capped with `.slice(-HISTORY_LIMIT)`.
+- **The reducer stays pure.** No `Date.now()`, no coalescing keys, no merge logic inside it.
+- **Never `git stash`** in any form, never `git add -A`/`git add .`, never `git add node_modules`. ` D node_modules` in `git status` is a known pre-existing condition — leave it. Stage explicit paths only.
+- Run tests as `npx vitest run --pool=forks --poolOptions.forks.singleFork <path>`.
+- Full check suite before the PR: `npm test`, `npm run lint`, `npm run typecheck`, `npm run build`.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `src/ui/state/history.js` **(new)** | The snapshot data model alone: `HISTORY_LIMIT`, `snapshot()`, `restore()`. No React, no action types — importing `ACTIONS` here would make a cycle with `reducer.js`. |
+| `src/ui/state/reducer.js` | Existing `reducer` renamed to `baseReducer`; new `reducer` wrapper records history and handles `UNDO`/`REDO`. Owns `labelFor()`, because that needs `ACTIONS` and `presetById`. |
+| `src/ui/state/initialState.js` | Adds the `history` slice and its typedef. |
+| `src/ui/state/StoreProvider.jsx` | Adds `useHistory()` beside the three existing slice hooks. |
+| `src/ui/components/UndoControls.jsx` + `.module.css` **(new)** | The ↶ ↷ pair. Reads `history`, dispatches `UNDO`/`REDO`. `React.memo`'d. |
+| `src/ui/components/SelectionDock.jsx` | Slider becomes commit-on-release. |
+| `src/ui/screens/tune/{Airflow,Spark,Fuel}Screen.jsx` + `.module.css` | Mount `UndoControls` in a `.gridHead` row beside the `Eyebrow`. |
+| `src/ui/screens/build/EngineScreen.jsx` + `.module.css` | The post-preset/post-reset UNDO `Note`. |
+| `src/ui/EcuLab.jsx` | The Cmd/Ctrl+Z key handler. |
+| `src/ui/components/README.md` | Documents `UndoControls`. |
+
+**Known duplication, accepted deliberately:** the `.gridHead` flex row is four lines of identical CSS in three screen stylesheets. A shared `GridHeader` component to avoid it would be more machinery than the problem deserves, and each screen's header already differs in icon and label. Do not extract it; do not flag it as an oversight.
+
+## Blast radius — read before Task 1
+
+Two existing tests pin the store's shape and **will fail** the moment `history` exists. Both updates are correct and expected, not workarounds:
+
+1. `tests/ui/state/reducer.test.js:95` — `expect(Object.keys(s).sort()).toEqual(['build', 'session', 'tune'])`. Becomes four slices.
+2. `tests/ui/state/reducer.test.js:489` — APPLY_PRESET's "changes exactly the 21 documented fields" test. Recording history makes `history.past` and `history.future` change too, so the expected list grows by exactly those two entries.
+
+`makeSentinelState()` (`:37`) seeds every field of every slice with a sentinel *string*. That trick does not work for `history`, whose fields are arrays the reducer spreads — `[...'SENTINEL::history.past']` would silently produce a 24-element array of characters. Task 1 gives `history` a real empty structure instead.
+
+Nothing else in the repo asserts the store's slice list.
+
+---
+
+### Task 1: The history slice, snapshot/restore, and UNDO/REDO in the reducer
+
+**Files:**
+- Create: `src/ui/state/history.js`
+- Modify: `src/ui/state/initialState.js`
+- Modify: `src/ui/state/reducer.js`
+- Modify: `src/ui/state/StoreProvider.jsx`
+- Test: `tests/ui/state/reducer.test.js`
+
+**Interfaces:**
+- Produces: `HISTORY_LIMIT: number` (50), `snapshot(state: StoreState): Snapshot`, `restore(state: StoreState, before: Snapshot): StoreState` from `src/ui/state/history.js`; `ACTIONS.UNDO`, `ACTIONS.REDO`; `useHistory(): [HistoryState, React.Dispatch<StoreAction>]` from `StoreProvider.jsx`.
+- `HistoryState` is `{past: HistoryEntry[], future: HistoryEntry[]}`; `HistoryEntry` is `{label: string, before: Snapshot}`.
+- Later tasks rely on: `useHistory`, `ACTIONS.UNDO`, `ACTIONS.REDO`, and the entry `label` strings `'VE edit'`, `'Spark edit'`, `'Fuel edit'`, `'Reset to stock'`, and `` `Preset · ${name}` ``.
+
+- [ ] **Step 1: Create the snapshot module**
+
+Create `src/ui/state/history.js`:
+
+```js
+/**
+ * The undo stack's data model: what one snapshot contains, and how it goes back.
+ *
+ * Deliberately holds NO action types. `reducer.js` imports this, so importing
+ * `ACTIONS` back from there would be a cycle — which is also why `labelFor()`
+ * lives in the reducer rather than here.
+ *
+ * The snapshot is UNIFORM: it captures the union of every field any undoable
+ * action can overwrite, not the subset a particular action happens to touch. One
+ * shape means one restore path. A per-action shape would mean three, and a fourth
+ * undoable action added later could produce a half-restored state that no test
+ * thought to cover.
+ */
+
+/** @typedef {import('./initialState.js').StoreState} StoreState */
+/** @typedef {{build: object, tune: object}} Snapshot */
+
+/**
+ * How many undo steps are kept. A snapshot is roughly 1 KB (144 table numbers plus
+ * scalars), so the cap is not about memory — it is that an array which only ever
+ * grows is a leak with a long fuse.
+ */
+export const HISTORY_LIMIT = 50;
+
+/**
+ * BUILD fields an undoable action can overwrite. APPLY_PRESET writes all thirteen;
+ * RESET_TO_STOCK writes three; SET_TABLE writes one. The snapshot carries the union
+ * so `restore` never has to know which action it is undoing.
+ */
+const BUILD_KEYS = [
+  'engineConfig', 'mods', 'turboOn', 'boostCurve', 'turbineIdx', 'turbineCount',
+  'compressorIdx', 'injIdx', 'ecuInjectorCc', 'octaneIdx', 'exhaustDiaIdx',
+  'mafScalar', 'presetId',
+];
+
+/**
+ * TUNE fields an undoable action can overwrite.
+ *
+ * `selection` is deliberately absent: it is a cursor, not calibration. Restoring it
+ * would make undo move the player's highlight around, and the grid's dimensions never
+ * change, so a selection is always still valid after a restore.
+ */
+const TUNE_KEYS = ['ve', 'timing', 'afr', 'tablesDirty'];
+
+/**
+ * Captures the undoable projection of a state tree.
+ * @param {StoreState} state
+ * @returns {Snapshot}
+ */
+export function snapshot(state) {
+  /** @type {any} */
+  const build = {};
+  /** @type {any} */
+  const tune = {};
+  for (const key of BUILD_KEYS) build[key] = /** @type {any} */ (state.build)[key];
+  for (const key of TUNE_KEYS) tune[key] = /** @type {any} */ (state.tune)[key];
+  return { build, tune };
+}
+
+/**
+ * Puts a snapshot back, leaving every field it does not carry alone — `session`
+ * entirely, and `tune.selection`.
+ * @param {StoreState} state
+ * @param {Snapshot} before
+ * @returns {StoreState}
+ */
+export function restore(state, before) {
+  return {
+    ...state,
+    build: { ...state.build, ...before.build },
+    tune: { ...state.tune, ...before.tune },
+  };
+}
+```
+
+- [ ] **Step 2: Add the slice to initial state**
+
+In `src/ui/state/initialState.js`, add the typedef next to the other slice typedefs:
+
+```js
+/**
+ * The undo stack. `past` is oldest-first, so the next thing UNDO reverses is the LAST
+ * element; `future` is newest-first, so REDO takes element 0.
+ *
+ * Each entry holds the state BEFORE its action ran, and a `label` naming what would be
+ * undone. The label is load-bearing twice: it gives the undo buttons a real
+ * `aria-label` instead of a bare glyph, and it is how BUILD decides whether the top of
+ * the stack is a preset load worth offering to reverse.
+ *
+ * @typedef {object} HistoryState
+ * @property {{label: string, before: import('./history.js').Snapshot}[]} past
+ * @property {{label: string, before: import('./history.js').Snapshot}[]} future
+ */
+```
+
+Add to the `StoreState` typedef:
+
+```js
+ * @property {HistoryState} history
+```
+
+And in `makeInitialState()`'s returned object, after the `session` block:
+
+```js
+    history: { past: [], future: [] },
+```
+
+- [ ] **Step 3: Write the failing reducer tests**
+
+In `tests/ui/state/reducer.test.js`, first fix the two shape assertions the new slice breaks.
+
+At `:95`, change the slice list:
+
+```js
+  it('returns the four slices', () => {
+    const s = makeInitialState();
+    expect(Object.keys(s).sort()).toEqual(['build', 'history', 'session', 'tune']);
+  });
+```
+
+In `makeSentinelState()` (`:37`), give `history` a real structure instead of sentinel strings — the reducer spreads `history.past`, and spreading a string yields its characters:
+
+```js
+  for (const slice of Object.keys(init)) {
+    // `history` is structural, not scalar: the reducer spreads `past`, and
+    // `[...'SENTINEL::history.past']` would silently become 24 single characters.
+    // A real empty stack still starts unequal to anything a write produces, which is
+    // all `changedFieldKeys` needs.
+    if (slice === 'history') {
+      state[slice] = { past: [], future: [] };
+      continue;
+    }
+    const sliceState = /** @type {any} */ ({});
+    for (const field of Object.keys(/** @type {any} */ (init)[slice])) {
+      sliceState[field] = `SENTINEL::${slice}.${field}`;
+    }
+    state[slice] = sliceState;
+  }
+```
+
+At `:489`, APPLY_PRESET now also writes history. Extend the expected set and the title:
+
+```js
+  it('changes exactly the 21 documented fields, plus the two history fields', () => {
+```
+
+and add to `expected`, after `'session.result', 'session.prevResult',`:
+
+```js
+      // APPLY_PRESET is undoable, so it records a snapshot in the same pass. These two
+      // belong in the exact-write-surface contract like any other field it touches.
+      'history.past', 'history.future',
+```
+
+Now append the new suites at the end of the file:
+
+```js
+describe('UNDO / REDO', () => {
+  /** A state with one hand VE edit already applied. */
+  const edited = () => reducer(
+    makeInitialState(),
+    { type: ACTIONS.SET_TABLE, table: 've', value: [[42]] },
+  );
+
+  it('records the state BEFORE an edit, not after', () => {
+    const before = makeInitialState();
+    const after = reducer(before, { type: ACTIONS.SET_TABLE, table: 've', value: [[42]] });
+    expect(after.history.past).toHaveLength(1);
+    expect(after.history.past[0].before.tune.ve).toBe(before.tune.ve);
+    expect(after.history.past[0].label).toBe('VE edit');
+  });
+
+  it('puts the table back', () => {
+    const start = makeInitialState();
+    const s = reducer(edited(), { type: ACTIONS.UNDO });
+    expect(s.tune.ve).toBe(start.tune.ve);
+    expect(s.history.past).toHaveLength(0);
+    expect(s.history.future).toHaveLength(1);
+  });
+
+  it('restores tablesDirty, not just the numbers', () => {
+    // A history that carried only the table would leave the player's unsaved-work flag
+    // stuck true after undoing their only edit.
+    expect(edited().tune.tablesDirty).toBe(true);
+    expect(reducer(edited(), { type: ACTIONS.UNDO }).tune.tablesDirty).toBe(false);
+  });
+
+  it('restores presetId, because SET_TABLE cleared it', () => {
+    // The reason the snapshot is a projection of BOTH slices. SET_TABLE clears
+    // presetId in the same pass it writes the table; undo has to put the label back or
+    // the header goes on disowning a preset the player never actually left.
+    const loaded = { ...makeInitialState() };
+    loaded.build = { ...loaded.build, presetId: 'n54' };
+    const dirty = reducer(loaded, { type: ACTIONS.SET_TABLE, table: 'timing', value: [[9]] });
+    expect(dirty.build.presetId).toBeNull();
+    expect(reducer(dirty, { type: ACTIONS.UNDO }).build.presetId).toBe('n54');
+  });
+
+  it('restores the build fields APPLY_PRESET overwrote', () => {
+    const before = makeInitialState();
+    const after = reducer(before, { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
+    expect(after.build.turboOn).toBe(true);
+    const undone = reducer(after, { type: ACTIONS.UNDO });
+    expect(undone.build.turboOn).toBe(false);
+    expect(undone.build.engineConfig).toBe(before.build.engineConfig);
+    expect(undone.build.presetId).toBeNull();
+  });
+
+  it('labels a preset load with the preset name', () => {
+    const after = reducer(makeInitialState(), { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
+    expect(after.history.past[0].label).toBe('Preset · BMW N54');
+  });
+
+  it('labels a reset', () => {
+    const after = reducer(makeInitialState(), { type: ACTIONS.RESET_TO_STOCK, ve: [[70]] });
+    expect(after.history.past[0].label).toBe('Reset to stock');
+  });
+
+  it('redo puts the edit back', () => {
+    const undone = reducer(edited(), { type: ACTIONS.UNDO });
+    const redone = reducer(undone, { type: ACTIONS.REDO });
+    expect(redone.tune.ve).toEqual([[42]]);
+    expect(redone.history.past).toHaveLength(1);
+    expect(redone.history.future).toHaveLength(0);
+  });
+
+  it('a new edit clears the redo stack', () => {
+    // Otherwise redo would jump the player onto a branch they had already left.
+    const undone = reducer(edited(), { type: ACTIONS.UNDO });
+    expect(undone.history.future).toHaveLength(1);
+    const branched = reducer(undone, { type: ACTIONS.SET_TABLE, table: 've', value: [[7]] });
+    expect(branched.history.future).toHaveLength(0);
+  });
+
+  it('caps the stack at 50 and drops the OLDEST entry', () => {
+    let s = makeInitialState();
+    for (let i = 0; i < 60; i += 1) {
+      s = reducer(s, { type: ACTIONS.SET_TABLE, table: 've', value: [[i]] });
+    }
+    expect(s.history.past).toHaveLength(50);
+    // Entry 0 must be the snapshot taken before edit #10 — i.e. holding edit #9's
+    // value. Asserting the LENGTH alone would pass just as well for a cap that
+    // discarded the newest entries, which is the opposite of what undo needs.
+    expect(s.history.past[0].before.tune.ve).toEqual([[9]]);
+  });
+
+  it('undo and redo on an empty stack return the SAME object', () => {
+    // Reference equality, not deep equality: React's useReducer bails out of the
+    // re-render only when the reducer returns the identical object.
+    const s = makeInitialState();
+    expect(reducer(s, { type: ACTIONS.UNDO })).toBe(s);
+    expect(reducer(s, { type: ACTIONS.REDO })).toBe(s);
+  });
+
+  it('does not record actions that are not undoable', () => {
+    const s = reducer(makeInitialState(), { type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: true });
+    expect(s.history.past).toHaveLength(0);
+  });
+
+  it('does not restore dyno results', () => {
+    // A deliberate asymmetry, spec'd: undo brings back hardware and calibration, but
+    // re-showing a banked score beside a build that was just reverted would state
+    // something false.
+    const withResult = { ...makeInitialState() };
+    withResult.session = { ...withResult.session, result: { peakHp: 400 } };
+    const loaded = reducer(withResult, { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
+    expect(loaded.session.result).toBeNull();
+    expect(reducer(loaded, { type: ACTIONS.UNDO }).session.result).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 4: Run the tests and watch them fail**
+
+Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/state/reducer.test.js`
+
+Expected: the `UNDO / REDO` suite fails — `ACTIONS.UNDO` is `undefined`, so every dispatch hits the reducer's `default` case and returns state unchanged, and `s.history` is `undefined`. The `makeInitialState` and APPLY_PRESET shape tests should already pass once Step 2 landed.
+
+- [ ] **Step 5: Wire the reducer**
+
+In `src/ui/state/reducer.js`:
+
+Add to the imports (`presetById` for the label, and the snapshot module):
+
+```js
+import { clamp, clone2D, DEFAULT_AFR, DEFAULT_MODS, DEFAULT_TIMING, liveStep, presetById } from '../../sim/index.js';
+
+import { HISTORY_LIMIT, restore, snapshot } from './history.js';
+```
+
+Add to `ACTIONS`, after `LIVE_PATCH`:
+
+```js
+  UNDO: 'UNDO',
+  REDO: 'REDO',
+```
+
+Rename the existing exported reducer — `export function reducer(state, action) {` becomes:
+
+```js
+/**
+ * Every case except UNDO/REDO. Wrapped by `reducer` below, which is what callers use.
+ */
+function baseReducer(state, action) {
+```
+
+Then append, after `baseReducer`'s closing brace:
+
+```js
+/**
+ * The three actions that destroy calibration the player cannot otherwise get back.
+ *
+ * Hardware writes are deliberately absent: every hardware control already displays its
+ * own current value, so it is self-reversing, and undo must not become a time machine
+ * over banked career progress.
+ */
+const UNDOABLE = new Set([ACTIONS.SET_TABLE, ACTIONS.APPLY_PRESET, ACTIONS.RESET_TO_STOCK]);
+
+/**
+ * Names what an undoable action did, for the undo button's `aria-label` and BUILD's
+ * post-load offer. Lives here rather than in history.js because it needs `ACTIONS` and
+ * the preset catalogue, and history.js must not import this module.
+ * @param {any} action
+ * @returns {string}
+ */
+function labelFor(action) {
+  switch (action.type) {
+    case ACTIONS.SET_TABLE:
+      return { ve: 'VE edit', timing: 'Spark edit', afr: 'Fuel edit' }[action.table];
+    case ACTIONS.APPLY_PRESET: {
+      const preset = presetById(action.preset.presetId);
+      return `Preset · ${preset ? preset.name : 'factory calibration'}`;
+    }
+    default:
+      return 'Reset to stock';
+  }
+}
+
+/**
+ * The store's reducer: `baseReducer` plus the undo stack.
+ *
+ * Recording is a WRAPPER rather than a line inside each undoable case, so the three
+ * existing cases stay exactly as they were and a fourth undoable action is one entry in
+ * `UNDOABLE` rather than a fourth place to remember. It stays a pure function of
+ * `(state, action)` — no clock, no coalescing keys, no merge logic. The dock's slider
+ * commits once on release instead (see SelectionDock.jsx), which is what keeps a drag
+ * from becoming eighteen undo steps without any of that machinery.
+ *
+ * @param {StoreState} state
+ * @param {any} action
+ * @returns {StoreState}
+ */
+export function reducer(state, action) {
+  if (action.type === ACTIONS.UNDO) {
+    const { past, future } = state.history;
+    if (past.length === 0) return state;
+    const entry = past[past.length - 1];
+    return {
+      ...restore(state, entry.before),
+      history: {
+        past: past.slice(0, -1),
+        future: [{ label: entry.label, before: snapshot(state) }, ...future],
+      },
+    };
+  }
+
+  if (action.type === ACTIONS.REDO) {
+    const { past, future } = state.history;
+    if (future.length === 0) return state;
+    const entry = future[0];
+    return {
+      ...restore(state, entry.before),
+      history: {
+        past: [...past, { label: entry.label, before: snapshot(state) }].slice(-HISTORY_LIMIT),
+        future: future.slice(1),
+      },
+    };
+  }
+
+  const next = baseReducer(state, action);
+  if (!UNDOABLE.has(action.type)) return next;
+  return {
+    ...next,
+    history: {
+      past: [...state.history.past, { label: labelFor(action), before: snapshot(state) }]
+        .slice(-HISTORY_LIMIT),
+      // A new edit abandons the redo branch: keeping it would let redo jump the player
+      // onto a timeline they had already left.
+      future: [],
+    },
+  };
+}
+```
+
+- [ ] **Step 6: Add the `useHistory` hook**
+
+In `src/ui/state/StoreProvider.jsx`, add the typedef beside the others:
+
+```js
+/** @typedef {import('./initialState.js').HistoryState} HistoryState */
+```
+
+and the hook after `useSession`:
+
+```js
+/**
+ * The HISTORY slice: the undo and redo stacks.
+ * @returns {[HistoryState, React.Dispatch<StoreAction>]}
+ */
+export function useHistory() {
+  const [state, dispatch] = useStore();
+  return [state.history, dispatch];
+}
+```
+
+- [ ] **Step 7: Run the tests and watch them pass**
+
+Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/state/reducer.test.js`
+Expected: PASS, all suites.
+
+Then run the whole suite — the store shape changed, so anything reading it is in scope:
+
+Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork`
+Expected: PASS. If anything outside `reducer.test.js` fails, report it rather than editing that test — the Blast Radius section says only two tests should have needed changes, so a third is a finding.
+
+- [ ] **Step 8: Verify the cap test can actually fail**
+
+A test that cannot fail is worse than no test. Temporarily change `.slice(-HISTORY_LIMIT)` in the `UNDOABLE` branch to `.slice(0, HISTORY_LIMIT)` (keep oldest, drop newest — the plausible wrong version).
+
+Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/state/reducer.test.js -t 'caps the stack'`
+Expected: FAIL on the `past[0].before.tune.ve` assertion.
+
+Revert the change and re-run to confirm PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/ui/state/history.js src/ui/state/reducer.js src/ui/state/initialState.js src/ui/state/StoreProvider.jsx tests/ui/state/reducer.test.js
+git commit -m "Add an undo stack to the store"
+```
+
+---
+
+### Task 2: The undo/redo buttons on TUNE
+
+**Files:**
+- Create: `src/ui/components/UndoControls.jsx`, `src/ui/components/UndoControls.module.css`
+- Modify: `src/ui/screens/tune/AirflowScreen.jsx`, `SparkScreen.jsx`, `FuelScreen.jsx` and their three `.module.css` files
+- Modify: `src/ui/components/README.md`
+- Test: `tests/ui/undo-controls.test.jsx` (new)
+
+**Interfaces:**
+- Consumes: `useHistory()` and `ACTIONS.UNDO`/`ACTIONS.REDO` from Task 1; entry labels `'VE edit'`, `'Spark edit'`, `'Fuel edit'`.
+- Produces: `<UndoControls />` — takes no props, reads the store itself.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/ui/undo-controls.test.jsx`:
+
+```jsx
+// @vitest-environment jsdom
+
+/**
+ * The undo/redo pair on TUNE's table screens.
+ *
+ * The load-bearing test here is the last one: it drives the REAL app through a preset
+ * load, a table edit and a click on the real button, and asserts the header goes back
+ * to claiming the preset. That fails for any implementation which restores the 48
+ * numbers but forgets `presetId` — the exact defect a table-only history would ship.
+ */
+
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import EcuLab from '../../src/ui/EcuLab.jsx';
+import { UndoControls } from '../../src/ui/components/UndoControls.jsx';
+import { ACTIONS } from '../../src/ui/state/reducer.js';
+import { StoreProvider, useTune } from '../../src/ui/state/StoreProvider.jsx';
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+const hadResizeObserver = 'ResizeObserver' in window;
+if (!hadResizeObserver) window.ResizeObserver = ResizeObserverStub;
+
+afterEach(cleanup);
+
+/** Dispatches one VE edit, so the undo stack is non-empty. */
+function EditOnce() {
+  const [, dispatch] = useTune();
+  return (
+    <button onClick={() => dispatch({ type: ACTIONS.SET_TABLE, table: 've', value: [[42]] })}>
+      EDIT
+    </button>
+  );
+}
+
+function mount() {
+  return render(
+    <StoreProvider>
+      <UndoControls />
+      <EditOnce />
+    </StoreProvider>,
+  );
+}
+
+const undoBtn = () => screen.getByRole('button', { name: /^(Undo|Nothing to undo)/ });
+const redoBtn = () => screen.getByRole('button', { name: /^(Redo|Nothing to redo)/ });
+
+describe('UndoControls', () => {
+  it('starts with both buttons disabled', () => {
+    mount();
+    expect(/** @type {HTMLButtonElement} */ (undoBtn()).disabled).toBe(true);
+    expect(/** @type {HTMLButtonElement} */ (redoBtn()).disabled).toBe(true);
+  });
+
+  it('names what it would undo', () => {
+    mount();
+    fireEvent.click(screen.getByRole('button', { name: 'EDIT' }));
+    expect(undoBtn().getAttribute('aria-label')).toBe('Undo VE edit');
+  });
+
+  it('enables redo only after an undo', () => {
+    mount();
+    fireEvent.click(screen.getByRole('button', { name: 'EDIT' }));
+    expect(/** @type {HTMLButtonElement} */ (redoBtn()).disabled).toBe(true);
+    fireEvent.click(undoBtn());
+    expect(/** @type {HTMLButtonElement} */ (redoBtn()).disabled).toBe(false);
+    expect(redoBtn().getAttribute('aria-label')).toBe('Redo VE edit');
+  });
+
+  it('puts the preset label back when a table edit is undone', () => {
+    // The whole point of a snapshot spanning both slices, driven through the real app.
+    render(<EcuLab />);
+    fireEvent.click(screen.getByRole('button', { name: 'START' }));
+
+    const picker = /** @type {HTMLSelectElement[]} */ (screen.getAllByRole('combobox'))
+      .find((el) => el.querySelector('optgroup'));
+    const target = [...picker.querySelectorAll('option')]
+      .map((o) => o.value)
+      .find((v) => v && v !== picker.value);
+    fireEvent.change(picker, { target: { value: target } });
+    // Loading over an untouched default asks for no confirmation, so the preset is on.
+    expect(screen.getByTestId('build-line').textContent).not.toMatch(/^\d\.\dL /);
+
+    fireEvent.click(screen.getByRole('button', { name: /TUNE/ }));
+    const grid = within(screen.getByTestId('tuning-grid'));
+    const cells = grid.getAllByRole('button')
+      .filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent));
+    fireEvent.click(cells[Math.floor(cells.length / 2)]);
+    fireEvent.click(within(screen.getByTestId('selection-dock')).getByRole('button', { name: '+1' }));
+
+    // The edit disowned the preset: the header falls back to the derived "3.0L I6".
+    expect(screen.getByTestId('build-line').textContent).toMatch(/^\d\.\dL /);
+
+    fireEvent.click(undoBtn());
+
+    // ...and undo gives it back.
+    expect(screen.getByTestId('build-line').textContent).not.toMatch(/^\d\.\dL /);
+  });
+});
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx`
+Expected: FAIL — `Failed to resolve import ".../UndoControls.jsx"`.
+
+- [ ] **Step 3: Write the component**
+
+Create `src/ui/components/UndoControls.jsx`:
+
+```jsx
+/**
+ * The undo/redo pair for TUNE's calibration tables.
+ *
+ * Chrome only: it reads the two stack lengths and dispatches. What is undoable, and
+ * what a snapshot contains, belongs to the reducer — see `src/ui/state/history.js`.
+ *
+ * Each button takes its accessible name from the entry it would reverse ("Undo VE
+ * edit"), so the control is not a bare glyph to a screen reader, and the disabled
+ * state carries its own reason ("Nothing to undo") rather than going silent.
+ *
+ * `React.memo` matters here: LIVE_STEP dispatches at 20 Hz and the store is a single
+ * context, so every consumer re-renders on every action regardless of the slice it
+ * reads (see AppShell.jsx, "THE 20 Hz PROBLEM"). Memoising bails this out whenever the
+ * stacks have not moved.
+ */
+
+import { Redo2, Undo2 } from 'lucide-react';
+import React from 'react';
+
+import { ACTIONS } from '../state/reducer.js';
+import { useHistory } from '../state/StoreProvider.jsx';
+
+import styles from './UndoControls.module.css';
+
+/** @returns {React.ReactElement} */
+export const UndoControls = React.memo(function UndoControls() {
+  const [history, dispatch] = useHistory();
+  const { past, future } = history;
+  const undoLabel = past.length ? `Undo ${past[past.length - 1].label}` : 'Nothing to undo';
+  const redoLabel = future.length ? `Redo ${future[0].label}` : 'Nothing to redo';
+  return (
+    <div className={styles.row}>
+      <button
+        type="button" className={styles.btn} disabled={past.length === 0}
+        aria-label={undoLabel} title={undoLabel}
+        onClick={() => dispatch({ type: ACTIONS.UNDO })}
+      >
+        <Undo2 size={14} />
+      </button>
+      <button
+        type="button" className={styles.btn} disabled={future.length === 0}
+        aria-label={redoLabel} title={redoLabel}
+        onClick={() => dispatch({ type: ACTIONS.REDO })}
+      >
+        <Redo2 size={14} />
+      </button>
+    </div>
+  );
+});
+```
+
+Create `src/ui/components/UndoControls.module.css`:
+
+```css
+.row {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 26px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--panel2);
+  color: var(--ink2);
+  cursor: pointer;
+}
+
+.btn:hover:not(:disabled) {
+  border-color: var(--line-hi);
+  color: var(--ink);
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--acc);
+  outline-offset: 2px;
+}
+```
+
+Confirm `--line-hi` is the real token name before using it: `grep -n 'line-hi\|lineHi' src/ui/tokens.css`. If the CSS custom property is spelled differently there, use the spelling `tokens.css` actually defines.
+
+- [ ] **Step 4: Mount it in the three screens**
+
+In each of `AirflowScreen.jsx`, `SparkScreen.jsx` and `FuelScreen.jsx`, add the import:
+
+```js
+import { UndoControls } from '../../components/UndoControls.jsx';
+```
+
+and wrap the existing `<Eyebrow …>` line in a header row. For `SparkScreen.jsx` the `<Eyebrow icon={Zap}>Ignition Timing</Eyebrow>` line becomes:
+
+```jsx
+          <div className={styles.gridHead}>
+            <Eyebrow icon={Zap}>Ignition Timing</Eyebrow>
+            <UndoControls />
+          </div>
+```
+
+Do the same in the other two, keeping each screen's own icon and label text exactly as it is now — do not retype the labels from memory, wrap the line that is already there.
+
+Add to all three `.module.css` files:
+
+```css
+.gridHead {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-sm);
+}
+```
+
+- [ ] **Step 5: Document it**
+
+Add to `src/ui/components/README.md`, after the `TuneAdvisory` paragraph:
+
+```markdown
+`UndoControls` is the ordinary shared-component reason again: AIRFLOW, SPARK and FUEL
+each mount one above their grid. It takes no props and reads `history` from the store
+itself, because the stacks are global — undoing a spark edit from the FUEL screen is
+correct behaviour, not a bug. What is undoable lives in `src/ui/state/reducer.js`
+(`UNDOABLE`); what a snapshot carries lives in `src/ui/state/history.js`.
+```
+
+- [ ] **Step 6: Run the tests**
+
+Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx`
+Expected: PASS, 4 tests.
+
+Then: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/`
+Expected: PASS. `button-call-sites.test.jsx` sweeps every rendered `.button` class — `UndoControls` uses its own class, not `Button`, so it should not appear there. If that test fails, report it rather than editing it.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui/components/UndoControls.jsx src/ui/components/UndoControls.module.css src/ui/components/README.md src/ui/screens/tune tests/ui/undo-controls.test.jsx
+git commit -m "Put undo and redo above the tuning grid"
+```
+
+---
+
+### Task 3: Commit the slider on release
+
+**Files:**
+- Modify: `src/ui/components/SelectionDock.jsx`
+- Test: `tests/ui/undo-controls.test.jsx` (append one suite)
+
+**Interfaces:**
+- Consumes: nothing new. `SelectionDock`'s props are unchanged.
+- Produces: no new exports. The behaviour change is that dragging the slider dispatches `SET_TABLE` once, on release, instead of on every intermediate value.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/ui/undo-controls.test.jsx`:
+
+```jsx
+describe('the dock slider commits once, on release', () => {
+  /** Reports the undo depth into the DOM so a test can read it. */
+  function Depth() {
+    const [history] = useHistory();
+    return <output data-testid="depth">{history.past.length}</output>;
+  }
+
+  it('records ONE history entry for a drag, not one per intermediate value', () => {
+    // React maps onChange on a range input to the `input` event, so a real drag fires
+    // it continuously — roughly 18 times from 12 to 30 degrees. Recorded naively, undo
+    // would walk back one slider pixel at a time.
+    //
+    // Asserting the DEPTH is the point. Asserting only the final table value would
+    // pass just as well with eighteen entries recorded.
+    render(
+      <StoreProvider>
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' }));
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '20' } });
+    fireEvent.change(slider, { target: { value: '25' } });
+    fireEvent.change(slider, { target: { value: '30' } });
+
+    // Mid-drag: nothing committed yet.
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+
+    fireEvent.pointerUp(slider);
+
+    expect(screen.getByTestId('depth').textContent).toBe('1');
+  });
+});
+```
+
+and add the harness beside the other helpers near the top of the file:
+
+```jsx
+/** A bare SelectionDock over the store's timing table, with a cell pre-selectable. */
+function EcuLabTuneHarness() {
+  const [tune, dispatch] = useTune();
+  return (
+    <>
+      <button onClick={() => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value: { type: 'cell', row: 0, col: 0 } })}>
+        SELECT
+      </button>
+      <SelectionDock
+        data={tune.timing}
+        setData={(value) => dispatch({ type: ACTIONS.SET_TABLE, table: 'timing', value })}
+        selection={tune.selection} min={-5} max={50} decimals={0} unit="°"
+        onClose={() => {}} kind="timing"
+      />
+    </>
+  );
+}
+```
+
+with the imports it needs added to the file's import block:
+
+```js
+import { SelectionDock } from '../../src/ui/components/SelectionDock.jsx';
+import { StoreProvider, useHistory, useTune } from '../../src/ui/state/StoreProvider.jsx';
+```
+
+(replacing the earlier `StoreProvider, useTune` import line — one import statement per module.)
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx -t 'commits once'`
+Expected: FAIL — depth reads `3` after the three `change` events and before any `pointerUp`.
+
+- [ ] **Step 3: Make the slider hold a draft**
+
+In `src/ui/components/SelectionDock.jsx`:
+
+**Hooks must be declared before the early return.** The function currently opens with `if (!selection) return null;`. A `useState` placed after that would run conditionally and break the Rules of Hooks — React would throw on the render where a selection first appears. Restructure the top of the component to:
+
+```jsx
+export function SelectionDock({ data, setData, selection, min, max, decimals, unit, onClose, kind }) {
+  // The slider's in-flight value. React maps onChange on a range input to the `input`
+  // event, so a drag fires it continuously; committing each one would turn a single
+  // drag into eighteen undo steps. The draft holds the value while the finger is down
+  // and commits exactly once on release.
+  const [draft, setDraft] = React.useState(/** @type {number|null} */ (null));
+
+  // A new selection is a new cell: drop any draft left over from the last one, or the
+  // slider would open showing the previous cell's in-flight value.
+  const selKey = selection
+    ? `${selection.type}:${selection.row ?? ''}:${selection.col ?? ''}`
+    : '';
+  React.useEffect(() => { setDraft(null); }, [selKey]);
+
+  if (!selection) return null;
+  let current;
+```
+
+Leave the rest of the `current`/`apply`/`setAbs` block exactly as it is, then add below `setAbs`:
+
+```jsx
+  // What the slider and the big readout show: the finger's position while dragging,
+  // the table's committed value otherwise.
+  const shown = draft === null ? current : draft;
+  const commitDraft = () => {
+    if (draft === null) return;
+    setAbs(draft);
+    setDraft(null);
+  };
+```
+
+Change the readout to use `shown` — the line currently reading
+
+```jsx
+            {decimals ? current.toFixed(decimals) : Math.round(current)}<span style={{ fontSize: 12, color: T.ink2, marginLeft: 4 }}>{unit}</span>
+```
+
+becomes
+
+```jsx
+            {decimals ? shown.toFixed(decimals) : Math.round(shown)}<span style={{ fontSize: 12, color: T.ink2, marginLeft: 4 }}>{unit}</span>
+```
+
+and replace the slider (`SelectionDock.jsx:127`) with:
+
+```jsx
+      <input
+        type="range" min={min} max={max} step={smallStep} value={shown}
+        onChange={(e) => setDraft(Number(e.target.value))}
+        onPointerUp={commitDraft}
+        onKeyUp={commitDraft}
+        style={{ width: '100%', accentColor: T.acc }}
+      />
+```
+
+Leave `cellReference` and the four stepper buttons untouched: a stepper click is already one discrete edit, so it stays one history entry.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx`
+Expected: PASS, 5 tests.
+
+Then: `npx vitest run --pool=forks --poolOptions.forks.singleFork`
+Expected: PASS. `characterisation.test.jsx` must still pass **unmodified** — it drives the `+1` stepper, not the slider.
+
+- [ ] **Step 5: Verify the test can fail**
+
+Temporarily change `onChange={(e) => setDraft(Number(e.target.value))}` back to `onChange={(e) => setAbs(Number(e.target.value))}`.
+
+Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx -t 'commits once'`
+Expected: FAIL at the mid-drag assertion, depth `3` instead of `0`.
+
+Revert and re-run to confirm PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/components/SelectionDock.jsx tests/ui/undo-controls.test.jsx
+git commit -m "Commit the dock slider on release, not on every drag frame"
+```
+
+---
+
+### Task 4: The undo offer on BUILD
+
+**Files:**
+- Modify: `src/ui/screens/build/EngineScreen.jsx`, `src/ui/screens/build/EngineScreen.module.css`
+- Test: `tests/ui/build-screens.test.jsx` (append one suite)
+
+**Interfaces:**
+- Consumes: `useHistory()`, `ACTIONS.UNDO`, and the label prefixes `'Preset · '` and `'Reset to stock'` from Task 1.
+- Produces: nothing other tasks depend on.
+
+Both `APPLY_PRESET` (`EngineScreen.jsx:81`) and `RESET_TO_STOCK` (`EngineScreen.jsx:255`, via the `onResetToStock` prop) fire from this one screen, so this is a single surface, not two.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/ui/build-screens.test.jsx`, inside the existing `describe('EngineScreen', …)` block if there is one, otherwise as a new top-level suite:
+
+```jsx
+describe('EngineScreen — the undo offer', () => {
+  /** The prop bundle this file already uses for EngineScreen, at :47. */
+  const props = {
+    engineDerived, activePreset: null, veAdvice, onResetToStock: noop,
+  };
+
+  it('offers nothing before anything destructive has happened', () => {
+    mount(<EngineScreen active onToggle={noop} {...props} />);
+    expect(screen.queryByRole('button', { name: /^Undo / })).toBeNull();
+  });
+
+  it('offers to undo a preset load, naming the preset', () => {
+    mount(<EngineScreen active onToggle={noop} {...props} />);
+    const picker = /** @type {HTMLSelectElement[]} */ (screen.getAllByRole('combobox'))
+      .find((el) => el.querySelector('optgroup'));
+    const target = [...picker.querySelectorAll('option')]
+      .map((o) => o.value)
+      .find((v) => v && v !== picker.value);
+    fireEvent.change(picker, { target: { value: target } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Undo Preset · / }));
+
+    // Undone: the offer goes with it, because the top of the stack is gone.
+    expect(screen.queryByRole('button', { name: /^Undo Preset · / })).toBeNull();
+  });
+
+  it('does not offer undo for a plain hardware change', () => {
+    // Hardware writes are not undoable, so an offer here would be a lie about what the
+    // button does. "Block Material" is a Seg on this screen (`EngineScreen.jsx:242`)
+    // that dispatches SET_ENGINE_CONFIG_PATCH — a hardware write, not a calibration one.
+    mount(<EngineScreen active onToggle={noop} {...props} />);
+    const materials = within(screen.getByRole('group', { name: 'Block Material' }));
+    fireEvent.click(materials.getByRole('button', { name: 'Cast Iron' }));
+    expect(screen.queryByRole('button', { name: /^Undo / })).toBeNull();
+  });
+});
+```
+
+This reuses the file's existing `mount` (`:36`), `noop` (`:40`), `engineDerived` (`:41`) and `veAdvice` (`:42`) — do not define a second set. Add `within` to the `@testing-library/react` import if it is not there already. `MATERIAL_OPTS` is `['Cast Iron', 'Aluminum']` (`src/sim/hardware.js:45`) and the default block is `Aluminum`, so clicking `Cast Iron` is a real change rather than a no-op the reducer would skip.
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/build-screens.test.jsx -t 'undo offer'`
+Expected: FAIL — no such button.
+
+- [ ] **Step 3: Add the offer**
+
+In `src/ui/screens/build/EngineScreen.jsx`, add the imports:
+
+```js
+import { useHistory } from '../../state/StoreProvider.jsx';
+```
+
+(`Note` and `Button` are likely imported already — check before adding a duplicate import line.)
+
+Inside the component, beside the existing `useBuild()` call:
+
+```js
+  const [history, dispatch] = useHistory();
+  // Only the two acts that replace the whole calibration get an offer here. A table
+  // edit is undoable too, but its undo lives above the grid on TUNE, where the edit
+  // happened — an offer on BUILD for something the player did on another tab would be
+  // a control with no visible cause.
+  const top = history.past[history.past.length - 1];
+  const undoable = top && (top.label.startsWith('Preset · ') || top.label === 'Reset to stock');
+```
+
+and render it immediately after the `{presetPrompt && (…)}` block:
+
+```jsx
+      {undoable && (
+        <Note tone="warn">
+          <span className={styles.undoRow}>
+            <span>{top.label} replaced your VE, spark and fuel tables.</span>
+            <Button
+              variant="quiet" size="sm"
+              aria-label={`Undo ${top.label}`}
+              onClick={() => dispatch({ type: ACTIONS.UNDO })}
+            >
+              UNDO
+            </Button>
+          </span>
+        </Note>
+      )}
+```
+
+Add to `src/ui/screens/build/EngineScreen.module.css`:
+
+```css
+.undoRow {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-sm);
+  justify-content: space-between;
+}
+```
+
+Check `Note`'s props before using `tone="warn"` — read `src/ui/primitives/Note.jsx` and use whatever tone values it actually accepts.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/build-screens.test.jsx`
+Expected: PASS.
+
+Then: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/`
+Expected: PASS. `button-call-sites.test.jsx` sweeps `Button` call sites and this adds one — if it reports a new unguarded call site, fix the call site, not the test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/screens/build/EngineScreen.jsx src/ui/screens/build/EngineScreen.module.css tests/ui/build-screens.test.jsx
+git commit -m "Offer undo where a preset load replaced the tune"
+```
+
+---
+
+### Task 5: Cmd/Ctrl+Z
+
+**Files:**
+- Modify: `src/ui/EcuLab.jsx`
+- Test: `tests/ui/undo-controls.test.jsx` (append one suite)
+
+**Interfaces:**
+- Consumes: `ACTIONS.UNDO`, `ACTIONS.REDO`.
+- Produces: nothing.
+
+The handler goes in `EcuLab.jsx`, not `AppShell.jsx`. The shell's file header states it owns chrome only and "never dispatches to the store directly"; a global key handler is app behaviour. `EcuLab.jsx` already holds five `useEffect`s — add a sixth beside them.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/ui/undo-controls.test.jsx`:
+
+```jsx
+describe('keyboard shortcuts', () => {
+  function launchWithEdit() {
+    render(<EcuLab />);
+    fireEvent.click(screen.getByRole('button', { name: 'START' }));
+    fireEvent.click(screen.getByRole('button', { name: /TUNE/ }));
+    const grid = within(screen.getByTestId('tuning-grid'));
+    const cells = grid.getAllByRole('button')
+      .filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent));
+    fireEvent.click(cells[0]);
+    const dock = within(screen.getByTestId('selection-dock'));
+    fireEvent.click(dock.getByRole('button', { name: '+1' }));
+    return cells[0].textContent;
+  }
+
+  it('undoes on Cmd+Z and redoes on Cmd+Shift+Z', () => {
+    const before = launchWithEdit();
+    const cell = () => within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent))[0];
+    const edited = cell().textContent;
+    expect(edited).not.toBe(before);
+
+    fireEvent.keyDown(window, { key: 'z', metaKey: true });
+    expect(cell().textContent).toBe(before);
+
+    fireEvent.keyDown(window, { key: 'z', metaKey: true, shiftKey: true });
+    expect(cell().textContent).toBe(edited);
+  });
+
+  it('ignores the shortcut while focus is in a text field', () => {
+    // Otherwise the app would steal undo from the field the player is typing in.
+    launchWithEdit();
+    const cell = () => within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent))[0];
+    const edited = cell().textContent;
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    fireEvent.keyDown(input, { key: 'z', metaKey: true });
+    expect(cell().textContent).toBe(edited);
+    input.remove();
+  });
+
+  it('ignores a bare z with no modifier', () => {
+    launchWithEdit();
+    const cell = () => within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent))[0];
+    const edited = cell().textContent;
+    fireEvent.keyDown(window, { key: 'z' });
+    expect(cell().textContent).toBe(edited);
+  });
+});
+```
+
+- [ ] **Step 2: Run and watch it fail**
+
+Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx -t 'keyboard shortcuts'`
+Expected: FAIL — the cell keeps its edited value after Cmd+Z.
+
+- [ ] **Step 3: Add the handler**
+
+In `src/ui/EcuLab.jsx`, beside the other `useEffect`s:
+
+```jsx
+  // Cmd/Ctrl+Z and Cmd+Shift+Z / Ctrl+Y. This lives here rather than in AppShell,
+  // whose header is explicit that the shell owns chrome only and never dispatches to
+  // the store — a global key handler is app behaviour, not chrome.
+  //
+  // PR 4b's arrow-key tuning will need this same seam.
+  useEffect(() => {
+    /** @param {KeyboardEvent} e */
+    const onKey = (e) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      const key = e.key.toLowerCase();
+      if (key !== 'z' && key !== 'y') return;
+      // Never steal undo from a field the player is typing in.
+      const el = /** @type {HTMLElement|null} */ (e.target);
+      const tag = el && el.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || (el && el.isContentEditable)) return;
+      e.preventDefault();
+      const redo = key === 'y' || e.shiftKey;
+      dispatch({ type: redo ? ACTIONS.REDO : ACTIONS.UNDO });
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [dispatch]);
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx`
+Expected: PASS, 9 tests.
+
+- [ ] **Step 5: Run the full check suite**
+
+```bash
+npx vitest run --pool=forks --poolOptions.forks.singleFork
+npm run lint
+npm run typecheck
+npm run build
+```
+
+Expected: all four clean. `npm run lint` must report **zero** warnings as well as zero errors — issue #26 records that hook-dependency warnings pass CI silently, and this task adds a hook with a dependency array.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ui/EcuLab.jsx tests/ui/undo-controls.test.jsx
+git commit -m "Bind undo and redo to the keyboard"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every section maps to a task: `history` slice and uniform snapshot → Task 1; the 50 cap → Task 1 Step 3; "undo does not restore dyno results" → Task 1's `does not restore dyno results` test; reducer purity → Task 1 Step 5's wrapper; commit-on-release → Task 3; `UndoControls` → Task 2; BUILD's offer → Task 4; keyboard → Task 5; the load-bearing preset-label test → Task 2 Step 1; `characterisation.test.jsx` byte-identical → asserted in Task 3 Step 4 and the Global Constraints.
+
+**Type consistency.** `snapshot`/`restore`/`HISTORY_LIMIT` are defined in Task 1 and used by exactly that spelling in Task 1 Step 5. `useHistory` is defined in Task 1 Step 6 and consumed in Tasks 2 and 4. The entry shape `{label, before}` is written in Task 1 and read in Tasks 2 and 4. Labels `'VE edit'`/`'Spark edit'`/`'Fuel edit'`/`'Reset to stock'`/`` `Preset · ${name}` `` are produced by `labelFor` in Task 1 and matched in Tasks 2 and 4.
+
+**Known soft spots, flagged rather than hidden:**
+
+- Task 4's test reuses helpers from `build-screens.test.jsx` that this plan has not read in full. The step says to read them first and adapt rather than invent — if the prop bundle or the turbo switch is not where the plan assumes, that is a deviation to report, not a blocker.
+- `Note`'s accepted `tone` values and the `--line-hi` custom-property spelling are both verify-before-use, called out inline.
+- No test in this repo can see a colour: vitest applies no CSS. The three `.gridHead` blocks and `UndoControls.module.css` are unverifiable by the suite, and nobody will have opened this in a browser. Say so in the PR.

--- a/docs/superpowers/plans/2026-08-25-tune-undo-redo.md
+++ b/docs/superpowers/plans/2026-08-25-tune-undo-redo.md
@@ -1131,6 +1131,38 @@ describe('EngineScreen — the undo offer', () => {
     expect(picker.value).toBe(target);
   });
 
+  it('withdraws the offer once a later edit sits on top of the preset load', () => {
+    // The offer reads the TOP of the stack — `past[past.length - 1]`. Every other test
+    // here creates at most ONE entry before looking, so `past[0]` would satisfy all of
+    // them while reversing the wrong thing. This is the discriminator: after a table
+    // edit lands on top, the top is a 'VE edit', the button would no longer undo the
+    // preset load, and offering it would be a lie about what the click does.
+    function WithTableEdit() {
+      const [tune, dispatch] = useTune();
+      return (
+        <>
+          <button onClick={() => dispatch({ type: ACTIONS.SET_TABLE, table: 've', value: tune.ve })}>
+            EDIT VE
+          </button>
+          <EngineScreen active onToggle={noop} {...props} />
+        </>
+      );
+    }
+    mount(<WithTableEdit />);
+    const picker = /** @type {HTMLSelectElement[]} */ (screen.getAllByRole('combobox'))
+      .find((el) => el.querySelector('optgroup'));
+    const target = [...picker.querySelectorAll('option')]
+      .map((o) => o.value)
+      .find((v) => v && v !== picker.value);
+    fireEvent.change(picker, { target: { value: target } });
+    // The offer is up, so its disappearance below cannot be a false negative.
+    expect(screen.getByRole('button', { name: /^Undo Preset · / })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'EDIT VE' }));
+
+    expect(screen.queryByRole('button', { name: /^Undo / })).toBeNull();
+  });
+
   it('does not offer undo for a plain hardware change', () => {
     // Hardware writes are not undoable, so an offer here would be a lie about what the
     // button does. "Block Material" is a Seg on this screen (`EngineScreen.jsx:242`)

--- a/docs/superpowers/plans/2026-08-25-tune-undo-redo.md
+++ b/docs/superpowers/plans/2026-08-25-tune-undo-redo.md
@@ -21,7 +21,7 @@
 - **History depth is 50**, capped with `.slice(-HISTORY_LIMIT)`.
 - **The reducer stays pure.** No `Date.now()`, no coalescing keys, no merge logic inside it.
 - **Never `git stash`** in any form, never `git add -A`/`git add .`, never `git add node_modules`. ` D node_modules` in `git status` is a known pre-existing condition — leave it. Stage explicit paths only.
-- Run tests as `npx vitest run --pool=forks --poolOptions.forks.singleFork <path>`.
+- Run tests as `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork <path>`.
 - Full check suite before the PR: `npm test`, `npm run lint`, `npm run typecheck`, `npm run build`.
 
 ## File Structure
@@ -353,7 +353,7 @@ describe('UNDO / REDO', () => {
 
 - [ ] **Step 4: Run the tests and watch them fail**
 
-Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/state/reducer.test.js`
+Run: `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/state/reducer.test.js`
 
 Expected: the `UNDO / REDO` suite fails — `ACTIONS.UNDO` is `undefined`, so every dispatch hits the reducer's `default` case and returns state unchanged, and `s.history` is `undefined`. The `makeInitialState` and APPLY_PRESET shape tests should already pass once Step 2 landed.
 
@@ -496,19 +496,19 @@ export function useHistory() {
 
 - [ ] **Step 7: Run the tests and watch them pass**
 
-Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/state/reducer.test.js`
+Run: `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/state/reducer.test.js`
 Expected: PASS, all suites.
 
 Then run the whole suite — the store shape changed, so anything reading it is in scope:
 
-Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork`
+Run: `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork`
 Expected: PASS. If anything outside `reducer.test.js` fails, report it rather than editing that test — the Blast Radius section says only two tests should have needed changes, so a third is a finding.
 
 - [ ] **Step 8: Verify the cap test can actually fail**
 
 A test that cannot fail is worse than no test. Temporarily change `.slice(-HISTORY_LIMIT)` in the `UNDOABLE` branch to `.slice(0, HISTORY_LIMIT)` (keep oldest, drop newest — the plausible wrong version).
 
-Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/state/reducer.test.js -t 'caps the stack'`
+Run: `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/state/reducer.test.js -t 'caps the stack'`
 Expected: FAIL on the `past[0].before.tune.ve` assertion.
 
 Revert the change and re-run to confirm PASS.
@@ -647,7 +647,7 @@ describe('UndoControls', () => {
 
 - [ ] **Step 2: Run and watch it fail**
 
-Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx`
+Run: `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx`
 Expected: FAIL — `Failed to resolve import ".../UndoControls.jsx"`.
 
 - [ ] **Step 3: Write the component**
@@ -789,10 +789,10 @@ correct behaviour, not a bug. What is undoable lives in `src/ui/state/reducer.js
 
 - [ ] **Step 6: Run the tests**
 
-Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx`
+Run: `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx`
 Expected: PASS, 4 tests.
 
-Then: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/`
+Then: `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/`
 Expected: PASS. `button-call-sites.test.jsx` sweeps every rendered `.button` class — `UndoControls` uses its own class, not `Button`, so it should not appear there. If that test fails, report it rather than editing it.
 
 - [ ] **Step 7: Commit**
@@ -852,6 +852,59 @@ describe('the dock slider commits once, on release', () => {
     fireEvent.pointerUp(slider);
 
     expect(screen.getByTestId('depth').textContent).toBe('1');
+    // ...and it must commit the LAST draft, not the first. Depth alone cannot tell
+    // those apart: an implementation that commits the value it saw when the drag
+    // started records exactly one entry too, and would silently write 20 where the
+    // player released at 30.
+    expect(screen.getByTestId('cell').textContent).toBe('30');
+  });
+
+  it('commits on key release too, so the slider is usable from the keyboard', () => {
+    // A keyboard user arrows the slider instead of dragging it. If only onPointerUp
+    // commits, their edit is held in the draft forever and never reaches the table —
+    // the control looks like it works and silently discards every change.
+    render(
+      <StoreProvider>
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' }));
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '22' } });
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+
+    fireEvent.keyUp(slider, { key: 'ArrowRight' });
+
+    expect(screen.getByTestId('depth').textContent).toBe('1');
+    expect(screen.getByTestId('cell').textContent).toBe('22');
+  });
+
+  it('drops an uncommitted draft when the selection moves to another cell', () => {
+    // The draft is per-cell. Without the reset, selecting a new cell keeps showing the
+    // previous cell's abandoned value, and the next release would write that stale
+    // number into a cell the player never dragged.
+    render(
+      <StoreProvider>
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' }));
+    const slider = screen.getByRole('slider');
+    const before = screen.getByTestId('cell').textContent;
+    fireEvent.change(slider, { target: { value: '40' } });
+    expect(screen.getByRole('slider').value).toBe('40');
+
+    // Move to a different cell without releasing: the abandoned 40 must not follow.
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT OTHER' }));
+
+    expect(screen.getByRole('slider').value).not.toBe('40');
+    // Nothing was ever committed, and the first cell still holds its original value.
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+    expect(screen.getByTestId('cell').textContent).toBe(before);
   });
 });
 ```
@@ -867,6 +920,12 @@ function EcuLabTuneHarness() {
       <button onClick={() => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value: { type: 'cell', row: 0, col: 0 } })}>
         SELECT
       </button>
+      <button onClick={() => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value: { type: 'cell', row: 1, col: 1 } })}>
+        SELECT OTHER
+      </button>
+      {/* The cell the first SELECT targets, so a test can assert WHICH value was
+          committed rather than only how many entries were recorded. */}
+      <output data-testid="cell">{tune.timing[0][0]}</output>
       <SelectionDock
         data={tune.timing}
         setData={(value) => dispatch({ type: ACTIONS.SET_TABLE, table: 'timing', value })}
@@ -889,7 +948,7 @@ import { StoreProvider, useHistory, useTune } from '../../src/ui/state/StoreProv
 
 - [ ] **Step 2: Run and watch it fail**
 
-Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx -t 'commits once'`
+Run: `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx -t 'commits once'`
 Expected: FAIL — depth reads `3` after the three `change` events and before any `pointerUp`.
 
 - [ ] **Step 3: Make the slider hold a draft**
@@ -958,17 +1017,17 @@ Leave `cellReference` and the four stepper buttons untouched: a stepper click is
 
 - [ ] **Step 4: Run the tests**
 
-Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx`
+Run: `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx`
 Expected: PASS, 5 tests.
 
-Then: `npx vitest run --pool=forks --poolOptions.forks.singleFork`
+Then: `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork`
 Expected: PASS. `characterisation.test.jsx` must still pass **unmodified** — it drives the `+1` stepper, not the slider.
 
 - [ ] **Step 5: Verify the test can fail**
 
 Temporarily change `onChange={(e) => setDraft(Number(e.target.value))}` back to `onChange={(e) => setAbs(Number(e.target.value))}`.
 
-Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx -t 'commits once'`
+Run: `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx -t 'commits once'`
 Expected: FAIL at the mid-drag assertion, depth `3` instead of `0`.
 
 Revert and re-run to confirm PASS.
@@ -1041,7 +1100,7 @@ This reuses the file's existing `mount` (`:36`), `noop` (`:40`), `engineDerived`
 
 - [ ] **Step 2: Run and watch it fail**
 
-Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/build-screens.test.jsx -t 'undo offer'`
+Run: `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/build-screens.test.jsx -t 'undo offer'`
 Expected: FAIL — no such button.
 
 - [ ] **Step 3: Add the offer**
@@ -1100,10 +1159,10 @@ Check `Note`'s props before using `tone="warn"` — read `src/ui/primitives/Note
 
 - [ ] **Step 4: Run the tests**
 
-Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/build-screens.test.jsx`
+Run: `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/build-screens.test.jsx`
 Expected: PASS.
 
-Then: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/`
+Then: `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/`
 Expected: PASS. `button-call-sites.test.jsx` sweeps `Button` call sites and this adds one — if it reports a new unguarded call site, fix the call site, not the test.
 
 - [ ] **Step 5: Commit**
@@ -1187,7 +1246,7 @@ describe('keyboard shortcuts', () => {
 
 - [ ] **Step 2: Run and watch it fail**
 
-Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx -t 'keyboard shortcuts'`
+Run: `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx -t 'keyboard shortcuts'`
 Expected: FAIL — the cell keeps its edited value after Cmd+Z.
 
 - [ ] **Step 3: Add the handler**
@@ -1221,13 +1280,13 @@ In `src/ui/EcuLab.jsx`, beside the other `useEffect`s:
 
 - [ ] **Step 4: Run the tests**
 
-Run: `npx vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx`
+Run: `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/undo-controls.test.jsx`
 Expected: PASS, 9 tests.
 
 - [ ] **Step 5: Run the full check suite**
 
 ```bash
-npx vitest run --pool=forks --poolOptions.forks.singleFork
+./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork
 npm run lint
 npm run typecheck
 npm run build

--- a/docs/superpowers/plans/2026-08-25-tune-undo-redo.md
+++ b/docs/superpowers/plans/2026-08-25-tune-undo-redo.md
@@ -1271,6 +1271,11 @@ Append to `tests/ui/undo-controls.test.jsx`:
 
 ```jsx
 describe('keyboard shortcuts', () => {
+  // Mid-array, NOT [0]: in TuningGrid's DOM order the first numeric-looking button is
+  // the static RPM=800 axis HEADER, whose text never changes. This is the same index
+  // the file's own pre-existing tests use, for the same reason.
+  const dataCell = (list) => list[Math.floor(list.length / 2)];
+
   function launchWithEdit() {
     render(<EcuLab />);
     fireEvent.click(screen.getByRole('button', { name: 'START' }));
@@ -1278,16 +1283,21 @@ describe('keyboard shortcuts', () => {
     const grid = within(screen.getByTestId('tuning-grid'));
     const cells = grid.getAllByRole('button')
       .filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent));
-    fireEvent.click(cells[0]);
+    const target = dataCell(cells);
+    // Read the value BEFORE the edit. Reading it after would compare the post-edit
+    // state against itself, and every `expect(edited).not.toBe(before)` downstream
+    // would be an assertion that cannot fail.
+    const before = target.textContent;
+    fireEvent.click(target);
     const dock = within(screen.getByTestId('selection-dock'));
     fireEvent.click(dock.getByRole('button', { name: '+1' }));
-    return cells[0].textContent;
+    return before;
   }
 
   it('undoes on Cmd+Z and redoes on Cmd+Shift+Z', () => {
     const before = launchWithEdit();
-    const cell = () => within(screen.getByTestId('tuning-grid'))
-      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent))[0];
+    const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
     const edited = cell().textContent;
     expect(edited).not.toBe(before);
 
@@ -1301,8 +1311,8 @@ describe('keyboard shortcuts', () => {
   it('ignores the shortcut while focus is in a text field', () => {
     // Otherwise the app would steal undo from the field the player is typing in.
     launchWithEdit();
-    const cell = () => within(screen.getByTestId('tuning-grid'))
-      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent))[0];
+    const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
     const edited = cell().textContent;
 
     const input = document.createElement('input');
@@ -1314,8 +1324,8 @@ describe('keyboard shortcuts', () => {
 
   it('ignores a bare z with no modifier', () => {
     launchWithEdit();
-    const cell = () => within(screen.getByTestId('tuning-grid'))
-      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent))[0];
+    const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
     const edited = cell().textContent;
     fireEvent.keyDown(window, { key: 'z' });
     expect(cell().textContent).toBe(edited);
@@ -1326,8 +1336,8 @@ describe('keyboard shortcuts', () => {
     // `key !== 'y'` half of the guard could be deleted and every other test here would
     // still pass — leaving Ctrl+Y silently dead for every Windows player.
     const before = launchWithEdit();
-    const cell = () => within(screen.getByTestId('tuning-grid'))
-      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent))[0];
+    const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
     const edited = cell().textContent;
 
     fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
@@ -1343,8 +1353,8 @@ describe('keyboard shortcuts', () => {
     // SELECT is not hypothetical here: BUILD's preset picker is one, and stealing
     // Cmd+Z from an open picker takes the browser's own behaviour away from it.
     launchWithEdit();
-    const cell = () => within(screen.getByTestId('tuning-grid'))
-      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent))[0];
+    const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
     const edited = cell().textContent;
 
     const select = document.createElement('select');

--- a/docs/superpowers/plans/2026-08-25-tune-undo-redo.md
+++ b/docs/superpowers/plans/2026-08-25-tune-undo-redo.md
@@ -683,7 +683,7 @@ import styles from './UndoControls.module.css';
 
 /** @returns {React.ReactElement} */
 export function UndoControls() {
-  const [history, dispatch] = useHistory();
+  const [history] = useHistory();  // NOT [history, dispatch] — `dispatch` is already bound by useBuild() in this scope, and redeclaring it is a syntax error. It is the same function either way.
   const { past, future } = history;
   const undoLabel = past.length ? `Undo ${past[past.length - 1].label}` : 'Nothing to undo';
   const redoLabel = future.length ? `Redo ${future[0].label}` : 'Nothing to redo';
@@ -1121,7 +1121,7 @@ describe('EngineScreen — the undo offer', () => {
     fireEvent.change(picker, { target: { value: target } });
     expect(picker.value).toBe(target);
 
-    fireEvent.click(screen.getByRole('button', { name: /^RESET TO STOCK$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /RESET ALL TO STOCK/i }));
     // The reset cleared presetId, so the picker no longer names the preset.
     expect(picker.value).not.toBe(target);
 
@@ -1195,7 +1195,7 @@ import { useHistory } from '../../state/StoreProvider.jsx';
 Inside the component, beside the existing `useBuild()` call:
 
 ```js
-  const [history, dispatch] = useHistory();
+  const [history] = useHistory();  // NOT [history, dispatch] — `dispatch` is already bound by useBuild() in this scope, and redeclaring it is a syntax error. It is the same function either way.
   // Only the two acts that replace the whole calibration get an offer here. A table
   // edit is undoable too, but its undo lives above the grid on TUNE, where the edit
   // happened — an offer on BUILD for something the player did on another tab would be

--- a/docs/superpowers/plans/2026-08-25-tune-undo-redo.md
+++ b/docs/superpowers/plans/2026-08-25-tune-undo-redo.md
@@ -1073,15 +1073,60 @@ describe('EngineScreen — the undo offer', () => {
     mount(<EngineScreen active onToggle={noop} {...props} />);
     const picker = /** @type {HTMLSelectElement[]} */ (screen.getAllByRole('combobox'))
       .find((el) => el.querySelector('optgroup'));
+    const was = picker.value;
     const target = [...picker.querySelectorAll('option')]
       .map((o) => o.value)
       .find((v) => v && v !== picker.value);
     fireEvent.change(picker, { target: { value: target } });
+    expect(picker.value).toBe(target);
 
     fireEvent.click(screen.getByRole('button', { name: /^Undo Preset · / }));
 
+    // The offer going away is NOT sufficient evidence: a button that dispatches
+    // nothing and merely hides the Note passes that assertion too. Assert the preset
+    // load was actually reversed.
+    expect(picker.value).toBe(was);
     // Undone: the offer goes with it, because the top of the stack is gone.
     expect(screen.queryByRole('button', { name: /^Undo Preset · / })).toBeNull();
+  });
+
+  it('offers to undo a reset to stock, naming it', () => {
+    // The Note appears for a preset load OR a reset — both are the destructive acts
+    // this offer exists for. Testing only the preset case would let an implementation
+    // that matches on `Preset · ` alone pass while leaving the reset, which throws
+    // away EVERYTHING, with no offer at all.
+    //
+    // `onResetToStock` is a PROP, so the shared `props` object's `noop` would dispatch
+    // nothing and this test would pass without a reset ever happening. Wire a real one
+    // the way EcuLab.jsx does. `ve` is supplied by the caller, not the reducer — the
+    // current table is fine here, since what is under test is the history entry, not
+    // which numbers a reset computes.
+    function WithRealReset() {
+      const [tune, dispatch] = useTune();
+      return (
+        <EngineScreen
+          active onToggle={noop} {...props}
+          onResetToStock={() => dispatch({ type: ACTIONS.RESET_TO_STOCK, ve: tune.ve })}
+        />
+      );
+    }
+    mount(<WithRealReset />);
+    const picker = /** @type {HTMLSelectElement[]} */ (screen.getAllByRole('combobox'))
+      .find((el) => el.querySelector('optgroup'));
+    const target = [...picker.querySelectorAll('option')]
+      .map((o) => o.value)
+      .find((v) => v && v !== picker.value);
+    fireEvent.change(picker, { target: { value: target } });
+    expect(picker.value).toBe(target);
+
+    fireEvent.click(screen.getByRole('button', { name: /^RESET TO STOCK$/i }));
+    // The reset cleared presetId, so the picker no longer names the preset.
+    expect(picker.value).not.toBe(target);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Undo Reset to stock' }));
+
+    // The reset is reversed, so the preset it wiped is selected again.
+    expect(picker.value).toBe(target);
   });
 
   it('does not offer undo for a plain hardware change', () => {
@@ -1096,7 +1141,7 @@ describe('EngineScreen — the undo offer', () => {
 });
 ```
 
-This reuses the file's existing `mount` (`:36`), `noop` (`:40`), `engineDerived` (`:41`) and `veAdvice` (`:42`) — do not define a second set. Add `within` to the `@testing-library/react` import if it is not there already. `MATERIAL_OPTS` is `['Cast Iron', 'Aluminum']` (`src/sim/hardware.js:45`) and the default block is `Aluminum`, so clicking `Cast Iron` is a real change rather than a no-op the reducer would skip.
+This reuses the file's existing `mount` (`:36`), `noop` (`:40`), `engineDerived` (`:41`) and `veAdvice` (`:42`) — do not define a second set. Add `within` to the `@testing-library/react` import if it is not there already, and add `useTune` to the existing `StoreProvider.jsx` import plus an `ACTIONS` import from `../../src/ui/state/reducer.js` — the reset test needs both. `MATERIAL_OPTS` is `['Cast Iron', 'Aluminum']` (`src/sim/hardware.js:45`) and the default block is `Aluminum`, so clicking `Cast Iron` is a real change rather than a no-op the reducer would skip.
 
 - [ ] **Step 2: Run and watch it fail**
 
@@ -1241,8 +1286,61 @@ describe('keyboard shortcuts', () => {
     fireEvent.keyDown(window, { key: 'z' });
     expect(cell().textContent).toBe(edited);
   });
+
+  it('redoes on Ctrl+Y, the Windows spelling', () => {
+    // The handler accepts 'y' as well as shift+z. Nothing else asserts it, so the
+    // `key !== 'y'` half of the guard could be deleted and every other test here would
+    // still pass — leaving Ctrl+Y silently dead for every Windows player.
+    const before = launchWithEdit();
+    const cell = () => within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent))[0];
+    const edited = cell().textContent;
+
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+    expect(cell().textContent).toBe(before);
+
+    fireEvent.keyDown(window, { key: 'y', ctrlKey: true });
+    expect(cell().textContent).toBe(edited);
+  });
+
+  it('ignores the shortcut while focus is in a select or a contenteditable', () => {
+    // The INPUT case above is the only guard any other test exercises, so the SELECT
+    // and isContentEditable halves could both be dropped with the suite still green.
+    // SELECT is not hypothetical here: BUILD's preset picker is one, and stealing
+    // Cmd+Z from an open picker takes the browser's own behaviour away from it.
+    launchWithEdit();
+    const cell = () => within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent))[0];
+    const edited = cell().textContent;
+
+    const select = document.createElement('select');
+    document.body.appendChild(select);
+    fireEvent.keyDown(select, { key: 'z', metaKey: true });
+    expect(cell().textContent).toBe(edited);
+    select.remove();
+
+    const editable = document.createElement('div');
+    editable.contentEditable = 'true';
+    document.body.appendChild(editable);
+    fireEvent.keyDown(editable, { key: 'z', metaKey: true });
+    expect(cell().textContent).toBe(edited);
+    editable.remove();
+  });
 });
 ```
+
+Note on the contenteditable case: jsdom does not implement `isContentEditable`, so
+setting `contentEditable = 'true'` leaves the property `undefined` and that assertion
+would pass for the wrong reason. Define it on the element explicitly so the guard is
+actually exercised:
+
+```jsx
+Object.defineProperty(editable, 'isContentEditable', { value: true });
+```
+
+Add that line immediately after `editable.contentEditable = 'true';`. Verify it matters
+by deleting the `|| (el && el.isContentEditable)` clause from the handler and confirming
+this test fails.
 
 - [ ] **Step 2: Run and watch it fail**
 

--- a/docs/superpowers/plans/2026-08-25-tune-undo-redo.md
+++ b/docs/superpowers/plans/2026-08-25-tune-undo-redo.md
@@ -246,8 +246,14 @@ describe('UNDO / REDO', () => {
   });
 
   it('puts the table back', () => {
+    // One `start`, threaded through both dispatches, so this can assert reference
+    // equality: restore must hand back the SAME array the snapshot captured, not a
+    // recomputed one that merely looks equal. Two independent `makeInitialState()`
+    // calls would defeat that — the function's own header documents that it returns a
+    // fresh object graph every time, and `ve` is recomputed by `computeHardwareVE`.
     const start = makeInitialState();
-    const s = reducer(edited(), { type: ACTIONS.UNDO });
+    const edit = reducer(start, { type: ACTIONS.SET_TABLE, table: 've', value: [[42]] });
+    const s = reducer(edit, { type: ACTIONS.UNDO });
     expect(s.tune.ve).toBe(start.tune.ve);
     expect(s.history.past).toHaveLength(0);
     expect(s.history.future).toHaveLength(1);

--- a/docs/superpowers/specs/2026-08-25-tune-undo-redo-design.md
+++ b/docs/superpowers/specs/2026-08-25-tune-undo-redo-design.md
@@ -71,6 +71,20 @@ live-engine model, navigation, and grid selection. Every hardware control alread
 displays its own current value, so it is self-reversing; and undo must not become a time
 machine over banked career progress.
 
+**Correction, made during implementation.** "Not undoable" above means *does not push a
+history entry* — it does NOT mean undo leaves hardware alone. The snapshot is the union
+of every field an undoable action can touch, and that includes thirteen build fields, so
+undoing a preset load or a reset restores the hardware as it was at that moment. A
+hardware change made *after* an undoable action is therefore reversed by undoing that
+action, silently, even though the hardware change pushed nothing itself.
+
+That is the correct behaviour — undoing a preset load means returning to the state before
+it, and a partial restore would be worse. But it makes the wording of BUILD's offer
+load-bearing: the Note must say that undo restores tables **and hardware**, or it
+promises a smaller click than the one it performs. The original sentence named only the
+three tables, which was false; the review caught it, and the human chose to keep the
+behaviour and fix the sentence.
+
 ## Design
 
 ### The `history` slice

--- a/docs/superpowers/specs/2026-08-25-tune-undo-redo-design.md
+++ b/docs/superpowers/specs/2026-08-25-tune-undo-redo-design.md
@@ -1,0 +1,211 @@
+# Undo/redo for calibration edits — design
+
+Issue: [#60](https://github.com/DNiev/ecu-lab/issues/60) (first of three PRs)
+Date: 2026-08-25
+Status: approved
+
+## Problem
+
+There is no undo anywhere in ECU Lab. Every calibration edit is permanent the moment it
+lands, and the only way back to a known state is `RESET TO STOCK`, which throws away
+*everything* rather than the last thing you did.
+
+That is already bad. Issue #60's later PRs make it dangerous: bulk operations over a
+selected rectangle (±delta, scale %, set, interpolate, smooth) are exactly the feature
+that turns a slip into a wrecked 6×8 table. The issue's own words — "a mis-drag on a 6×8
+table is currently unrecoverable" — describe a hazard that does not fully exist yet.
+
+So undo ships **before** the thing it protects against, not alongside it.
+
+### What issue #60 got right
+
+All five claims verify against the code:
+
+| Claim | Verdict |
+|---|---|
+| `TuningGrid` holds one `{type:'cell'\|'row'\|'col'}`, no range selection | **Valid.** `TuningGrid.jsx:19` |
+| No undo/redo anywhere in the app | **Valid.** `ACTIONS` has 15 entries, none a history op |
+| No diff-vs-stock overlay | **Valid.** `TuningGrid` colours by `heat(val, min, max)` only |
+| Pure grid transforms belong in `src/sim/tables.js` | **Valid.** It already owns the tables, axes and `SPARK_MIN_DEG`/`SPARK_MAX_DEG`; `CONTRIBUTING.md:27` forbids engineering maths in `src/ui/` |
+| The reducer-backed store makes an edit log natural | **Valid.** `SET_TABLE` is the single funnel for all three calibration tables |
+
+### What the issue missed
+
+**Changing the `Selection` shape breaks the advisor panel merged in #87.**
+`advisorReports.js` reads `selection.type === 'row'`, `selection.row` and `selection.col`
+in all three report functions, and `countIn()` (`:37`) branches on exactly those.
+`TuningGrid`, `SelectionDock`, `EcuLab.jsx:258`, the `initialState.js:60` typedef and
+their tests read the same shape. That is a migration, not an addition — and it is why
+selection work is deferred to PR 4b rather than bundled here.
+
+**#60 is five features, not one.** Range selection, bulk operations, undo/redo, keyboard
+navigation and a diff overlay. Only two are coupled (bulk ops and keyboard both need the
+new selection). Undo and the overlay are independent of it.
+
+## Scope
+
+Issue #60 is split into three PRs. **This spec covers 4a only.**
+
+| PR | Contents | Depends on |
+|---|---|---|
+| **4a** | Undo/redo | — |
+| 4b | Selection rectangle, bulk ops, keyboard tuning | 4a |
+| 4c | Diff-vs-stock overlay | — |
+
+### Undoable
+
+- `SET_TABLE` — any VE / spark / AFR edit
+- `APPLY_PRESET` — loading a factory preset over the current tune
+- `RESET_TO_STOCK`
+
+`APPLY_PRESET` and `RESET_TO_STOCK` are included deliberately. Loading a preset over
+hand-tuned tables is the most destructive single act in the app, and it already carries a
+confirmation prompt (`presetPrompt`), which is the codebase agreeing that the danger is
+real. Undo that covers the small mistake but not the large one teaches players not to
+trust it.
+
+### Not undoable
+
+Hardware changes (turbo, injectors, octane, bolt-ons), dyno pulls and scores, the
+live-engine model, navigation, and grid selection. Every hardware control already
+displays its own current value, so it is self-reversing; and undo must not become a time
+machine over banked career progress.
+
+## Design
+
+### The `history` slice
+
+A fourth top-level slice beside `build`, `tune` and `session`:
+
+```js
+history: { past: [], future: [] }   // entries: { label, before }
+```
+
+`before` is a **uniform snapshot** — the union of every field any undoable action can
+touch, rather than a per-action shape:
+
+- from `build`: `engineConfig`, `mods`, `turboOn`, `boostCurve`, `turbineIdx`,
+  `turbineCount`, `compressorIdx`, `injIdx`, `ecuInjectorCc`, `octaneIdx`,
+  `exhaustDiaIdx`, `mafScalar`, `presetId`
+- from `tune`: `ve`, `timing`, `afr`, `tablesDirty`
+
+One shape means one `snapshot()` and one `restore()`. A per-action shape would mean three
+restore paths, and a fourth undoable action added later could produce a half-restored
+state that no test thought to cover.
+
+`label` names what would be undone — `"VE edit"`, `"Preset · N54 Twin Turbo"`,
+`"Reset to stock"`. It is load-bearing twice over: it gives the buttons a real
+`aria-label` instead of a bare glyph, and it is how BUILD decides whether the top of the
+stack is a preset load worth offering to reverse.
+
+Depth is capped at **50** entries via `slice(-50)` on push. A snapshot is roughly 1 KB
+(144 table numbers plus scalars), so 50 is ~50 KB — irrelevant, since only career stats
+(`{best, total, pulls}`) reach storage and the state tree itself is never persisted. The
+cap exists because an array that only ever grows is a leak with a long fuse, and because
+"unlimited" is not a promise the UI can show honestly.
+
+### Why undo does not restore dyno results
+
+`APPLY_PRESET` clears `session.result` and `prevResult` so that "a factory rating from the
+newly loaded engine must never sit next to a pull logged on whatever was running before
+it" (`reducer.js:393-397`). Undo restores hardware and calibration but leaves the results
+cleared.
+
+This is a deliberate asymmetry, not an oversight. The result is lost either way — undo
+does not make it worse than the path without undo — whereas re-showing a banked score
+beside a build that was just reverted is the direction that states something false.
+
+### Reducer changes
+
+`ACTIONS` gains `UNDO` and `REDO`. Every existing case is untouched; recording wraps them:
+
+```js
+const UNDOABLE = new Set([ACTIONS.SET_TABLE, ACTIONS.APPLY_PRESET, ACTIONS.RESET_TO_STOCK]);
+```
+
+- An undoable action pushes `snapshot(state)` — the state *before* it — onto `past`,
+  capped at 50, and clears `future`.
+- `UNDO` pops `past`, pushes the current snapshot onto `future`, and restores.
+- `REDO` mirrors it.
+- Either with an empty stack returns `state` unchanged rather than throwing.
+
+The reducer stays a pure function of `(state, action)`: no clock, no coalescing keys, no
+merge logic. That purity is what the commit-on-release decision below buys, and the
+existing reducer tests depend on it.
+
+No `src/sim` change of any kind, so the behavioural fingerprint is untouched by this PR.
+The history stack is state bookkeeping, not engineering maths, so `CONTRIBUTING.md:27`
+keeps it in `src/ui/state/`. PR 4b is where `tables.js` gains the grid transforms.
+
+### Commit-on-release, and why it is required
+
+`SelectionDock.jsx:127` is `<input type="range" onChange={...}>`, and React maps `onChange`
+on a range input to the `input` event — so it fires continuously during a drag. Dragging
+timing from 12° to 30° dispatches roughly **18** `SET_TABLE`s today. Recorded naively,
+undo would walk back one slider pixel at a time and be worthless.
+
+The fix is at the source rather than in the history: the slider holds a local draft value,
+`onChange` updates only the draft, and `onPointerUp`/`onKeyUp` commits exactly one
+`SET_TABLE`. The draft resets when the selection changes. The steppers are unchanged — one
+click, one entry.
+
+Cost: the grid's heat tint updates on release rather than continuously. The dock's own
+large readout still tracks the input live, so the value feedback a player actually watches
+while dragging is unchanged.
+
+The two alternatives were rejected for concrete reasons. Merging entries by an edit key
+adds a field to the action plus merge logic, and still mis-merges two separate edits to
+the same cell with nothing in between unless the dock also tracks gesture boundaries.
+Merging by a time window puts a clock inside a reducer whose purity its tests rely on, and
+makes undo depth depend on how fast the player happened to drag.
+
+### Components
+
+**`src/ui/components/UndoControls.jsx` + `.module.css`** (new) — the ↶ ↷ pair. Each button
+is disabled when its stack is empty and takes its `aria-label` from the entry it would
+reverse ("Undo VE edit"). Mounted in the grid header on TUNE's AIRFLOW, SPARK and FUEL.
+A `React.memo`'d leaf: `LIVE_STEP` dispatches at 20 Hz and the store is a single context,
+so every consumer re-renders on every action (`AppShell.jsx`, "THE 20 Hz PROBLEM"). This
+must not add to that.
+
+**`src/ui/components/SelectionDock.jsx`** — the draft-value slider described above.
+
+**BUILD** — after a preset load or a reset, a `Note` offering `UNDO`, shown when the top of
+`past` is a preset or reset entry. Placing it at the hazard rather than in the app header
+keeps HOME and DYNO free of a control that would be inert on both, which is what the
+overhaul's "more pages, less things on a page" brief asks for.
+
+**`src/ui/EcuLab.jsx`** — the Cmd/Ctrl+Z and Cmd+Shift+Z / Ctrl+Y handler. It goes here,
+not in `AppShell`, whose header states that the shell owns chrome only and "never
+dispatches to the store directly". A global key handler is app behaviour, not chrome. It
+is ignored while focus is in an `input`, `textarea`, `select`, or a contenteditable
+element.
+
+## Testing
+
+The load-bearing test, because it proves the cross-slice restore end to end:
+
+> load a preset → edit a cell (the header falls back to `3.0L I6`) → undo → **the header
+> claims the preset again**
+
+That fails for any implementation which restores the 48 numbers but forgets `presetId` —
+the exact defect a table-only history would ship.
+
+Alongside it:
+
+- Pure reducer tests: depth capped at 50; `future` cleared by a new edit; undo and redo on
+  an empty stack are no-ops; `tablesDirty` restored; `UNDO` after `APPLY_PRESET` restores
+  the build fields.
+- Slider: three `change` events followed by one `pointerUp` produce exactly **one** history
+  entry. Asserting the count is the point — asserting only the final value would pass just
+  as well with 18 entries recorded.
+- `UndoControls`: disabled states, and labels drawn from the entry.
+
+`tests/ui/characterisation.test.jsx` stays byte-identical. It drives the dock's `+1`
+stepper, not the slider, and no existing test touches the TUNE slider at all — only
+BUILD's boost slider (`build-store.test.jsx:503`), which this PR does not change.
+
+## Out of scope
+
+Selection rectangles, bulk operations, keyboard tuning and the diff overlay — PRs 4b and
+4c. Undoing hardware changes. Persisting history across a reload.

--- a/docs/superpowers/specs/2026-08-25-tune-undo-redo-design.md
+++ b/docs/superpowers/specs/2026-08-25-tune-undo-redo-design.md
@@ -103,9 +103,27 @@ touch, rather than a per-action shape:
   `exhaustDiaIdx`, `mafScalar`, `presetId`
 - from `tune`: `ve`, `timing`, `afr`, `tablesDirty`
 
-One shape means one `snapshot()` and one `restore()`. A per-action shape would mean three
-restore paths, and a fourth undoable action added later could produce a half-restored
-state that no test thought to cover.
+One shape means one `snapshot()`. A per-action *capture* shape would mean a fourth
+undoable action added later could snapshot too little and produce a half-restored state
+that no test thought to cover.
+
+**Correction, made during the final review.** This section originally extended that
+argument to `restore()` as well — one shape, one restore path. That half was wrong, and
+the review proved it: `SET_TABLE` writes only `build.presetId` on the build side, so
+restoring all thirteen build fields when undoing a table edit reverts hardware the player
+installed *after* that edit. Turn the turbo on, then press undo on a VE edit, and the
+turbo silently comes off under the label "Undo VE edit".
+
+Capture stays uniform; **restore is now scoped to what the undone action actually wrote**.
+Undoing a `SET_TABLE` restores `presetId` and the tune fields and leaves the other twelve
+build fields alone. `APPLY_PRESET` and `RESET_TO_STOCK` still restore everything, because
+undoing a preset load genuinely does mean returning to the state before it. The entry
+carries the scope so `restore` does not have to import the action types.
+
+The same review found the matching gap on the other side: only undoable actions cleared
+`future`, so a redo could replay a snapshot over hardware built since the undo and destroy
+it. Any build- or tune-writing action now clears the redo stack. `LIVE_STEP` is excluded —
+at 20 Hz it would empty `future` before a player could reach the button.
 
 `label` names what would be undone — `"VE edit"`, `"Preset · N54 Twin Turbo"`,
 `"Reset to stock"`. It is load-bearing twice over: it gives the buttons a real

--- a/docs/superpowers/specs/2026-08-25-tune-undo-redo-design.md
+++ b/docs/superpowers/specs/2026-08-25-tune-undo-redo-design.md
@@ -164,9 +164,16 @@ makes undo depth depend on how fast the player happened to drag.
 **`src/ui/components/UndoControls.jsx` + `.module.css`** (new) — the ↶ ↷ pair. Each button
 is disabled when its stack is empty and takes its `aria-label` from the entry it would
 reverse ("Undo VE edit"). Mounted in the grid header on TUNE's AIRFLOW, SPARK and FUEL.
-A `React.memo`'d leaf: `LIVE_STEP` dispatches at 20 Hz and the store is a single context,
-so every consumer re-renders on every action (`AppShell.jsx`, "THE 20 Hz PROBLEM"). This
-must not add to that.
+**Correction, made during implementation.** This section originally called for a
+`React.memo`'d leaf, reasoning that `LIVE_STEP` dispatches at 20 Hz and the store is a
+single context, so every consumer re-renders on every action (`AppShell.jsx`, "THE 20 Hz
+PROBLEM"). That reasoning was wrong about what `memo` does. The review measured it: five
+unrelated dispatches took the component's render count from 1 to 6 with the wrapper in
+place. `React.memo` only blocks re-renders driven by a parent's props; a component
+reading context re-renders whenever the context value changes, which is exactly the 20 Hz
+case. The wrapper is gone, and the component's header says so, because the next reader
+would otherwise copy it. The real fix for the 20 Hz problem is splitting the context —
+out of scope here, and not something two buttons and two string reads justify.
 
 **`src/ui/components/SelectionDock.jsx`** — the draft-value slider described above.
 

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -657,7 +657,10 @@ export function EcuLabApp() {
   useEffect(() => {
     /** @param {KeyboardEvent} e */
     const onKey = (e) => {
-      if (!(e.metaKey || e.ctrlKey)) return;
+      // Ctrl+Alt is AltGr on many European keyboard layouts, where AltGr+Z / AltGr+Y
+      // types a real character. Excluding altKey keeps this handler from stealing
+      // that keystroke and swallowing it with preventDefault().
+      if (!(e.metaKey || e.ctrlKey) || e.altKey) return;
       const key = e.key.toLowerCase();
       if (key !== 'z' && key !== 'y') return;
       // Never steal undo from a field the player is typing in.

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -649,6 +649,29 @@ export function EcuLabApp() {
     // Stable for the life of the store, so this still loads career stats exactly once.
   }, [dispatch]);
 
+  // Cmd/Ctrl+Z and Cmd+Shift+Z / Ctrl+Y. This lives here rather than in AppShell,
+  // whose header is explicit that the shell owns chrome only and never dispatches to
+  // the store — a global key handler is app behaviour, not chrome.
+  //
+  // PR 4b's arrow-key tuning will need this same seam.
+  useEffect(() => {
+    /** @param {KeyboardEvent} e */
+    const onKey = (e) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      const key = e.key.toLowerCase();
+      if (key !== 'z' && key !== 'y') return;
+      // Never steal undo from a field the player is typing in.
+      const el = /** @type {HTMLElement|null} */ (e.target);
+      const tag = el && el.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || (el && el.isContentEditable)) return;
+      e.preventDefault();
+      const redo = key === 'y' || e.shiftKey;
+      dispatch({ type: redo ? ACTIONS.REDO : ACTIONS.UNDO });
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [dispatch]);
+
   const chartData = useMemo(() => {
     if (!result) return [];
     return result.points.slice(0, running ? revealCount : result.points.length).map((p, i) => ({

--- a/src/ui/components/README.md
+++ b/src/ui/components/README.md
@@ -42,3 +42,9 @@ the body; `report.state` (from `sparkReport`/`fuelReport`/`veReport` in
 supplies the numbers. It is pure — no store access, no computation — so the screens stay
 the only thing in TUNE that talks to the store, and `advisorReports.js` stays the only
 thing that decides what a cell's category means.
+
+`UndoControls` is the ordinary shared-component reason again: AIRFLOW, SPARK and FUEL
+each mount one above their grid. It takes no props and reads `history` from the store
+itself, because the stacks are global — undoing a spark edit from the FUEL screen is
+correct behaviour, not a bug. What is undoable lives in `src/ui/state/reducer.js`
+(`UNDOABLE`); what a snapshot carries lives in `src/ui/state/history.js`.

--- a/src/ui/components/SelectionDock.jsx
+++ b/src/ui/components/SelectionDock.jsx
@@ -74,6 +74,19 @@ function cellReference(kind, row, col, value) {
  * @returns {React.ReactElement|null}
  */
 export function SelectionDock({ data, setData, selection, min, max, decimals, unit, onClose, kind }) {
+  // The slider's in-flight value. React maps onChange on a range input to the `input`
+  // event, so a drag fires it continuously; committing each one would turn a single
+  // drag into eighteen undo steps. The draft holds the value while the finger is down
+  // and commits exactly once on release.
+  const [draft, setDraft] = React.useState(/** @type {number|null} */ (null));
+
+  // A new selection is a new cell: drop any draft left over from the last one, or the
+  // slider would open showing the previous cell's in-flight value.
+  const selKey = selection
+    ? `${selection.type}:${selection.row ?? ''}:${selection.col ?? ''}`
+    : '';
+  React.useEffect(() => { setDraft(null); }, [selKey]);
+
   if (!selection) return null;
   let current;
   if (selection.type === 'cell') current = data[selection.row][selection.col];
@@ -94,6 +107,14 @@ export function SelectionDock({ data, setData, selection, min, max, decimals, un
     else next.forEach((r) => { r[selection.col] = clamp(v, min, max); });
     setData(next);
   };
+  // What the slider and the big readout show: the finger's position while dragging,
+  // the table's committed value otherwise.
+  const shown = draft === null ? current : draft;
+  const commitDraft = () => {
+    if (draft === null) return;
+    setAbs(draft);
+    setDraft(null);
+  };
   const smallStep = decimals ? 0.1 : 1;
   const bigStep = decimals ? 1 : 5;
   let sel = 'Cell';
@@ -107,7 +128,7 @@ export function SelectionDock({ data, setData, selection, min, max, decimals, un
         <div>
           <div style={{ fontSize: 10, letterSpacing: 1, color: T.ink2, textTransform: 'uppercase', fontWeight: 700 }}>{sel}</div>
           <div style={{ fontFamily: T.mono, fontSize: 23, fontWeight: 800, color: T.ink }}>
-            {decimals ? current.toFixed(decimals) : Math.round(current)}<span style={{ fontSize: 12, color: T.ink2, marginLeft: 4 }}>{unit}</span>
+            {decimals ? shown.toFixed(decimals) : Math.round(shown)}<span style={{ fontSize: 12, color: T.ink2, marginLeft: 4 }}>{unit}</span>
           </div>
         </div>
         <Button variant="ghost" size="sm" onClick={onClose}>DONE</Button>
@@ -124,7 +145,13 @@ export function SelectionDock({ data, setData, selection, min, max, decimals, un
           </Panel>
         );
       })()}
-      <input type="range" min={min} max={max} step={smallStep} value={current} onChange={(e) => setAbs(Number(e.target.value))} style={{ width: '100%', accentColor: T.acc }} />
+      <input
+        type="range" min={min} max={max} step={smallStep} value={shown}
+        onChange={(e) => setDraft(Number(e.target.value))}
+        onPointerUp={commitDraft}
+        onKeyUp={commitDraft}
+        style={{ width: '100%', accentColor: T.acc }}
+      />
       <div style={{ display: 'flex', gap: 7, marginTop: 9 }}>
         {/* One colour for all four: the +/- is already in the label. Painting the
             positive steps with the status green said "raising this cell is good", which

--- a/src/ui/components/SelectionDock.jsx
+++ b/src/ui/components/SelectionDock.jsx
@@ -61,6 +61,17 @@ function cellReference(kind, row, col, value) {
 }
 
 /**
+ * Every key a range input responds to by changing its own value — the complete set
+ * per the HTML spec's slider behaviour. A key release only commits the draft if it is
+ * one of these, so Task 3's keyboard-usable slider still works while no other release
+ * (a modifier's own keyup above all) can commit anything.
+ */
+const COMMIT_KEYS = new Set([
+  'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown',
+  'Home', 'End', 'PageUp', 'PageDown',
+]);
+
+/**
  * @param {object} props
  * @param {number[][]} props.data rows of values, indexed [row][col] against LOAD/RPM
  * @param {(next: number[][]) => void} props.setData
@@ -91,8 +102,21 @@ export function SelectionDock({ data, setData, selection, min, max, decimals, un
   // the NEW cell's `current`. Comparing against the last-seen key here and
   // resetting before this render is returned avoids that frame entirely.
   const [prevSelKey, setPrevSelKey] = React.useState(selKey);
-  if (selKey !== prevSelKey) {
+  // ...and the same treatment for the TABLE moving under a still-selected cell. An
+  // undo (or any other external write) replaces `data` without touching `selection`,
+  // and an abandoned draft used to survive that: the grid went back to 10 while the
+  // dock's readout and slider still showed 42, and a late `pointerup` then wrote 42
+  // back over the undo and destroyed the redo branch with it. `apply()` already
+  // abandons the draft for exactly this reason when the write comes from a stepper;
+  // this is the same reasoning applied to a write from outside.
+  //
+  // Safe against a live drag: a drag commits nothing, so `data` keeps the same
+  // reference from the first `change` to the `pointerup` that ends it. The reference,
+  // not a deep compare — every write path here goes through `clone2D`.
+  const [prevData, setPrevData] = React.useState(data);
+  if (selKey !== prevSelKey || data !== prevData) {
     setPrevSelKey(selKey);
+    setPrevData(data);
     setDraft(null);
   }
 
@@ -135,15 +159,16 @@ export function SelectionDock({ data, setData, selection, min, max, decimals, un
     setAbs(draft);
     setDraft(null);
   };
-  // A modifier-shortcut key release must not reach commitDraft. EcuLab's global
-  // Cmd/Ctrl+Z handler blocks its *keydown* on this element (tagName === 'INPUT'),
-  // but the matching *keyup* still bubbles here — and without this guard it would
-  // commit whatever draft is pending, turning "press undo" into "commit an edit
-  // and burn an undo slot" (see tests/ui/undo-controls.test.jsx). An ordinary
-  // arrow-key release (no metaKey/ctrlKey) must still commit — that is Task 3's
-  // existing keyboard-usable slider, unaffected by this.
+  // Only a key that actually moved the slider may commit. A WHITELIST, not a
+  // modifier blacklist: the browser's real sequence for undo is keydown Meta ->
+  // keydown z -> keyup z -> keyup META, and on that last event `metaKey` is already
+  // false (modifier flags on a keyup report the state AFTER it), so a
+  // `if (e.metaKey || e.ctrlKey) return;` guard lets it through and commits the
+  // pending draft — turning "press undo" into "commit an edit and burn an undo slot",
+  // the exact bug the guard was added for. Naming the keys that CAN change a range
+  // input's value leaves nothing to enumerate on the other side.
   const onSliderKeyUp = (e) => {
-    if (e.metaKey || e.ctrlKey) return;
+    if (!COMMIT_KEYS.has(e.key)) return;
     commitDraft();
   };
   const smallStep = decimals ? 0.1 : 1;

--- a/src/ui/components/SelectionDock.jsx
+++ b/src/ui/components/SelectionDock.jsx
@@ -135,6 +135,17 @@ export function SelectionDock({ data, setData, selection, min, max, decimals, un
     setAbs(draft);
     setDraft(null);
   };
+  // A modifier-shortcut key release must not reach commitDraft. EcuLab's global
+  // Cmd/Ctrl+Z handler blocks its *keydown* on this element (tagName === 'INPUT'),
+  // but the matching *keyup* still bubbles here — and without this guard it would
+  // commit whatever draft is pending, turning "press undo" into "commit an edit
+  // and burn an undo slot" (see tests/ui/undo-controls.test.jsx). An ordinary
+  // arrow-key release (no metaKey/ctrlKey) must still commit — that is Task 3's
+  // existing keyboard-usable slider, unaffected by this.
+  const onSliderKeyUp = (e) => {
+    if (e.metaKey || e.ctrlKey) return;
+    commitDraft();
+  };
   const smallStep = decimals ? 0.1 : 1;
   const bigStep = decimals ? 1 : 5;
   let sel = 'Cell';
@@ -169,7 +180,7 @@ export function SelectionDock({ data, setData, selection, min, max, decimals, un
         type="range" min={min} max={max} step={smallStep} value={shown}
         onChange={(e) => setDraft(Number(e.target.value))}
         onPointerUp={commitDraft}
-        onKeyUp={commitDraft}
+        onKeyUp={onSliderKeyUp}
         style={{ width: '100%', accentColor: T.acc }}
       />
       <div style={{ display: 'flex', gap: 7, marginTop: 9 }}>

--- a/src/ui/components/SelectionDock.jsx
+++ b/src/ui/components/SelectionDock.jsx
@@ -128,7 +128,10 @@ export function SelectionDock({ data, setData, selection, min, max, decimals, un
     // A drag that ends where it began is not an edit. Committing it would burn an
     // undo slot AND, via SET_TABLE, clear build.presetId and set tablesDirty —
     // disowning a factory calibration the player never actually changed.
-    if (draft === current) { setDraft(null); return; }
+    //
+    // Cells only: for a row or column `current` is the MEAN, so landing on it is a
+    // real edit that flattens every cell to that value, not a no-op.
+    if (selection.type === 'cell' && draft === current) { setDraft(null); return; }
     setAbs(draft);
     setDraft(null);
   };

--- a/src/ui/components/SelectionDock.jsx
+++ b/src/ui/components/SelectionDock.jsx
@@ -85,7 +85,16 @@ export function SelectionDock({ data, setData, selection, min, max, decimals, un
   const selKey = selection
     ? `${selection.type}:${selection.row ?? ''}:${selection.col ?? ''}`
     : '';
-  React.useEffect(() => { setDraft(null); }, [selKey]);
+  // Adjusting state when a prop changes, done during render rather than in a
+  // useEffect: an effect only runs after the browser has already painted this
+  // render, so for one frame `shown` would show the PREVIOUS cell's draft against
+  // the NEW cell's `current`. Comparing against the last-seen key here and
+  // resetting before this render is returned avoids that frame entirely.
+  const [prevSelKey, setPrevSelKey] = React.useState(selKey);
+  if (selKey !== prevSelKey) {
+    setPrevSelKey(selKey);
+    setDraft(null);
+  }
 
   if (!selection) return null;
   let current;
@@ -94,6 +103,10 @@ export function SelectionDock({ data, setData, selection, min, max, decimals, un
   else current = data.reduce((a, r) => a + r[selection.col], 0) / data.length;
 
   const apply = (delta) => {
+    // A stepper click is a new intent on this cell: any draft left over from a drag
+    // that never released is abandoned, not pending. Without this it survives and the
+    // NEXT release overwrites the value this click just committed.
+    setDraft(null);
     const next = clone2D(data);
     if (selection.type === 'cell') next[selection.row][selection.col] = Number(clamp(next[selection.row][selection.col] + delta, min, max).toFixed(2));
     else if (selection.type === 'row') next[selection.row] = next[selection.row].map((v) => Number(clamp(v + delta, min, max).toFixed(2)));
@@ -112,6 +125,10 @@ export function SelectionDock({ data, setData, selection, min, max, decimals, un
   const shown = draft === null ? current : draft;
   const commitDraft = () => {
     if (draft === null) return;
+    // A drag that ends where it began is not an edit. Committing it would burn an
+    // undo slot AND, via SET_TABLE, clear build.presetId and set tablesDirty —
+    // disowning a factory calibration the player never actually changed.
+    if (draft === current) { setDraft(null); return; }
     setAbs(draft);
     setDraft(null);
   };
@@ -127,7 +144,7 @@ export function SelectionDock({ data, setData, selection, min, max, decimals, un
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 7 }}>
         <div>
           <div style={{ fontSize: 10, letterSpacing: 1, color: T.ink2, textTransform: 'uppercase', fontWeight: 700 }}>{sel}</div>
-          <div style={{ fontFamily: T.mono, fontSize: 23, fontWeight: 800, color: T.ink }}>
+          <div data-testid="dock-readout" style={{ fontFamily: T.mono, fontSize: 23, fontWeight: 800, color: T.ink }}>
             {decimals ? shown.toFixed(decimals) : Math.round(shown)}<span style={{ fontSize: 12, color: T.ink2, marginLeft: 4 }}>{unit}</span>
           </div>
         </div>

--- a/src/ui/components/UndoControls.jsx
+++ b/src/ui/components/UndoControls.jsx
@@ -1,0 +1,49 @@
+/**
+ * The undo/redo pair for TUNE's calibration tables.
+ *
+ * Chrome only: it reads the two stack lengths and dispatches. What is undoable, and
+ * what a snapshot contains, belongs to the reducer — see `src/ui/state/history.js`.
+ *
+ * Each button takes its accessible name from the entry it would reverse ("Undo VE
+ * edit"), so the control is not a bare glyph to a screen reader, and the disabled
+ * state carries its own reason ("Nothing to undo") rather than going silent.
+ *
+ * `React.memo` matters here: LIVE_STEP dispatches at 20 Hz and the store is a single
+ * context, so every consumer re-renders on every action regardless of the slice it
+ * reads (see AppShell.jsx, "THE 20 Hz PROBLEM"). Memoising bails this out whenever the
+ * stacks have not moved.
+ */
+
+import { Redo2, Undo2 } from 'lucide-react';
+import React from 'react';
+
+import { ACTIONS } from '../state/reducer.js';
+import { useHistory } from '../state/StoreProvider.jsx';
+
+import styles from './UndoControls.module.css';
+
+/** @returns {React.ReactElement} */
+export const UndoControls = React.memo(function UndoControls() {
+  const [history, dispatch] = useHistory();
+  const { past, future } = history;
+  const undoLabel = past.length ? `Undo ${past[past.length - 1].label}` : 'Nothing to undo';
+  const redoLabel = future.length ? `Redo ${future[0].label}` : 'Nothing to redo';
+  return (
+    <div className={styles.row}>
+      <button
+        type="button" className={styles.btn} disabled={past.length === 0}
+        aria-label={undoLabel} title={undoLabel}
+        onClick={() => dispatch({ type: ACTIONS.UNDO })}
+      >
+        <Undo2 size={14} />
+      </button>
+      <button
+        type="button" className={styles.btn} disabled={future.length === 0}
+        aria-label={redoLabel} title={redoLabel}
+        onClick={() => dispatch({ type: ACTIONS.REDO })}
+      >
+        <Redo2 size={14} />
+      </button>
+    </div>
+  );
+});

--- a/src/ui/components/UndoControls.jsx
+++ b/src/ui/components/UndoControls.jsx
@@ -8,10 +8,12 @@
  * edit"), so the control is not a bare glyph to a screen reader, and the disabled
  * state carries its own reason ("Nothing to undo") rather than going silent.
  *
- * `React.memo` matters here: LIVE_STEP dispatches at 20 Hz and the store is a single
- * context, so every consumer re-renders on every action regardless of the slice it
- * reads (see AppShell.jsx, "THE 20 Hz PROBLEM"). Memoising bails this out whenever the
- * stacks have not moved.
+ * `React.memo` would NOT help here and is deliberately absent. The store is a single
+ * context, so every consumer re-renders on every dispatch — including LIVE_STEP at
+ * 20 Hz — regardless of the slice it reads (see AppShell.jsx, "THE 20 Hz PROBLEM").
+ * memo only blocks re-renders driven by a parent's props. Two buttons and two string
+ * reads is cheap; the fix for the 20 Hz problem is splitting the context, not
+ * memoising its consumers.
  */
 
 import { Redo2, Undo2 } from 'lucide-react';
@@ -23,7 +25,7 @@ import { useHistory } from '../state/StoreProvider.jsx';
 import styles from './UndoControls.module.css';
 
 /** @returns {React.ReactElement} */
-export const UndoControls = React.memo(function UndoControls() {
+export function UndoControls() {
   const [history, dispatch] = useHistory();
   const { past, future } = history;
   const undoLabel = past.length ? `Undo ${past[past.length - 1].label}` : 'Nothing to undo';
@@ -46,4 +48,4 @@ export const UndoControls = React.memo(function UndoControls() {
       </button>
     </div>
   );
-});
+}

--- a/src/ui/components/UndoControls.module.css
+++ b/src/ui/components/UndoControls.module.css
@@ -1,0 +1,33 @@
+.row {
+  display: flex;
+  gap: 4px;
+  margin-left: auto;
+}
+
+.btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 26px;
+  border: 1px solid var(--line);
+  border-radius: 7px;
+  background: var(--panel2);
+  color: var(--ink2);
+  cursor: pointer;
+}
+
+.btn:hover:not(:disabled) {
+  border-color: var(--line-hi);
+  color: var(--ink);
+}
+
+.btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--acc);
+  outline-offset: 2px;
+}

--- a/src/ui/components/UndoControls.module.css
+++ b/src/ui/components/UndoControls.module.css
@@ -1,5 +1,8 @@
 .row {
   display: flex;
+  /* 4px is not on the spacing scale: this pair reads as one two-part control,
+     not two separate buttons with page rhythm between them. --sp-xs (3px)
+     read as touching; --sp-sm (7px) split them visibly. Left raw. */
   gap: 4px;
   margin-left: auto;
 }
@@ -11,6 +14,9 @@
   width: 30px;
   height: 26px;
   border: 1px solid var(--line);
+  /* 7px is not on the radius scale: --r-sm's 6px looked flush against this
+     button's 1px border at 30x26px, --r-md's 9px looked closer to a pill
+     than a square icon button. Left raw. */
   border-radius: 7px;
   background: var(--panel2);
   color: var(--ink2);

--- a/src/ui/screens/build/EngineScreen.jsx
+++ b/src/ui/screens/build/EngineScreen.jsx
@@ -167,8 +167,12 @@ export function EngineScreen({ active, onToggle, engineDerived, activePreset, ve
           </div>
           <div className={styles.calloutRow}>
             {/* The one `danger` in the app. This prompt is raised ONLY when
-                `hasTuningWork()` is true, so confirming it always destroys
-                hand-edited VE/spark/fuel tables that nothing can restore. */}
+                `hasTuningWork()` is true, so confirming it always overwrites
+                hand-edited VE/spark/fuel tables. It is no longer irreversible —
+                APPLY_PRESET is undoable, and the offer to undo it renders a few
+                lines below — but it is still a whole calibration replaced in one
+                click, and the undo stack is 50 deep and lives only for the session,
+                so the warning stays. */}
             {/* Button has the same rest-spread-after-className shape as Panel and
                 Select, so `style`, not `className`, is what actually reaches it
                 without discarding its variant class. */}

--- a/src/ui/screens/build/EngineScreen.jsx
+++ b/src/ui/screens/build/EngineScreen.jsx
@@ -184,7 +184,7 @@ export function EngineScreen({ active, onToggle, engineDerived, activePreset, ve
       {undoable && (
         <Note tone="warn">
           <span className={styles.undoRow}>
-            <span>{top.label} replaced your VE, spark and fuel tables.</span>
+            <span>{top.label} replaced your tune. Undo restores the tables and hardware as they were before it.</span>
             <Button
               variant="quiet" size="sm"
               aria-label={`Undo ${top.label}`}

--- a/src/ui/screens/build/EngineScreen.jsx
+++ b/src/ui/screens/build/EngineScreen.jsx
@@ -24,7 +24,7 @@ import { Panel } from '../../primitives/Panel.jsx';
 import { Seg } from '../../primitives/Seg.jsx';
 import { Select } from '../../primitives/Select.jsx';
 import { ACTIONS } from '../../state/reducer.js';
-import { useBuild, useSession, useTune } from '../../state/StoreProvider.jsx';
+import { useBuild, useHistory, useSession, useTune } from '../../state/StoreProvider.jsx';
 
 import styles from './EngineScreen.module.css';
 
@@ -63,6 +63,15 @@ export function EngineScreen({ active, onToggle, engineDerived, activePreset, ve
   const { tablesDirty } = tune;
   const [session] = useSession();
   const { result } = session;
+  // `dispatch` above is the store's one dispatch function — useHistory() would hand
+  // back the identical reference, so only `history` is taken from it here.
+  const [history] = useHistory();
+  // Only the two acts that replace the whole calibration get an offer here. A table
+  // edit is undoable too, but its undo lives above the grid on TUNE, where the edit
+  // happened — an offer on BUILD for something the player did on another tab would be
+  // a control with no visible cause.
+  const top = history.past[history.past.length - 1];
+  const undoable = top && (top.label.startsWith('Preset · ') || top.label === 'Reset to stock');
 
   const setCfg = (patch) => dispatch({ type: ACTIONS.SET_ENGINE_CONFIG_PATCH, patch });
   const clearPresetId = () => dispatch({ type: ACTIONS.CLEAR_PRESET_ID });
@@ -171,6 +180,20 @@ export function EngineScreen({ active, onToggle, engineDerived, activePreset, ve
             </Button>
           </div>
         </div>
+      )}
+      {undoable && (
+        <Note tone="warn">
+          <span className={styles.undoRow}>
+            <span>{top.label} replaced your VE, spark and fuel tables.</span>
+            <Button
+              variant="quiet" size="sm"
+              aria-label={`Undo ${top.label}`}
+              onClick={() => dispatch({ type: ACTIONS.UNDO })}
+            >
+              UNDO
+            </Button>
+          </span>
+        </Note>
       )}
       <Panel tight style={{ marginBottom: 13 }}>
         <div className={styles.displacementRow}><span>DISPLACEMENT</span><span className={styles.statValue}>{engineDerived.displacementL.toFixed(2)} L</span></div>

--- a/src/ui/screens/build/EngineScreen.module.css
+++ b/src/ui/screens/build/EngineScreen.module.css
@@ -154,3 +154,10 @@
   margin-top: 14px;
   margin-bottom: 9px;
 }
+
+.undoRow {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-sm);
+  justify-content: space-between;
+}

--- a/src/ui/screens/tune/AirflowScreen.jsx
+++ b/src/ui/screens/tune/AirflowScreen.jsx
@@ -18,6 +18,7 @@ import { SelectionDock } from '../../components/SelectionDock.jsx';
 import { TuneAdvisory } from '../../components/TuneAdvisory.jsx';
 import { TuningGrid } from '../../components/TuningGrid.jsx';
 import { ExpandableInfo } from '../../components/ExpandableInfo.jsx';
+import { UndoControls } from '../../components/UndoControls.jsx';
 import { Eyebrow } from '../../primitives/Eyebrow.jsx';
 import { ACTIONS } from '../../state/reducer.js';
 import { useTune } from '../../state/StoreProvider.jsx';
@@ -61,7 +62,10 @@ export function AirflowScreen({ veAdvice, veTruth }) {
     <>
       <div className={styles.wrap}>
         <div className={styles.main}>
-          <Eyebrow icon={Grid3x3}>Volumetric Efficiency</Eyebrow>
+          <div className={styles.gridHead}>
+            <Eyebrow icon={Grid3x3}>Volumetric Efficiency</Eyebrow>
+            <UndoControls />
+          </div>
           <div className={styles.intro}>How completely the cylinder fills at each engine speed and load. Rows are manifold pressure (MAP kPa &mdash; about 100 is wide open, higher is boost); columns are RPM. Tap any cell for reference data.</div>
           <TuningGrid data={ve} min={10} max={130} decimals={0} selection={selection} setSelection={setSelection} />
 

--- a/src/ui/screens/tune/AirflowScreen.module.css
+++ b/src/ui/screens/tune/AirflowScreen.module.css
@@ -4,6 +4,12 @@
   padding: var(--sp-xl) var(--sp-xl) 0;
 }
 
+.gridHead {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-sm);
+}
+
 /* 560px is the project's one breakpoint — see the note beside the scale in
    tokens.css, which lists every file that uses it. Kept in sync by hand with
    StartScreen.module.css, TutorialScreen.module.css, AppShell.module.css and

--- a/src/ui/screens/tune/FuelScreen.jsx
+++ b/src/ui/screens/tune/FuelScreen.jsx
@@ -15,6 +15,7 @@ import { SelectionDock } from '../../components/SelectionDock.jsx';
 import { TuneAdvisory } from '../../components/TuneAdvisory.jsx';
 import { TuningGrid } from '../../components/TuningGrid.jsx';
 import { ExpandableInfo } from '../../components/ExpandableInfo.jsx';
+import { UndoControls } from '../../components/UndoControls.jsx';
 import { Eyebrow } from '../../primitives/Eyebrow.jsx';
 import { ACTIONS } from '../../state/reducer.js';
 import { useTune } from '../../state/StoreProvider.jsx';
@@ -42,7 +43,10 @@ export function FuelScreen({ calAdvice }) {
     <>
       <div className={styles.wrap}>
         <div className={styles.main}>
-          <Eyebrow icon={Droplets}>Air-Fuel Ratio Target</Eyebrow>
+          <div className={styles.gridHead}>
+            <Eyebrow icon={Droplets}>Air-Fuel Ratio Target</Eyebrow>
+            <UndoControls />
+          </div>
           <div className={styles.intro}>Target air:fuel ratio the ECU aims for. Divide by 14.7 to read it as lambda.</div>
           <TuningGrid data={afr} min={10} max={18} decimals={1} selection={selection} setSelection={setSelection} />
 

--- a/src/ui/screens/tune/FuelScreen.module.css
+++ b/src/ui/screens/tune/FuelScreen.module.css
@@ -4,6 +4,12 @@
   padding: var(--sp-xl) var(--sp-xl) 0;
 }
 
+.gridHead {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-sm);
+}
+
 /* 560px is the project's one breakpoint — see the note beside the scale in
    tokens.css, which lists every file that uses it. Kept in sync by hand with
    StartScreen.module.css, TutorialScreen.module.css, AppShell.module.css and

--- a/src/ui/screens/tune/SparkScreen.jsx
+++ b/src/ui/screens/tune/SparkScreen.jsx
@@ -17,6 +17,7 @@ import { SelectionDock } from '../../components/SelectionDock.jsx';
 import { TuneAdvisory } from '../../components/TuneAdvisory.jsx';
 import { TuningGrid } from '../../components/TuningGrid.jsx';
 import { ExpandableInfo } from '../../components/ExpandableInfo.jsx';
+import { UndoControls } from '../../components/UndoControls.jsx';
 import { Eyebrow } from '../../primitives/Eyebrow.jsx';
 import { ACTIONS } from '../../state/reducer.js';
 import { useTune } from '../../state/StoreProvider.jsx';
@@ -51,7 +52,10 @@ export function SparkScreen({ calAdvice }) {
     <>
       <div className={styles.wrap}>
         <div className={styles.main}>
-          <Eyebrow icon={Zap}>Ignition Timing</Eyebrow>
+          <div className={styles.gridHead}>
+            <Eyebrow icon={Zap}>Ignition Timing</Eyebrow>
+            <UndoControls />
+          </div>
           <div className={styles.intro}>Degrees of spark advance before top dead center (° BTDC).</div>
           <TuningGrid data={timing} min={SPARK_MIN_DEG} max={SPARK_MAX_DEG} decimals={0} selection={selection} setSelection={setSelection} />
 

--- a/src/ui/screens/tune/SparkScreen.module.css
+++ b/src/ui/screens/tune/SparkScreen.module.css
@@ -4,6 +4,12 @@
   padding: var(--sp-xl) var(--sp-xl) 0;
 }
 
+.gridHead {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-sm);
+}
+
 /* 560px is the project's one breakpoint — see the note beside the scale in
    tokens.css, which lists every file that uses it. Kept in sync by hand with
    StartScreen.module.css, TutorialScreen.module.css, AppShell.module.css and

--- a/src/ui/state/StoreProvider.jsx
+++ b/src/ui/state/StoreProvider.jsx
@@ -17,6 +17,7 @@ import { reducer } from './reducer.js';
 /** @typedef {import('./initialState.js').BuildState} BuildState */
 /** @typedef {import('./initialState.js').TuneState} TuneState */
 /** @typedef {import('./initialState.js').SessionState} SessionState */
+/** @typedef {import('./initialState.js').HistoryState} HistoryState */
 /** @typedef {import('./reducer.js').StoreAction} StoreAction */
 
 /** @typedef {[StoreState, React.Dispatch<StoreAction>]} StoreContextValue */
@@ -84,4 +85,13 @@ export function useTune() {
 export function useSession() {
   const [state, dispatch] = useStore();
   return [state.session, dispatch];
+}
+
+/**
+ * The HISTORY slice: the undo and redo stacks.
+ * @returns {[HistoryState, React.Dispatch<StoreAction>]}
+ */
+export function useHistory() {
+  const [state, dispatch] = useStore();
+  return [state.history, dispatch];
 }

--- a/src/ui/state/StoreProvider.jsx
+++ b/src/ui/state/StoreProvider.jsx
@@ -1,11 +1,12 @@
 /**
  * The store's React binding.
  *
- * One `useReducer`, one context carrying `[state, dispatch]`, and three hooks —
- * `useBuild`, `useTune`, `useSession` — that each select their own slice. Consumers
- * see the three-way split the design doc specifies; internally it stays one state
- * tree, for the reasons in reducer.js's file header (cross-slice actions like
- * SET_TABLE, and APPLY_PRESET/RESET_TO_STOCK to come, must land in a single pass).
+ * One `useReducer`, one context carrying `[state, dispatch]`, and four hooks —
+ * `useBuild`, `useTune`, `useSession`, `useHistory` — that each select their own
+ * slice. Consumers see the per-slice split the design doc specifies; internally it
+ * stays one state tree, for the reasons in reducer.js's file header (cross-slice
+ * actions like SET_TABLE, and APPLY_PRESET/RESET_TO_STOCK, must land in a single
+ * pass).
  */
 
 import React, { createContext, useContext, useReducer } from 'react';

--- a/src/ui/state/history.js
+++ b/src/ui/state/history.js
@@ -1,0 +1,73 @@
+/**
+ * The undo stack's data model: what one snapshot contains, and how it goes back.
+ *
+ * Deliberately holds NO action types. `reducer.js` imports this, so importing
+ * `ACTIONS` back from there would be a cycle — which is also why `labelFor()`
+ * lives in the reducer rather than here.
+ *
+ * The snapshot is UNIFORM: it captures the union of every field any undoable
+ * action can overwrite, not the subset a particular action happens to touch. One
+ * shape means one restore path. A per-action shape would mean three, and a fourth
+ * undoable action added later could produce a half-restored state that no test
+ * thought to cover.
+ */
+
+/** @typedef {import('./initialState.js').StoreState} StoreState */
+/** @typedef {{build: object, tune: object}} Snapshot */
+
+/**
+ * How many undo steps are kept. A snapshot is roughly 1 KB (144 table numbers plus
+ * scalars), so the cap is not about memory — it is that an array which only ever
+ * grows is a leak with a long fuse.
+ */
+export const HISTORY_LIMIT = 50;
+
+/**
+ * BUILD fields an undoable action can overwrite. APPLY_PRESET writes all thirteen;
+ * RESET_TO_STOCK writes three; SET_TABLE writes one. The snapshot carries the union
+ * so `restore` never has to know which action it is undoing.
+ */
+const BUILD_KEYS = [
+  'engineConfig', 'mods', 'turboOn', 'boostCurve', 'turbineIdx', 'turbineCount',
+  'compressorIdx', 'injIdx', 'ecuInjectorCc', 'octaneIdx', 'exhaustDiaIdx',
+  'mafScalar', 'presetId',
+];
+
+/**
+ * TUNE fields an undoable action can overwrite.
+ *
+ * `selection` is deliberately absent: it is a cursor, not calibration. Restoring it
+ * would make undo move the player's highlight around, and the grid's dimensions never
+ * change, so a selection is always still valid after a restore.
+ */
+const TUNE_KEYS = ['ve', 'timing', 'afr', 'tablesDirty'];
+
+/**
+ * Captures the undoable projection of a state tree.
+ * @param {StoreState} state
+ * @returns {Snapshot}
+ */
+export function snapshot(state) {
+  /** @type {any} */
+  const build = {};
+  /** @type {any} */
+  const tune = {};
+  for (const key of BUILD_KEYS) build[key] = /** @type {any} */ (state.build)[key];
+  for (const key of TUNE_KEYS) tune[key] = /** @type {any} */ (state.tune)[key];
+  return { build, tune };
+}
+
+/**
+ * Puts a snapshot back, leaving every field it does not carry alone — `session`
+ * entirely, and `tune.selection`.
+ * @param {StoreState} state
+ * @param {Snapshot} before
+ * @returns {StoreState}
+ */
+export function restore(state, before) {
+  return {
+    ...state,
+    build: { ...state.build, ...before.build },
+    tune: { ...state.tune, ...before.tune },
+  };
+}

--- a/src/ui/state/history.js
+++ b/src/ui/state/history.js
@@ -5,11 +5,25 @@
  * `ACTIONS` back from there would be a cycle — which is also why `labelFor()`
  * lives in the reducer rather than here.
  *
- * The snapshot is UNIFORM: it captures the union of every field any undoable
- * action can overwrite, not the subset a particular action happens to touch. One
- * shape means one restore path. A per-action shape would mean three, and a fourth
- * undoable action added later could produce a half-restored state that no test
- * thought to cover.
+ * CAPTURE is UNIFORM: `snapshot` records the union of every field any undoable
+ * action can overwrite, not the subset a particular action happens to touch. That
+ * half of the original design is unchanged and stays — one shape means a snapshot
+ * cannot be half-taken, and a fourth undoable action added later cannot forget a
+ * field.
+ *
+ * RESTORE is NOT uniform, and the original argument for making it so was wrong. It
+ * read "one shape means one restore path", but a single restore path puts back all
+ * thirteen build fields regardless of what the undone action actually wrote — so
+ * `SET_TABLE ve` -> `SET_BUILD_FIELD turboOn = true` -> UNDO silently took the turbo
+ * back off, under a label reading "Undo VE edit". The snapshot was never wrong; the
+ * assumption that every entry should be played back in full was. So an entry now
+ * carries a SCOPE alongside its snapshot, and `restore` puts back only as much as
+ * that scope names — see {@link RESTORE_ALL} and {@link RESTORE_CALIBRATION}.
+ *
+ * The scope is a plain string on the entry rather than something derived from the
+ * action type here, because deriving it would mean importing `ACTIONS` — the cycle
+ * this file's header opens by ruling out. `reducer.js` names the scope when it
+ * records the entry; this file only knows the two names and what each puts back.
  *
  * The union's rule for membership is: HARDWARE AND CALIBRATION, NEVER UI CURSORS.
  * Two fields an undoable action does write are deliberately excluded even though
@@ -73,16 +87,53 @@ export function snapshot(state) {
 }
 
 /**
- * Puts a snapshot back, leaving every field it does not carry alone — `session`
- * entirely, and `tune.selection`.
+ * Puts back EVERY snapshotted field — all thirteen build fields and all four tune
+ * fields. The scope for an action that replaces the whole calibration and the
+ * hardware under it: APPLY_PRESET and RESET_TO_STOCK. Undoing a preset load
+ * genuinely means "return to the state before it", so anything the player changed
+ * afterwards is meant to go with it.
+ */
+export const RESTORE_ALL = 'all';
+
+/**
+ * Puts back the four tune fields and `build.presetId` ONLY, leaving the other twelve
+ * build fields exactly as they are. The scope for SET_TABLE, whose entire build-side
+ * write IS `presetId` (a hand edit disowns the preset). Restoring more than that is
+ * how a VE edit's undo used to remove a turbo fitted after it.
+ *
+ * `presetId` is restored rather than left alone for the same reason it is cleared on
+ * the way in: put the table back without it and the header goes on disowning a preset
+ * the player never actually left.
+ */
+export const RESTORE_CALIBRATION = 'calibration';
+
+/** @typedef {typeof RESTORE_ALL | typeof RESTORE_CALIBRATION} RestoreScope */
+
+/**
+ * Puts a snapshot back, as far as `scope` names, leaving every field it does not
+ * touch alone — `session` entirely, `tune.selection`, and under
+ * {@link RESTORE_CALIBRATION} every build field except `presetId`.
  * @param {StoreState} state
  * @param {Snapshot} before
+ * @param {RestoreScope} scope
  * @returns {StoreState}
  */
-export function restore(state, before) {
-  return {
-    ...state,
-    build: { ...state.build, ...before.build },
-    tune: { ...state.tune, ...before.tune },
-  };
+export function restore(state, before, scope) {
+  // The tune side is the same under both scopes: SET_TABLE writes a table and
+  // `tablesDirty`, APPLY_PRESET/RESET_TO_STOCK write all four, and putting back a
+  // table the action never touched is a no-op because the snapshot holds the value
+  // that is already there.
+  const tune = { ...state.tune, ...before.tune };
+  switch (scope) {
+    case RESTORE_ALL:
+      return { ...state, build: { ...state.build, ...before.build }, tune };
+    case RESTORE_CALIBRATION:
+      return { ...state, build: { ...state.build, presetId: before.build.presetId }, tune };
+    default:
+      // Same reasoning as `labelFor`'s default branch in reducer.js: an entry
+      // recorded with no scope, or with a scope this function does not implement,
+      // would otherwise restore some arbitrary subset and look like a physics or
+      // state bug somewhere else entirely. Fail here, naming the scope.
+      throw new Error(`restore: unknown scope "${scope}"`);
+  }
 }

--- a/src/ui/state/history.js
+++ b/src/ui/state/history.js
@@ -72,6 +72,22 @@ const BUILD_KEYS = [
 const TUNE_KEYS = ['ve', 'timing', 'afr', 'tablesDirty'];
 
 /**
+ * Does a write to `tune.<field>` touch something a snapshot carries?
+ *
+ * `reducer.js` asks this so `SET_TUNE_FIELD`'s exclusion from the redo-clearing set is
+ * STRUCTURAL rather than a fact about who happens to call it. Every production caller
+ * passes `field: 'selection'` today — a cursor, outside the snapshot — but nothing stops
+ * a future one passing `'ve'`, and that write would then survive alongside a live redo
+ * branch that overwrites exactly it. Asking the key list directly closes that by
+ * construction, and keeps the list itself private to this module.
+ * @param {string} field
+ * @returns {boolean}
+ */
+export function snapshotsTuneField(field) {
+  return TUNE_KEYS.includes(field);
+}
+
+/**
  * Captures the undoable projection of a state tree.
  * @param {StoreState} state
  * @returns {Snapshot}

--- a/src/ui/state/history.js
+++ b/src/ui/state/history.js
@@ -10,6 +10,12 @@
  * shape means one restore path. A per-action shape would mean three, and a fourth
  * undoable action added later could produce a half-restored state that no test
  * thought to cover.
+ *
+ * The union's rule for membership is: HARDWARE AND CALIBRATION, NEVER UI CURSORS.
+ * Two fields an undoable action does write are deliberately excluded even though
+ * that might look like a missed field at a glance — `tune.selection` and
+ * `build.presetPrompt` — see the comments on TUNE_KEYS and BUILD_KEYS below for why
+ * each one specifically is a cursor rather than state worth restoring.
  */
 
 /** @typedef {import('./initialState.js').StoreState} StoreState */
@@ -23,9 +29,17 @@
 export const HISTORY_LIMIT = 50;
 
 /**
- * BUILD fields an undoable action can overwrite. APPLY_PRESET writes all thirteen;
- * RESET_TO_STOCK writes three; SET_TABLE writes one. The snapshot carries the union
- * so `restore` never has to know which action it is undoing.
+ * BUILD fields an undoable action can overwrite. APPLY_PRESET actually writes
+ * FOURTEEN build fields, not the thirteen listed here — it also sets
+ * `presetPrompt: null`, which is deliberately absent from this list. `presetPrompt`
+ * is a cursor/UI-state field, not hardware — `reducer.js`'s own typedef for
+ * `SET_PRESET_PROMPT` already describes it that way — it tracks whether the
+ * overwrite-confirmation modal is open, exactly like `tune.selection` below tracks
+ * the grid highlight. Restoring it on undo would re-open a "load this preset?" modal
+ * immediately after the player undid loading that preset, which is worse than
+ * leaving it closed. RESET_TO_STOCK writes three of the fields below; SET_TABLE
+ * writes one. The snapshot carries the union of the hardware/calibration fields so
+ * `restore` never has to know which action it is undoing.
  */
 const BUILD_KEYS = [
   'engineConfig', 'mods', 'turboOn', 'boostCurve', 'turbineIdx', 'turbineCount',
@@ -36,9 +50,10 @@ const BUILD_KEYS = [
 /**
  * TUNE fields an undoable action can overwrite.
  *
- * `selection` is deliberately absent: it is a cursor, not calibration. Restoring it
- * would make undo move the player's highlight around, and the grid's dimensions never
- * change, so a selection is always still valid after a restore.
+ * `selection` is deliberately absent, for the same "hardware and calibration, never UI
+ * cursors" reason `presetPrompt` is absent from BUILD_KEYS above: it is a cursor, not
+ * calibration. Restoring it would make undo move the player's highlight around, and the
+ * grid's dimensions never change, so a selection is always still valid after a restore.
  */
 const TUNE_KEYS = ['ve', 'timing', 'afr', 'tablesDirty'];
 

--- a/src/ui/state/initialState.js
+++ b/src/ui/state/initialState.js
@@ -91,14 +91,22 @@ import {
  * The undo stack. `past` is oldest-first, so the next thing UNDO reverses is the LAST
  * element; `future` is newest-first, so REDO takes element 0.
  *
- * Each entry holds the state BEFORE its action ran, and a `label` naming what would be
- * undone. The label is load-bearing twice: it gives the undo buttons a real
- * `aria-label` instead of a bare glyph, and it is how BUILD decides whether the top of
- * the stack is a preset load worth offering to reverse.
+ * Each entry holds the state BEFORE its action ran, a `label` naming what would be
+ * undone, and the `scope` saying how much of that snapshot goes back. The label is
+ * load-bearing twice: it gives the undo buttons a real `aria-label` instead of a bare
+ * glyph, and it is how BUILD decides whether the top of the stack is a preset load
+ * worth offering to reverse. The scope is what keeps a uniform snapshot from being
+ * replayed over fields the recorded action never wrote — see `restore` in history.js.
+ *
+ * @typedef {{
+ *   label: string,
+ *   before: import('./history.js').Snapshot,
+ *   scope: import('./history.js').RestoreScope,
+ * }} HistoryEntry
  *
  * @typedef {object} HistoryState
- * @property {{label: string, before: import('./history.js').Snapshot}[]} past
- * @property {{label: string, before: import('./history.js').Snapshot}[]} future
+ * @property {HistoryEntry[]} past
+ * @property {HistoryEntry[]} future
  */
 
 /**

--- a/src/ui/state/initialState.js
+++ b/src/ui/state/initialState.js
@@ -88,10 +88,25 @@ import {
  */
 
 /**
+ * The undo stack. `past` is oldest-first, so the next thing UNDO reverses is the LAST
+ * element; `future` is newest-first, so REDO takes element 0.
+ *
+ * Each entry holds the state BEFORE its action ran, and a `label` naming what would be
+ * undone. The label is load-bearing twice: it gives the undo buttons a real
+ * `aria-label` instead of a bare glyph, and it is how BUILD decides whether the top of
+ * the stack is a preset load worth offering to reverse.
+ *
+ * @typedef {object} HistoryState
+ * @property {{label: string, before: import('./history.js').Snapshot}[]} past
+ * @property {{label: string, before: import('./history.js').Snapshot}[]} future
+ */
+
+/**
  * @typedef {object} StoreState
  * @property {BuildState} build
  * @property {TuneState} tune
  * @property {SessionState} session
+ * @property {HistoryState} history
  */
 
 /**
@@ -142,5 +157,6 @@ export function makeInitialState() {
       soundOn: true,
       journeyStep: 0,
     },
+    history: { past: [], future: [] },
   };
 }

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -254,7 +254,7 @@ export const ACTIONS = Object.freeze({
 /**
  * The union of every action shape the reducer actually understands. Deliberately has
  * NO catch-all `{type: string, [key: string]: *}` member: with one, every object
- * shape is assignable to `StoreAction` and the eleven specific typedefs above become
+ * shape is assignable to `StoreAction` and the seventeen specific typedefs above become
  * decorative — a typo'd payload key (`presset` instead of `preset`) would typecheck
  * clean. Without the catch-all, `tsc` must reject it.
  * @typedef {SetBuildFieldAction | ClearPresetIdAction | SetTurbineAction | SetTableAction |

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -28,7 +28,7 @@
 import { clamp, clone2D, DEFAULT_AFR, DEFAULT_MODS, DEFAULT_TIMING, liveStep, presetById } from '../../sim/index.js';
 
 import {
-  HISTORY_LIMIT, RESTORE_ALL, RESTORE_CALIBRATION, restore, snapshot,
+  HISTORY_LIMIT, RESTORE_ALL, RESTORE_CALIBRATION, restore, snapshot, snapshotsTuneField,
 } from './history.js';
 
 /** @typedef {import('./initialState.js').StoreState} StoreState */
@@ -562,6 +562,26 @@ const UNDOABLE = new Set(Object.keys(UNDO_SCOPE));
  * new work?" — they reach `future: []` through the recording branch below rather than
  * through this Set, and listing them keeps the two from disagreeing on paper.
  */
+/**
+ * Does this action write a field some snapshot carries, and therefore abandon a live
+ * redo branch?
+ *
+ * `SET_TUNE_FIELD` needs the extra question because it is the one action whose write
+ * surface depends on its payload rather than its type. Its five production callers all
+ * pass `field: 'selection'` — a cursor, outside the snapshot, and written by `changeTab`
+ * on every tab switch, so treating it as new work would mean walking from TUNE to BUILD
+ * killed the redo the player crossed tabs to reach. But nothing in the type stops a
+ * caller passing `'ve'`, and that write WOULD be overwritten by a redo. Asking the
+ * snapshot's own key list makes the exclusion structural instead of an observation about
+ * today's callers.
+ * @param {any} action
+ * @returns {boolean}
+ */
+function clearsRedo(action) {
+  if (action.type === ACTIONS.SET_TUNE_FIELD) return snapshotsTuneField(action.field);
+  return CLEARS_REDO.has(action.type);
+}
+
 const CLEARS_REDO = new Set([
   ACTIONS.SET_BUILD_FIELD, ACTIONS.CLEAR_PRESET_ID, ACTIONS.SET_TURBINE,
   ACTIONS.SET_ENGINE_CONFIG_PATCH, ACTIONS.SET_TABLE, ACTIONS.APPLY_PRESET,
@@ -669,7 +689,7 @@ export function reducer(state, action) {
   // Not recordable, but still new work: a hardware write is not undoable (the control
   // shows its own value) yet it changes fields a redo would overwrite, so it abandons
   // the redo branch just the same. See CLEARS_REDO for what counts and what must not.
-  if (!CLEARS_REDO.has(action.type) || state.history.future.length === 0) return next;
+  if (!clearsRedo(action) || state.history.future.length === 0) return next;
   return {
     ...next,
     history: { past: state.history.past, future: [] },

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -239,6 +239,19 @@ export const ACTIONS = Object.freeze({
  */
 
 /**
+ * Steps the undo stack back one entry, restoring the snapshot `past[past.length - 1]`
+ * carries and pushing the pre-undo state onto `future`. No payload: the reducer reads
+ * everything it needs off `state.history` itself.
+ * @typedef {{type: 'UNDO'}} UndoAction
+ */
+
+/**
+ * Steps the redo stack forward one entry, replaying the snapshot `future[0]` carries.
+ * The mirror of `UndoAction` — see there for why no payload travels on the action.
+ * @typedef {{type: 'REDO'}} RedoAction
+ */
+
+/**
  * The union of every action shape the reducer actually understands. Deliberately has
  * NO catch-all `{type: string, [key: string]: *}` member: with one, every object
  * shape is assignable to `StoreAction` and the eleven specific typedefs above become
@@ -248,7 +261,7 @@ export const ACTIONS = Object.freeze({
  *   SetSessionFieldAction | SetTuneFieldAction | SetBoostSelAction |
  *   SetPresetPromptAction | SetEngineConfigPatchAction | ApplyPresetAction |
  *   ResetToStockAction | RepairEngineAction | BankPullAction | LiveStepAction |
- *   LivePatchAction
+ *   LivePatchAction | UndoAction | RedoAction
  * } KnownStoreAction
  */
 

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -27,7 +27,9 @@
 
 import { clamp, clone2D, DEFAULT_AFR, DEFAULT_MODS, DEFAULT_TIMING, liveStep, presetById } from '../../sim/index.js';
 
-import { HISTORY_LIMIT, restore, snapshot } from './history.js';
+import {
+  HISTORY_LIMIT, RESTORE_ALL, RESTORE_CALIBRATION, restore, snapshot,
+} from './history.js';
 
 /** @typedef {import('./initialState.js').StoreState} StoreState */
 /** @typedef {import('./initialState.js').BuildState} BuildState */
@@ -506,13 +508,65 @@ function baseReducer(state, action) {
 }
 
 /**
- * The three actions that destroy calibration the player cannot otherwise get back.
+ * The three actions that destroy calibration the player cannot otherwise get back,
+ * each mapped to HOW MUCH of its snapshot an undo puts back (history.js).
  *
  * Hardware writes are deliberately absent: every hardware control already displays its
  * own current value, so it is self-reversing, and undo must not become a time machine
  * over banked career progress.
+ *
+ * The scope is per-action because the snapshot is not: `snapshot()` captures the union
+ * of every field ANY of these three can write, so replaying an entry in full would put
+ * back fields the recorded action never touched. `SET_TABLE`'s entire build-side write
+ * is `presetId`, so RESTORE_CALIBRATION is exactly its write surface; the other two
+ * replace the whole build, so RESTORE_ALL is exactly theirs.
+ *
+ * A map rather than a Set plus a lookup elsewhere: `UNDOABLE` is derived from its keys
+ * below, so a fourth undoable action cannot be added to the membership list without
+ * also declaring what its undo restores.
  */
-const UNDOABLE = new Set([ACTIONS.SET_TABLE, ACTIONS.APPLY_PRESET, ACTIONS.RESET_TO_STOCK]);
+const UNDO_SCOPE = Object.freeze({
+  [ACTIONS.SET_TABLE]: RESTORE_CALIBRATION,
+  [ACTIONS.APPLY_PRESET]: RESTORE_ALL,
+  [ACTIONS.RESET_TO_STOCK]: RESTORE_ALL,
+});
+
+const UNDOABLE = new Set(Object.keys(UNDO_SCOPE));
+
+/**
+ * Every action that counts as NEW WORK, and therefore abandons the redo branch.
+ *
+ * The membership rule is: does this case write a field the snapshot carries — the
+ * hardware and calibration in BUILD_KEYS/TUNE_KEYS? Those are precisely the fields a
+ * later REDO would overwrite, so leaving `future` alive across one of them lets redo
+ * throw away work the player did after the undo, labelled only with what the redone
+ * action was. That was reachable: APPLY_PRESET -> UNDO -> fit a turbo, build a boost
+ * curve, pick a fuel -> REDO, and the octane goes back to the preset's under the
+ * label "Redo Preset · Nissan VQ35HR".
+ *
+ * Excluded, and why each one has to be:
+ *  - LIVE_STEP / LIVE_PATCH write `session.live`. LIVE_STEP alone fires at 20 Hz, so
+ *    including it would destroy the redo branch within one tick of the engine
+ *    running — undo would be unusable on any tab while the engine idles.
+ *  - SET_SESSION_FIELD, BANK_PULL, REPAIR_ENGINE write `session` only, which no
+ *    snapshot carries and no restore touches.
+ *  - SET_BOOST_SEL, SET_PRESET_PROMPT, SET_TUNE_FIELD are cursors and UI state:
+ *    `boostSel`, `presetPrompt` and `selection` are all deliberately outside the
+ *    snapshot (see history.js). SET_TUNE_FIELD is the generic tune setter, but its
+ *    only callers pass `selection` — and one of them is the tab switch, so counting
+ *    it as new work would mean walking from TUNE to BUILD silently killed the redo
+ *    a player crossed tabs to reach.
+ *  - UNDO/REDO manage `future` themselves.
+ *
+ * The three UNDOABLE actions are listed here too, for one list that answers "is this
+ * new work?" — they reach `future: []` through the recording branch below rather than
+ * through this Set, and listing them keeps the two from disagreeing on paper.
+ */
+const CLEARS_REDO = new Set([
+  ACTIONS.SET_BUILD_FIELD, ACTIONS.CLEAR_PRESET_ID, ACTIONS.SET_TURBINE,
+  ACTIONS.SET_ENGINE_CONFIG_PATCH, ACTIONS.SET_TABLE, ACTIONS.APPLY_PRESET,
+  ACTIONS.RESET_TO_STOCK,
+]);
 
 /**
  * Names what an undoable action did, for the undo button's `aria-label` and BUILD's
@@ -523,8 +577,17 @@ const UNDOABLE = new Set([ACTIONS.SET_TABLE, ACTIONS.APPLY_PRESET, ACTIONS.RESET
  */
 function labelFor(action) {
   switch (action.type) {
-    case ACTIONS.SET_TABLE:
-      return { ve: 'VE edit', timing: 'Spark edit', afr: 'Fuel edit' }[action.table];
+    case ACTIONS.SET_TABLE: {
+      const label = { ve: 'VE edit', timing: 'Spark edit', afr: 'Fuel edit' }[action.table];
+      // Same reasoning as the `default` branch below, and it needs stating twice
+      // because the failure this one prevents is worse. An unrecognised table used to
+      // return `undefined`, which was pushed onto the stack as the entry's label; the
+      // crash then happened in EngineScreen.jsx, on BUILD, at `top.label.startsWith(...)`
+      // — a TypeError on a different screen, at a stack naming neither the dispatch nor
+      // the table. Throwing here names both.
+      if (!label) throw new Error(`labelFor: no label defined for table "${action.table}"`);
+      return label;
+    }
     case ACTIONS.APPLY_PRESET: {
       const preset = presetById(action.preset.presetId);
       return `Preset · ${preset ? preset.name : 'factory calibration'}`;
@@ -562,10 +625,12 @@ export function reducer(state, action) {
     if (past.length === 0) return state;
     const entry = past[past.length - 1];
     return {
-      ...restore(state, entry.before),
+      ...restore(state, entry.before, entry.scope),
       history: {
         past: past.slice(0, -1),
-        future: [{ label: entry.label, before: snapshot(state) }, ...future],
+        // The scope rides along with the entry in both directions, so a redo puts
+        // back exactly as much as the undo took away.
+        future: [{ label: entry.label, before: snapshot(state), scope: entry.scope }, ...future],
       },
     };
   }
@@ -575,24 +640,38 @@ export function reducer(state, action) {
     if (future.length === 0) return state;
     const entry = future[0];
     return {
-      ...restore(state, entry.before),
+      ...restore(state, entry.before, entry.scope),
       history: {
-        past: [...past, { label: entry.label, before: snapshot(state) }].slice(-HISTORY_LIMIT),
+        past: [...past, { label: entry.label, before: snapshot(state), scope: entry.scope }]
+          .slice(-HISTORY_LIMIT),
         future: future.slice(1),
       },
     };
   }
 
   const next = baseReducer(state, action);
-  if (!UNDOABLE.has(action.type)) return next;
+  if (UNDOABLE.has(action.type)) {
+    return {
+      ...next,
+      history: {
+        past: [...state.history.past, {
+          label: labelFor(action),
+          before: snapshot(state),
+          scope: UNDO_SCOPE[action.type],
+        }].slice(-HISTORY_LIMIT),
+        // A new edit abandons the redo branch: keeping it would let redo jump the
+        // player onto a timeline they had already left.
+        future: [],
+      },
+    };
+  }
+
+  // Not recordable, but still new work: a hardware write is not undoable (the control
+  // shows its own value) yet it changes fields a redo would overwrite, so it abandons
+  // the redo branch just the same. See CLEARS_REDO for what counts and what must not.
+  if (!CLEARS_REDO.has(action.type) || state.history.future.length === 0) return next;
   return {
     ...next,
-    history: {
-      past: [...state.history.past, { label: labelFor(action), before: snapshot(state) }]
-        .slice(-HISTORY_LIMIT),
-      // A new edit abandons the redo branch: keeping it would let redo jump the player
-      // onto a timeline they had already left.
-      future: [],
-    },
+    history: { past: state.history.past, future: [] },
   };
 }

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -260,8 +260,12 @@ export const ACTIONS = Object.freeze({
  */
 
 /**
- * The root reducer. No `Date.now()`, no mutation of `state` or any of its slices —
- * every case that changes a slice returns a NEW object for that slice only, and every
+ * Every case except UNDO/REDO. Wrapped by `reducer` below, which adds the undo stack
+ * on top and is what callers actually use — see that function's own doc for what the
+ * wrapper does and why it stays pure too.
+ *
+ * No `Date.now()`, no mutation of `state` or any of its slices — every case that
+ * changes a slice returns a NEW object for that slice only, and every
  * slice it does not touch keeps its existing reference (so `React.memo`/`useMemo`
  * consumers downstream can bail out on an unrelated dispatch).
  *
@@ -292,9 +296,6 @@ export const ACTIONS = Object.freeze({
  * @param {StoreState} state
  * @param {StoreAction} action
  * @returns {StoreState}
- */
-/**
- * Every case except UNDO/REDO. Wrapped by `reducer` below, which is what callers use.
  */
 function baseReducer(state, action) {
   switch (action.type) {
@@ -515,8 +516,16 @@ function labelFor(action) {
       const preset = presetById(action.preset.presetId);
       return `Preset · ${preset ? preset.name : 'factory calibration'}`;
     }
-    default:
+    case ACTIONS.RESET_TO_STOCK:
       return 'Reset to stock';
+    default:
+      // UNDOABLE lists exactly three action types, and `reducer` below only ever
+      // calls `labelFor` for an action already confirmed to be in that set — so this
+      // branch is unreachable BY CONSTRUCTION today. It throws instead of quietly
+      // returning 'Reset to stock' so that if a fourth action is ever added to
+      // UNDOABLE without a matching case here, it fails loudly at the call site
+      // instead of mislabelling every undo button for that action "Reset to stock".
+      throw new Error(`labelFor: no label defined for undoable action type "${action.type}"`);
   }
 }
 

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -25,7 +25,9 @@
  * resolves them against the `live` it already holds.
  */
 
-import { clamp, clone2D, DEFAULT_AFR, DEFAULT_MODS, DEFAULT_TIMING, liveStep } from '../../sim/index.js';
+import { clamp, clone2D, DEFAULT_AFR, DEFAULT_MODS, DEFAULT_TIMING, liveStep, presetById } from '../../sim/index.js';
+
+import { HISTORY_LIMIT, restore, snapshot } from './history.js';
 
 /** @typedef {import('./initialState.js').StoreState} StoreState */
 /** @typedef {import('./initialState.js').BuildState} BuildState */
@@ -53,6 +55,8 @@ export const ACTIONS = Object.freeze({
   BANK_PULL: 'BANK_PULL',
   LIVE_STEP: 'LIVE_STEP',
   LIVE_PATCH: 'LIVE_PATCH',
+  UNDO: 'UNDO',
+  REDO: 'REDO',
 });
 
 /**
@@ -289,7 +293,10 @@ export const ACTIONS = Object.freeze({
  * @param {StoreAction} action
  * @returns {StoreState}
  */
-export function reducer(state, action) {
+/**
+ * Every case except UNDO/REDO. Wrapped by `reducer` below, which is what callers use.
+ */
+function baseReducer(state, action) {
   switch (action.type) {
     case ACTIONS.SET_BUILD_FIELD:
       return {
@@ -482,4 +489,88 @@ export function reducer(state, action) {
       // bails out of the re-render instead of scheduling one for a no-op.
       return state;
   }
+}
+
+/**
+ * The three actions that destroy calibration the player cannot otherwise get back.
+ *
+ * Hardware writes are deliberately absent: every hardware control already displays its
+ * own current value, so it is self-reversing, and undo must not become a time machine
+ * over banked career progress.
+ */
+const UNDOABLE = new Set([ACTIONS.SET_TABLE, ACTIONS.APPLY_PRESET, ACTIONS.RESET_TO_STOCK]);
+
+/**
+ * Names what an undoable action did, for the undo button's `aria-label` and BUILD's
+ * post-load offer. Lives here rather than in history.js because it needs `ACTIONS` and
+ * the preset catalogue, and history.js must not import this module.
+ * @param {any} action
+ * @returns {string}
+ */
+function labelFor(action) {
+  switch (action.type) {
+    case ACTIONS.SET_TABLE:
+      return { ve: 'VE edit', timing: 'Spark edit', afr: 'Fuel edit' }[action.table];
+    case ACTIONS.APPLY_PRESET: {
+      const preset = presetById(action.preset.presetId);
+      return `Preset · ${preset ? preset.name : 'factory calibration'}`;
+    }
+    default:
+      return 'Reset to stock';
+  }
+}
+
+/**
+ * The store's reducer: `baseReducer` plus the undo stack.
+ *
+ * Recording is a WRAPPER rather than a line inside each undoable case, so the three
+ * existing cases stay exactly as they were and a fourth undoable action is one entry in
+ * `UNDOABLE` rather than a fourth place to remember. It stays a pure function of
+ * `(state, action)` — no clock, no coalescing keys, no merge logic. The dock's slider
+ * commits once on release instead (see SelectionDock.jsx), which is what keeps a drag
+ * from becoming eighteen undo steps without any of that machinery.
+ *
+ * @param {StoreState} state
+ * @param {any} action
+ * @returns {StoreState}
+ */
+export function reducer(state, action) {
+  if (action.type === ACTIONS.UNDO) {
+    const { past, future } = state.history;
+    if (past.length === 0) return state;
+    const entry = past[past.length - 1];
+    return {
+      ...restore(state, entry.before),
+      history: {
+        past: past.slice(0, -1),
+        future: [{ label: entry.label, before: snapshot(state) }, ...future],
+      },
+    };
+  }
+
+  if (action.type === ACTIONS.REDO) {
+    const { past, future } = state.history;
+    if (future.length === 0) return state;
+    const entry = future[0];
+    return {
+      ...restore(state, entry.before),
+      history: {
+        past: [...past, { label: entry.label, before: snapshot(state) }].slice(-HISTORY_LIMIT),
+        future: future.slice(1),
+      },
+    };
+  }
+
+  const next = baseReducer(state, action);
+  if (!UNDOABLE.has(action.type)) return next;
+  return {
+    ...next,
+    history: {
+      past: [...state.history.past, { label: labelFor(action), before: snapshot(state) }]
+        .slice(-HISTORY_LIMIT),
+      // A new edit abandons the redo branch: keeping it would let redo jump the player
+      // onto a timeline they had already left.
+      future: [],
+    },
+  };
 }

--- a/tests/ui/build-screens.test.jsx
+++ b/tests/ui/build-screens.test.jsx
@@ -208,6 +208,19 @@ describe('EngineScreen — the undo offer', () => {
     fireEvent.change(picker, { target: { value: target } });
     expect(picker.value).toBe(target);
 
+    // The prefix regex above is the brief's own query, kept as-is. It is satisfied by
+    // construction if the label is ever hardcoded wrong, so it is not enough on its
+    // own — pin the FULL accessible name as a literal too, naming the preset actually
+    // selected (`target` resolves to 'vq35de-revup', the default engine).
+    expect(screen.getByRole('button', { name: 'Undo Preset · Nissan VQ35DE Rev-Up' })).toBeTruthy();
+    // The visible sentence and the button's visible label are the only things a
+    // sighted player reads — every query above goes through `aria-label`, so nothing
+    // else pins them. Literal text, not derived from anything the component reads.
+    expect(screen.getByText(
+      'Preset · Nissan VQ35DE Rev-Up replaced your tune. Undo restores the tables and hardware as they were before it.',
+    )).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^Undo Preset · / }).textContent).toBe('UNDO');
+
     fireEvent.click(screen.getByRole('button', { name: /^Undo Preset · / }));
 
     // The offer going away is NOT sufficient evidence: a button that dispatches
@@ -251,6 +264,13 @@ describe('EngineScreen — the undo offer', () => {
     // The reset cleared presetId, so the picker no longer names the preset.
     expect(picker.value).not.toBe(target);
 
+    // The visible sentence and the button's visible label, pinned as literals — the
+    // 'Reset to stock' label shape, not the 'Preset · ' one covered above.
+    expect(screen.getByText(
+      'Reset to stock replaced your tune. Undo restores the tables and hardware as they were before it.',
+    )).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Undo Reset to stock' }).textContent).toBe('UNDO');
+
     fireEvent.click(screen.getByRole('button', { name: 'Undo Reset to stock' }));
 
     // The reset is reversed, so the preset it wiped is selected again.
@@ -282,7 +302,11 @@ describe('EngineScreen — the undo offer', () => {
       .find((v) => v && v !== picker.value);
     fireEvent.change(picker, { target: { value: target } });
     // The offer is up, so its disappearance below cannot be a false negative.
-    expect(screen.getByRole('button', { name: /^Undo Preset · / })).toBeTruthy();
+    // `getByRole` already throws if the element is absent, so a bare `.toBeTruthy()`
+    // here would assert nothing beyond the query itself — pin the actual accessible
+    // name as a literal instead, so this line carries real weight.
+    expect(screen.getByRole('button', { name: /^Undo Preset · / }).getAttribute('aria-label'))
+      .toBe('Undo Preset · Nissan VQ35DE Rev-Up');
 
     fireEvent.click(screen.getByRole('button', { name: 'EDIT VE' }));
 
@@ -296,6 +320,12 @@ describe('EngineScreen — the undo offer', () => {
     mount(<EngineScreen active onToggle={noop} {...props} />);
     const materials = within(screen.getByRole('group', { name: 'Block Material' }));
     fireEvent.click(materials.getByRole('button', { name: 'Cast Iron' }));
+    // Without this, a neutered `onChange` that writes nothing would pass the assertion
+    // below too — it would just be "nothing happened" rather than "a real hardware
+    // write happened and produced no offer". `Seg` reflects the store's value back as
+    // `aria-pressed`, so this proves the click actually reached the reducer.
+    expect(materials.getByRole('button', { name: 'Cast Iron' }).getAttribute('aria-pressed')).toBe('true');
+    expect(materials.getByRole('button', { name: 'Aluminum' }).getAttribute('aria-pressed')).toBe('false');
     expect(screen.queryByRole('button', { name: /^Undo / })).toBeNull();
   });
 });

--- a/tests/ui/build-screens.test.jsx
+++ b/tests/ui/build-screens.test.jsx
@@ -23,7 +23,8 @@ import { EngineScreen } from '../../src/ui/screens/build/EngineScreen.jsx';
 import { ExhaustScreen } from '../../src/ui/screens/build/ExhaustScreen.jsx';
 import { FuelSystemScreen } from '../../src/ui/screens/build/FuelSystemScreen.jsx';
 import { InductionScreen } from '../../src/ui/screens/build/InductionScreen.jsx';
-import { StoreProvider } from '../../src/ui/state/StoreProvider.jsx';
+import { ACTIONS } from '../../src/ui/state/reducer.js';
+import { StoreProvider, useTune } from '../../src/ui/state/StoreProvider.jsx';
 
 afterEach(cleanup);
 
@@ -183,6 +184,120 @@ describe('ExhaustScreen', () => {
     expect(screen.getByText(MOD_INFO.headers.label).closest('button').getAttribute('data-installed')).toBe('true');
   });
 
+});
+
+describe('EngineScreen — the undo offer', () => {
+  /** The prop bundle this file already uses for EngineScreen, at :47. */
+  const props = {
+    engineDerived, activePreset: null, veAdvice, onResetToStock: noop,
+  };
+
+  it('offers nothing before anything destructive has happened', () => {
+    mount(<EngineScreen active onToggle={noop} {...props} />);
+    expect(screen.queryByRole('button', { name: /^Undo / })).toBeNull();
+  });
+
+  it('offers to undo a preset load, naming the preset', () => {
+    mount(<EngineScreen active onToggle={noop} {...props} />);
+    const picker = /** @type {HTMLSelectElement[]} */ (screen.getAllByRole('combobox'))
+      .find((el) => el.querySelector('optgroup'));
+    const was = picker.value;
+    const target = [...picker.querySelectorAll('option')]
+      .map((o) => o.value)
+      .find((v) => v && v !== picker.value);
+    fireEvent.change(picker, { target: { value: target } });
+    expect(picker.value).toBe(target);
+
+    fireEvent.click(screen.getByRole('button', { name: /^Undo Preset · / }));
+
+    // The offer going away is NOT sufficient evidence: a button that dispatches
+    // nothing and merely hides the Note passes that assertion too. Assert the preset
+    // load was actually reversed.
+    expect(picker.value).toBe(was);
+    // Undone: the offer goes with it, because the top of the stack is gone.
+    expect(screen.queryByRole('button', { name: /^Undo Preset · / })).toBeNull();
+  });
+
+  it('offers to undo a reset to stock, naming it', () => {
+    // The Note appears for a preset load OR a reset — both are the destructive acts
+    // this offer exists for. Testing only the preset case would let an implementation
+    // that matches on `Preset · ` alone pass while leaving the reset, which throws
+    // away EVERYTHING, with no offer at all.
+    //
+    // `onResetToStock` is a PROP, so the shared `props` object's `noop` would dispatch
+    // nothing and this test would pass without a reset ever happening. Wire a real one
+    // the way EcuLab.jsx does. `ve` is supplied by the caller, not the reducer — the
+    // current table is fine here, since what is under test is the history entry, not
+    // which numbers a reset computes.
+    function WithRealReset() {
+      const [tune, dispatch] = useTune();
+      return (
+        <EngineScreen
+          active onToggle={noop} {...props}
+          onResetToStock={() => dispatch({ type: ACTIONS.RESET_TO_STOCK, ve: tune.ve })}
+        />
+      );
+    }
+    mount(<WithRealReset />);
+    const picker = /** @type {HTMLSelectElement[]} */ (screen.getAllByRole('combobox'))
+      .find((el) => el.querySelector('optgroup'));
+    const target = [...picker.querySelectorAll('option')]
+      .map((o) => o.value)
+      .find((v) => v && v !== picker.value);
+    fireEvent.change(picker, { target: { value: target } });
+    expect(picker.value).toBe(target);
+
+    fireEvent.click(screen.getByRole('button', { name: /RESET ALL TO STOCK/i }));
+    // The reset cleared presetId, so the picker no longer names the preset.
+    expect(picker.value).not.toBe(target);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Undo Reset to stock' }));
+
+    // The reset is reversed, so the preset it wiped is selected again.
+    expect(picker.value).toBe(target);
+  });
+
+  it('withdraws the offer once a later edit sits on top of the preset load', () => {
+    // The offer reads the TOP of the stack — `past[past.length - 1]`. Every other test
+    // here creates at most ONE entry before looking, so `past[0]` would satisfy all of
+    // them while reversing the wrong thing. This is the discriminator: after a table
+    // edit lands on top, the top is a 'VE edit', the button would no longer undo the
+    // preset load, and offering it would be a lie about what the click does.
+    function WithTableEdit() {
+      const [tune, dispatch] = useTune();
+      return (
+        <>
+          <button onClick={() => dispatch({ type: ACTIONS.SET_TABLE, table: 've', value: tune.ve })}>
+            EDIT VE
+          </button>
+          <EngineScreen active onToggle={noop} {...props} />
+        </>
+      );
+    }
+    mount(<WithTableEdit />);
+    const picker = /** @type {HTMLSelectElement[]} */ (screen.getAllByRole('combobox'))
+      .find((el) => el.querySelector('optgroup'));
+    const target = [...picker.querySelectorAll('option')]
+      .map((o) => o.value)
+      .find((v) => v && v !== picker.value);
+    fireEvent.change(picker, { target: { value: target } });
+    // The offer is up, so its disappearance below cannot be a false negative.
+    expect(screen.getByRole('button', { name: /^Undo Preset · / })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'EDIT VE' }));
+
+    expect(screen.queryByRole('button', { name: /^Undo / })).toBeNull();
+  });
+
+  it('does not offer undo for a plain hardware change', () => {
+    // Hardware writes are not undoable, so an offer here would be a lie about what the
+    // button does. "Block Material" is a Seg on this screen (`EngineScreen.jsx:242`)
+    // that dispatches SET_ENGINE_CONFIG_PATCH — a hardware write, not a calibration one.
+    mount(<EngineScreen active onToggle={noop} {...props} />);
+    const materials = within(screen.getByRole('group', { name: 'Block Material' }));
+    fireEvent.click(materials.getByRole('button', { name: 'Cast Iron' }));
+    expect(screen.queryByRole('button', { name: /^Undo / })).toBeNull();
+  });
 });
 
 describe('the dissolved Bolt-On Parts section', () => {

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -918,6 +918,24 @@ describe('UNDO / REDO', () => {
     expect(undone.session.prevResult).toBeNull();
   });
 
+  it('preserves the entry label when moving it between past and future', () => {
+    // Task 2 uses history.future[0].label for the redo button's accessible name, so a
+    // relabel on the way through UNDO or REDO would silently mislabel it. The existing
+    // ordering tests above only assert stack LENGTHS, which a hardcoded label could
+    // still pass.
+    const after = reducer(
+      makeInitialState(),
+      { type: ACTIONS.SET_TABLE, table: 'timing', value: [[9]] },
+    );
+    expect(after.history.past[0].label).toBe('Spark edit');
+
+    const undone = reducer(after, { type: ACTIONS.UNDO });
+    expect(undone.history.future[0].label).toBe('Spark edit');
+
+    const redone = reducer(undone, { type: ACTIONS.REDO });
+    expect(redone.history.past[0].label).toBe('Spark edit');
+  });
+
   it('labels each table edit distinctly', () => {
     const timing = reducer(
       makeInitialState(),
@@ -975,6 +993,42 @@ describe('UNDO / REDO', () => {
     expect(r3.tune.ve).toEqual([[3]]);
     expect(r3.history.past).toHaveLength(3);
     expect(r3.history.future).toHaveLength(0);
+  });
+});
+
+describe('restore leaves deliberately-excluded cursor fields alone', () => {
+  // Both `build.presetPrompt` and `tune.selection` are cursor/UI-state fields,
+  // deliberately absent from BUILD_KEYS/TUNE_KEYS in history.js — see that file's own
+  // comments for why each one specifically is excluded. APPLY_PRESET itself SETS
+  // presetPrompt: null and selection: null as part of its own write (reducer.js), so
+  // this test does not expect undo to bring back their pre-APPLY_PRESET seeded
+  // values — they were never captured in the snapshot to begin with, so they must
+  // stay null through UNDO too. `boostSel`, which APPLY_PRESET never touches at all,
+  // is the control: it must survive both the preset load and the undo completely
+  // untouched.
+  it('keeps boostSel untouched and presetPrompt/selection excluded, through APPLY_PRESET and UNDO', () => {
+    const seeded = { ...makeInitialState() };
+    seeded.build = { ...seeded.build, boostSel: 7, presetPrompt: { id: 'seed-prompt' } };
+    seeded.tune = { ...seeded.tune, selection: { type: 'cell', row: 9, col: 9 } };
+
+    const applied = reducer(seeded, { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
+    // Sanity: confirm APPLY_PRESET's own write really did null these two, and left
+    // boostSel alone, so a failure below can only mean UNDO got it wrong, not the setup.
+    expect(applied.build.presetPrompt).toBeNull();
+    expect(applied.tune.selection).toBeNull();
+    expect(applied.build.boostSel).toBe(7);
+
+    const undone = reducer(applied, { type: ACTIONS.UNDO });
+    // boostSel was never part of the snapshot at all, so it must ride through
+    // untouched — this is the field a `build: { ...before.build }` restore bug would
+    // silently drop to undefined.
+    expect(undone.build.boostSel).toBe(7);
+    // Deliberately excluded from the snapshot: undo must NOT resurrect the
+    // pre-APPLY_PRESET seeded values here, or it would re-open the
+    // overwrite-confirmation modal / move the grid highlight right after the player
+    // undid loading the preset.
+    expect(undone.build.presetPrompt).toBeNull();
+    expect(undone.tune.selection).toBeNull();
   });
 });
 

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -1274,6 +1274,42 @@ describe('new work abandons the redo branch', () => {
       .history.future).toHaveLength(1);
     expect(reducer(undoneLoad(), { type: ACTIONS.REPAIR_ENGINE })
       .history.future).toHaveLength(1);
+    // BANK_PULL is the excluded action a player fires most often between an undo and a
+    // redo — a dyno pull is the obvious thing to do to check whether the undo helped.
+    // It writes only session bookkeeping, so a redo cannot overwrite any of it.
+    expect(reducer(undoneLoad(), {
+      type: ACTIONS.BANK_PULL,
+      result: { peakHp: 410, wear: { piston: 3, bearing: 2, valve: 1 } },
+      pullScore: 50,
+    }).history.future).toHaveLength(1);
+  });
+
+  it('abandons the redo branch WITHOUT discarding the undo stack', () => {
+    // The clear rebuilds `history`, so it has to carry `past` across explicitly. Every
+    // other test here starts from a stack whose `past` is already empty, which is why
+    // `past: []` in that branch passed the whole suite: fitting a turbo after an undo
+    // would have thrown away every undo step the player still had.
+    let s = reducer(makeInitialState(), { type: ACTIONS.SET_TABLE, table: 've', value: [[1]] });
+    s = reducer(s, { type: ACTIONS.SET_TABLE, table: 'timing', value: [[2]] });
+    s = reducer(s, { type: ACTIONS.UNDO });
+    expect(s.history.past).toHaveLength(1);
+    expect(s.history.future).toHaveLength(1);
+
+    const built = reducer(s, { type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: true });
+
+    expect(built.history.future).toHaveLength(0);
+    // The surviving entry is still the FIRST edit's, so undo still walks back correctly.
+    expect(built.history.past).toHaveLength(1);
+    expect(built.history.past[0].label).toBe('VE edit');
+  });
+
+  it('a tune write to a SNAPSHOTTED field clears it, unlike a cursor write', () => {
+    // The exclusion above is structural, not a fact about today's callers: SET_TUNE_FIELD
+    // is the one action whose write surface depends on its payload. `selection` is a
+    // cursor and must not clear; `ve` is in the snapshot and must, or a redo would
+    // overwrite it.
+    const wrote = reducer(undoneLoad(), { type: ACTIONS.SET_TUNE_FIELD, field: 've', value: [[3]] });
+    expect(wrote.history.future).toHaveLength(0);
   });
 
   it('leaves the history object itself alone when there is nothing to abandon', () => {

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -15,7 +15,9 @@ import {
   OCTANE_OPTS,
 } from '../../../src/sim/index.js';
 import { applyPreset, ENGINE_PRESETS } from '../../../src/sim/presets.js';
-import { snapshot } from '../../../src/ui/state/history.js';
+import {
+  RESTORE_ALL, RESTORE_CALIBRATION, restore, snapshot,
+} from '../../../src/ui/state/history.js';
 import { makeInitialState } from '../../../src/ui/state/initialState.js';
 import { ACTIONS, reducer } from '../../../src/ui/state/reducer.js';
 
@@ -727,6 +729,30 @@ describe('LIVE_STEP and LIVE_PATCH', () => {
     expect(after.session.live.coolantC).toBe(before.session.live.coolantC);
   });
 
+  it('LIVE_STEP does not abandon the redo branch', () => {
+    // B2's one hard exclusion. This action arrives 20 times a second for as long as
+    // the app is open, so counting an engine tick as new work would destroy any redo
+    // branch within 50 ms of the player creating one — undo/redo would look broken on
+    // every tab while the engine idles. Driven with the engine RUNNING, so the
+    // early-return path is not what makes this pass.
+    const loaded = reducer(running(), { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
+    const undone = reducer(loaded, { type: ACTIONS.UNDO });
+    expect(undone.history.future).toHaveLength(1);
+
+    let s = undone;
+    for (let i = 0; i < 20; i += 1) s = reducer(s, step);
+    expect(s.session.live.rpm).not.toBe(undone.session.live.rpm); // it really did integrate
+    expect(s.history.future).toHaveLength(1);
+  });
+
+  it('LIVE_PATCH does not abandon the redo branch either', () => {
+    const loaded = reducer(running(), { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
+    const undone = reducer(loaded, { type: ACTIONS.UNDO });
+    const stopped = reducer(undone, { type: ACTIONS.LIVE_PATCH, patch: { running: false } });
+    expect(stopped.session.live.running).toBe(false);
+    expect(stopped.history.future).toHaveLength(1);
+  });
+
   it('neither action disowns a loaded preset', () => {
     // Running the engine is not a build edit.
     const before = running();
@@ -936,6 +962,19 @@ describe('UNDO / REDO', () => {
     expect(redone.history.past[0].label).toBe('Spark edit');
   });
 
+  it('refuses to record a table it has no label for, AT the dispatch', () => {
+    // F5. The lookup used to hand back `undefined` for an unrecognised table and the
+    // entry was pushed with `label: undefined`; the failure then surfaced as a
+    // TypeError inside EngineScreen's `top.label.startsWith(...)` — on BUILD, a
+    // different screen entirely, at a stack naming neither the dispatch nor the table.
+    // Unreachable from the UI today, exactly like the `default` branch beside it, and
+    // held for the same reason that branch is documented at length.
+    expect(() => reducer(
+      makeInitialState(),
+      /** @type {*} */ ({ type: ACTIONS.SET_TABLE, table: 'boost', value: [[1]] }),
+    )).toThrow(/no label defined for table "boost"/);
+  });
+
   it('labels each table edit distinctly', () => {
     const timing = reducer(
       makeInitialState(),
@@ -993,6 +1032,257 @@ describe('UNDO / REDO', () => {
     expect(r3.tune.ve).toEqual([[3]]);
     expect(r3.history.past).toHaveLength(3);
     expect(r3.history.future).toHaveLength(0);
+  });
+});
+
+describe('undo scope — an entry restores only what its action wrote', () => {
+  /**
+   * A build with every hardware field moved off its default, so a restore that
+   * overreaches has something visible to overwrite. Literals throughout; none of these
+   * is the makeInitialState() default and none is what N54_PRESET writes.
+   * @param {*} state
+   * @returns {*}
+   */
+  function withHandBuiltHardware(state) {
+    const next = { ...state };
+    next.build = {
+      ...next.build,
+      turboOn: true, octaneIdx: 2, exhaustDiaIdx: 5, injIdx: 4, mafScalar: 0.88,
+    };
+    return next;
+  }
+
+  it('undoing a table edit leaves hardware fitted AFTER the edit alone', () => {
+    // B1. SET_TABLE's entire build-side write is `presetId`, but the snapshot carries
+    // all thirteen build fields — so a restore that replayed the whole snapshot took
+    // a turbo fitted after the edit back off, under the label "Undo VE edit".
+    const start = makeInitialState();
+    const edit = reducer(start, { type: ACTIONS.SET_TABLE, table: 've', value: [[42]] });
+    const built = withHandBuiltHardware(edit);
+
+    const undone = reducer(built, { type: ACTIONS.UNDO });
+
+    // The calibration side IS reversed: the table goes back to the exact array the
+    // snapshot captured, and the unsaved-work flag with it.
+    expect(undone.tune.ve).toBe(start.tune.ve);
+    expect(undone.tune.tablesDirty).toBe(false);
+    // ...and every hardware field built afterwards survives, as literals.
+    expect(undone.build.turboOn).toBe(true);
+    expect(undone.build.octaneIdx).toBe(2);
+    expect(undone.build.exhaustDiaIdx).toBe(5);
+    expect(undone.build.injIdx).toBe(4);
+    expect(undone.build.mafScalar).toBe(0.88);
+  });
+
+  it('undoing a table edit still puts the preset label back, the one build field it wrote', () => {
+    // The other side of the same scope: narrowing the restore must not narrow it to
+    // nothing. SET_TABLE clears `presetId` in the pass that writes the table, so undo
+    // has to hand it back or the header goes on disowning a preset the player never
+    // left — while the twelve fields around it stay untouched.
+    const loaded = { ...makeInitialState() };
+    loaded.build = { ...loaded.build, presetId: 'n54', turboOn: true, octaneIdx: 2 };
+    const edit = reducer(loaded, { type: ACTIONS.SET_TABLE, table: 'timing', value: [[9]] });
+    expect(edit.build.presetId).toBeNull();
+
+    const undone = reducer(edit, { type: ACTIONS.UNDO });
+
+    expect(undone.build.presetId).toBe('n54');
+    expect(undone.build.turboOn).toBe(true);
+    expect(undone.build.octaneIdx).toBe(2);
+  });
+
+  it('undoing a PRESET LOAD reverts the hardware too — the scopes are not the same', () => {
+    // The exclusivity between the two scopes, driven through the reducer rather than
+    // read off the entry. APPLY_PRESET replaces the whole build, so "return to the
+    // state before it" has to include hardware changed since; the test above says the
+    // opposite for SET_TABLE, and only both together pin the distinction.
+    const start = makeInitialState();
+    const loaded = reducer(start, { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
+    const built = withHandBuiltHardware(loaded);
+    expect(built.build.octaneIdx).toBe(2);
+
+    const undone = reducer(built, { type: ACTIONS.UNDO });
+
+    // Back to the pre-preset defaults, not to the hand-built values above.
+    expect(undone.build.turboOn).toBe(false);
+    expect(undone.build.octaneIdx).toBe(0);
+    expect(undone.build.exhaustDiaIdx).toBe(start.build.exhaustDiaIdx);
+    expect(undone.build.injIdx).toBe(0);
+    expect(undone.build.mafScalar).toBe(1.0);
+    expect(undone.build.engineConfig).toBe(start.build.engineConfig);
+  });
+
+  it('carries the scope on the entry, in both directions', () => {
+    // The scope lives on the entry rather than being re-derived from the action,
+    // because history.js may not import ACTIONS. If UNDO or REDO dropped it while
+    // moving the entry between the stacks, `restore` would have nothing to go on.
+    const edit = reducer(makeInitialState(), { type: ACTIONS.SET_TABLE, table: 've', value: [[42]] });
+    expect(edit.history.past[0].scope).toBe('calibration');
+
+    const undone = reducer(edit, { type: ACTIONS.UNDO });
+    expect(undone.history.future[0].scope).toBe('calibration');
+
+    const redone = reducer(undone, { type: ACTIONS.REDO });
+    expect(redone.history.past[0].scope).toBe('calibration');
+  });
+
+  it('records the wider scope for the two actions that replace the whole build', () => {
+    const loaded = reducer(makeInitialState(), { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
+    expect(loaded.history.past[0].scope).toBe('all');
+
+    const reset = reducer(makeInitialState(), { type: ACTIONS.RESET_TO_STOCK, ve: [[70]] });
+    expect(reset.history.past[0].scope).toBe('all');
+  });
+});
+
+describe('restore scopes, on their own', () => {
+  // The reducer tests above pin the scopes through real sequences. These pin `restore`
+  // itself, which is where the exclusivity actually lives — and where a REDO's scope
+  // is observable at all: between an undo and its redo, nothing may write a snapshotted
+  // build field without abandoning the redo branch (see below), so no reducer sequence
+  // can tell the two scopes apart on the redo side.
+
+  /** A snapshot whose every value is distinguishable from the state it goes back into. */
+  const before = {
+    build: {
+      engineConfig: { configuration: 'V8' }, mods: { intake: true }, turboOn: true,
+      boostCurve: [9], turbineIdx: 7, turbineCount: 2, compressorIdx: 7, injIdx: 7,
+      ecuInjectorCc: 777, octaneIdx: 7, exhaustDiaIdx: 7, mafScalar: 0.77,
+      presetId: 'snapshotted-preset',
+    },
+    tune: { ve: [[55]], timing: [[33]], afr: [[7]], tablesDirty: true },
+  };
+
+  /** The live state the snapshot is restored into — no field shared with `before`. */
+  const live = () => ({
+    build: {
+      engineConfig: { configuration: 'I4' }, mods: { intake: false }, turboOn: false,
+      boostCurve: [1], turbineIdx: 1, turbineCount: 1, compressorIdx: 1, injIdx: 1,
+      ecuInjectorCc: 111, octaneIdx: 1, exhaustDiaIdx: 1, mafScalar: 1.0,
+      presetId: 'live-preset', boostSel: 4, presetPrompt: null,
+    },
+    tune: { ve: [[1]], timing: [[1]], afr: [[1]], tablesDirty: false, selection: 'live-selection' },
+    session: 'live-session',
+  });
+
+  it('the wide scope puts every snapshotted build field back', () => {
+    const out = /** @type {*} */ (restore(/** @type {*} */ (live()), /** @type {*} */ (before), RESTORE_ALL));
+    expect(out.build.turboOn).toBe(true);
+    expect(out.build.turbineIdx).toBe(7);
+    expect(out.build.ecuInjectorCc).toBe(777);
+    expect(out.build.mafScalar).toBe(0.77);
+    expect(out.build.presetId).toBe('snapshotted-preset');
+  });
+
+  it('the narrow scope puts back presetId and NOTHING else on the build side', () => {
+    const out = /** @type {*} */ (restore(/** @type {*} */ (live()), /** @type {*} */ (before), RESTORE_CALIBRATION));
+    expect(out.build.presetId).toBe('snapshotted-preset');
+    // The other twelve stay as the live state had them — literals, not `not.toBe`,
+    // which would pass for any wrong value including a third one.
+    expect(out.build.turboOn).toBe(false);
+    expect(out.build.turbineIdx).toBe(1);
+    expect(out.build.turbineCount).toBe(1);
+    expect(out.build.compressorIdx).toBe(1);
+    expect(out.build.injIdx).toBe(1);
+    expect(out.build.ecuInjectorCc).toBe(111);
+    expect(out.build.octaneIdx).toBe(1);
+    expect(out.build.exhaustDiaIdx).toBe(1);
+    expect(out.build.mafScalar).toBe(1.0);
+    expect(out.build.boostCurve).toEqual([1]);
+    expect(out.build.engineConfig).toEqual({ configuration: 'I4' });
+    expect(out.build.mods).toEqual({ intake: false });
+  });
+
+  it('both scopes put the whole tune projection back, and leave the cursors alone', () => {
+    for (const scope of [RESTORE_ALL, RESTORE_CALIBRATION]) {
+      const out = /** @type {*} */ (
+        restore(/** @type {*} */ (live()), /** @type {*} */ (before), /** @type {*} */ (scope))
+      );
+      expect(out.tune.ve).toEqual([[55]]);
+      expect(out.tune.timing).toEqual([[33]]);
+      expect(out.tune.afr).toEqual([[7]]);
+      expect(out.tune.tablesDirty).toBe(true);
+      // Outside the snapshot, so untouched under either scope.
+      expect(out.tune.selection).toBe('live-selection');
+      expect(out.build.boostSel).toBe(4);
+      expect(out.session).toBe('live-session');
+    }
+  });
+
+  it('throws on a scope it does not implement, rather than restoring some arbitrary subset', () => {
+    // The same choice `labelFor`'s default branch makes: an entry recorded with no
+    // scope would otherwise put back a half-state and look like a bug elsewhere.
+    expect(() => restore(/** @type {*} */ (live()), /** @type {*} */ (before), /** @type {*} */ (undefined)))
+      .toThrow(/unknown scope/);
+    expect(() => restore(/** @type {*} */ (live()), /** @type {*} */ (before), /** @type {*} */ ('tables')))
+      .toThrow(/unknown scope/);
+  });
+});
+
+describe('new work abandons the redo branch', () => {
+  /** A state with a preset load undone, so `future` holds exactly one entry. */
+  function undoneLoad() {
+    const loaded = reducer(makeInitialState(), { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
+    const undone = reducer(loaded, { type: ACTIONS.UNDO });
+    expect(undone.history.future).toHaveLength(1);
+    return undone;
+  }
+
+  it('a hardware write clears future, even though it records no undo entry', () => {
+    // B2. Only UNDOABLE actions used to clear `future`, so hardware built after an
+    // undo sat alongside a live redo branch that would overwrite exactly those
+    // fields — REDO then replaced a hand-picked octane with the preset's, under a
+    // label naming only the preset.
+    const built = reducer(undoneLoad(), { type: ACTIONS.SET_BUILD_FIELD, field: 'octaneIdx', value: 2 });
+    expect(built.history.future).toHaveLength(0);
+    // ...and it is still not undoable: clearing the branch is not the same as
+    // recording one.
+    expect(built.history.past).toHaveLength(0);
+  });
+
+  it('every other write to a snapshotted field clears it too', () => {
+    // SET_BUILD_FIELD above is one of four. Each is checked from its own fresh
+    // `undoneLoad()` so no one of them can pass on another's account.
+    expect(reducer(undoneLoad(), { type: ACTIONS.SET_TURBINE, value: 2 })
+      .history.future).toHaveLength(0);
+    expect(reducer(undoneLoad(), { type: ACTIONS.CLEAR_PRESET_ID })
+      .history.future).toHaveLength(0);
+    expect(reducer(undoneLoad(), { type: ACTIONS.SET_ENGINE_CONFIG_PATCH, patch: { bore: 90 } })
+      .history.future).toHaveLength(0);
+    expect(reducer(undoneLoad(), { type: ACTIONS.SET_TABLE, table: 've', value: [[7]] })
+      .history.future).toHaveLength(0);
+  });
+
+  it('moving the grid selection does NOT clear it', () => {
+    // `selection` is a cursor, outside the snapshot — and `changeTab` writes it on
+    // every tab switch, so counting it as new work would mean walking from TUNE to
+    // BUILD silently killed the redo the player crossed tabs to reach.
+    const moved = reducer(undoneLoad(), {
+      type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value: { type: 'cell', row: 1, col: 1 },
+    });
+    expect(moved.history.future).toHaveLength(1);
+  });
+
+  it('session-only and cursor writes do NOT clear it', () => {
+    // None of these touches a field any snapshot carries, so a redo cannot overwrite
+    // anything they did.
+    expect(reducer(undoneLoad(), { type: ACTIONS.SET_BOOST_SEL, value: 6 })
+      .history.future).toHaveLength(1);
+    expect(reducer(undoneLoad(), { type: ACTIONS.SET_PRESET_PROMPT, value: { id: 'x' } })
+      .history.future).toHaveLength(1);
+    expect(reducer(undoneLoad(), { type: ACTIONS.SET_SESSION_FIELD, field: 'pullCount', value: 3 })
+      .history.future).toHaveLength(1);
+    expect(reducer(undoneLoad(), { type: ACTIONS.REPAIR_ENGINE })
+      .history.future).toHaveLength(1);
+  });
+
+  it('leaves the history object itself alone when there is nothing to abandon', () => {
+    // The clear allocates a new history only when `future` is non-empty, so the
+    // ordinary case — a hardware write with no redo branch live — keeps the same
+    // object and React's bail-out machinery downstream sees no change.
+    const start = makeInitialState();
+    const built = reducer(start, { type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: true });
+    expect(built.history).toBe(start.history);
   });
 });
 

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -38,6 +38,14 @@ function makeSentinelState() {
   const init = makeInitialState();
   const state = /** @type {any} */ ({});
   for (const slice of Object.keys(init)) {
+    // `history` is structural, not scalar: the reducer spreads `past`, and
+    // `[...'SENTINEL::history.past']` would silently become 24 single characters.
+    // A real empty stack still starts unequal to anything a write produces, which is
+    // all `changedFieldKeys` needs.
+    if (slice === 'history') {
+      state[slice] = { past: [], future: [] };
+      continue;
+    }
     const sliceState = /** @type {any} */ ({});
     for (const field of Object.keys(/** @type {any} */ (init)[slice])) {
       sliceState[field] = `SENTINEL::${slice}.${field}`;
@@ -90,9 +98,9 @@ const N54_PRESET = {
 };
 
 describe('makeInitialState', () => {
-  it('returns the three slices', () => {
+  it('returns the four slices', () => {
     const s = makeInitialState();
-    expect(Object.keys(s).sort()).toEqual(['build', 'session', 'tune']);
+    expect(Object.keys(s).sort()).toEqual(['build', 'history', 'session', 'tune']);
   });
 
   it('starts with no preset loaded and clean tables', () => {
@@ -486,7 +494,7 @@ describe('APPLY_PRESET — exact write surface (catches drift in both directions
   // contract this action documents: a stray write grows the changed set past 21, a
   // dropped write shrinks it below 21, and the failure message names the field either
   // way.
-  it('changes exactly the 21 documented fields — no more, no fewer', () => {
+  it('changes exactly the 21 documented fields, plus the two history fields', () => {
     const before = makeSentinelState();
     const after = reducer(before, { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
     const changed = changedFieldKeys(before, after);
@@ -498,6 +506,9 @@ describe('APPLY_PRESET — exact write surface (catches drift in both directions
       'build.presetId', 'build.presetPrompt',
       'tune.ve', 'tune.timing', 'tune.afr', 'tune.tablesDirty', 'tune.selection',
       'session.result', 'session.prevResult',
+      // APPLY_PRESET is undoable, so it records a snapshot in the same pass. These two
+      // belong in the exact-write-surface contract like any other field it touches.
+      'history.past', 'history.future',
     ];
 
     expect([...changed].sort()).toEqual([...expected].sort());
@@ -775,5 +786,125 @@ describe('BANK_PULL', () => {
     const after = reducer(before, { type: ACTIONS.BANK_PULL, result, pullScore: 50 });
     expect(after.build).toBe(before.build);
     expect(after.tune).toBe(before.tune);
+  });
+});
+
+describe('UNDO / REDO', () => {
+  /** A state with one hand VE edit already applied. */
+  const edited = () => reducer(
+    makeInitialState(),
+    { type: ACTIONS.SET_TABLE, table: 've', value: [[42]] },
+  );
+
+  it('records the state BEFORE an edit, not after', () => {
+    const before = makeInitialState();
+    const after = reducer(before, { type: ACTIONS.SET_TABLE, table: 've', value: [[42]] });
+    expect(after.history.past).toHaveLength(1);
+    expect(after.history.past[0].before.tune.ve).toBe(before.tune.ve);
+    expect(after.history.past[0].label).toBe('VE edit');
+  });
+
+  it('puts the table back', () => {
+    const start = makeInitialState();
+    const s = reducer(edited(), { type: ACTIONS.UNDO });
+    // Deep equality, not `toBe`: `start` and `edited()` each call `makeInitialState()`
+    // independently, and its own file header documents that every call returns "a
+    // fresh object graph" — `computeHardwareVE` recomputes `ve` from scratch each time,
+    // so two independently-built initial states are never the SAME array, only an
+    // equal one. Reference equality is guaranteed only against the exact snapshot
+    // `edited()` itself recorded, which `start` is not.
+    expect(s.tune.ve).toEqual(start.tune.ve);
+    expect(s.history.past).toHaveLength(0);
+    expect(s.history.future).toHaveLength(1);
+  });
+
+  it('restores tablesDirty, not just the numbers', () => {
+    // A history that carried only the table would leave the player's unsaved-work flag
+    // stuck true after undoing their only edit.
+    expect(edited().tune.tablesDirty).toBe(true);
+    expect(reducer(edited(), { type: ACTIONS.UNDO }).tune.tablesDirty).toBe(false);
+  });
+
+  it('restores presetId, because SET_TABLE cleared it', () => {
+    // The reason the snapshot is a projection of BOTH slices. SET_TABLE clears
+    // presetId in the same pass it writes the table; undo has to put the label back or
+    // the header goes on disowning a preset the player never actually left.
+    const loaded = { ...makeInitialState() };
+    loaded.build = { ...loaded.build, presetId: 'n54' };
+    const dirty = reducer(loaded, { type: ACTIONS.SET_TABLE, table: 'timing', value: [[9]] });
+    expect(dirty.build.presetId).toBeNull();
+    expect(reducer(dirty, { type: ACTIONS.UNDO }).build.presetId).toBe('n54');
+  });
+
+  it('restores the build fields APPLY_PRESET overwrote', () => {
+    const before = makeInitialState();
+    const after = reducer(before, { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
+    expect(after.build.turboOn).toBe(true);
+    const undone = reducer(after, { type: ACTIONS.UNDO });
+    expect(undone.build.turboOn).toBe(false);
+    expect(undone.build.engineConfig).toBe(before.build.engineConfig);
+    expect(undone.build.presetId).toBeNull();
+  });
+
+  it('labels a preset load with the preset name', () => {
+    const after = reducer(makeInitialState(), { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
+    expect(after.history.past[0].label).toBe('Preset · BMW N54');
+  });
+
+  it('labels a reset', () => {
+    const after = reducer(makeInitialState(), { type: ACTIONS.RESET_TO_STOCK, ve: [[70]] });
+    expect(after.history.past[0].label).toBe('Reset to stock');
+  });
+
+  it('redo puts the edit back', () => {
+    const undone = reducer(edited(), { type: ACTIONS.UNDO });
+    const redone = reducer(undone, { type: ACTIONS.REDO });
+    expect(redone.tune.ve).toEqual([[42]]);
+    expect(redone.history.past).toHaveLength(1);
+    expect(redone.history.future).toHaveLength(0);
+  });
+
+  it('a new edit clears the redo stack', () => {
+    // Otherwise redo would jump the player onto a branch they had already left.
+    const undone = reducer(edited(), { type: ACTIONS.UNDO });
+    expect(undone.history.future).toHaveLength(1);
+    const branched = reducer(undone, { type: ACTIONS.SET_TABLE, table: 've', value: [[7]] });
+    expect(branched.history.future).toHaveLength(0);
+  });
+
+  it('caps the stack at 50 and drops the OLDEST entry', () => {
+    let s = makeInitialState();
+    for (let i = 0; i < 60; i += 1) {
+      s = reducer(s, { type: ACTIONS.SET_TABLE, table: 've', value: [[i]] });
+    }
+    expect(s.history.past).toHaveLength(50);
+    // Entry 0 must be the snapshot taken before edit #10 — i.e. holding edit #9's
+    // value. Asserting the LENGTH alone would pass just as well for a cap that
+    // discarded the newest entries, which is the opposite of what undo needs.
+    expect(s.history.past[0].before.tune.ve).toEqual([[9]]);
+  });
+
+  it('undo and redo on an empty stack return the SAME object', () => {
+    // Reference equality, not deep equality: React's useReducer bails out of the
+    // re-render only when the reducer returns the identical object.
+    const s = makeInitialState();
+    expect(reducer(s, { type: ACTIONS.UNDO })).toBe(s);
+    expect(reducer(s, { type: ACTIONS.REDO })).toBe(s);
+  });
+
+  it('does not record actions that are not undoable', () => {
+    const s = reducer(makeInitialState(), { type: ACTIONS.SET_BUILD_FIELD, field: 'turboOn', value: true });
+    expect(s.history.past).toHaveLength(0);
+  });
+
+  it('does not restore dyno results', () => {
+    // A deliberate asymmetry, spec'd: undo brings back hardware and calibration, but
+    // re-showing a banked score beside a build that was just reverted would state
+    // something false.
+    const withResult = { ...makeInitialState() };
+    withResult.session = { ...withResult.session, result: { peakHp: 400 } };
+    const loaded = reducer(withResult, { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
+    expect(loaded.session.result).toBeNull();
+    expect(reducer(loaded, { type: ACTIONS.UNDO }).session.result).toBeNull();
   });
 });

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -15,6 +15,7 @@ import {
   OCTANE_OPTS,
 } from '../../../src/sim/index.js';
 import { applyPreset, ENGINE_PRESETS } from '../../../src/sim/presets.js';
+import { snapshot } from '../../../src/ui/state/history.js';
 import { makeInitialState } from '../../../src/ui/state/initialState.js';
 import { ACTIONS, reducer } from '../../../src/ui/state/reducer.js';
 
@@ -805,15 +806,15 @@ describe('UNDO / REDO', () => {
   });
 
   it('puts the table back', () => {
+    // One `start`, threaded through both dispatches, so this can assert reference
+    // equality: restore must hand back the SAME array the snapshot captured, not a
+    // recomputed one that merely looks equal. Two independent `makeInitialState()`
+    // calls would defeat that — the function's own header documents that it returns a
+    // fresh object graph every time, and `ve` is recomputed by `computeHardwareVE`.
     const start = makeInitialState();
-    const s = reducer(edited(), { type: ACTIONS.UNDO });
-    // Deep equality, not `toBe`: `start` and `edited()` each call `makeInitialState()`
-    // independently, and its own file header documents that every call returns "a
-    // fresh object graph" — `computeHardwareVE` recomputes `ve` from scratch each time,
-    // so two independently-built initial states are never the SAME array, only an
-    // equal one. Reference equality is guaranteed only against the exact snapshot
-    // `edited()` itself recorded, which `start` is not.
-    expect(s.tune.ve).toEqual(start.tune.ve);
+    const edit = reducer(start, { type: ACTIONS.SET_TABLE, table: 've', value: [[42]] });
+    const s = reducer(edit, { type: ACTIONS.UNDO });
+    expect(s.tune.ve).toBe(start.tune.ve);
     expect(s.history.past).toHaveLength(0);
     expect(s.history.future).toHaveLength(1);
   });
@@ -900,11 +901,171 @@ describe('UNDO / REDO', () => {
   it('does not restore dyno results', () => {
     // A deliberate asymmetry, spec'd: undo brings back hardware and calibration, but
     // re-showing a banked score beside a build that was just reverted would state
-    // something false.
+    // something false. Both result AND prevResult must stay cleared — a snapshot that
+    // dropped only one of the pair would leave the OTHER field's stale score sitting
+    // next to the reverted build.
     const withResult = { ...makeInitialState() };
-    withResult.session = { ...withResult.session, result: { peakHp: 400 } };
+    withResult.session = {
+      ...withResult.session,
+      result: { peakHp: 400 },
+      prevResult: { peakHp: 350 },
+    };
     const loaded = reducer(withResult, { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
     expect(loaded.session.result).toBeNull();
-    expect(reducer(loaded, { type: ACTIONS.UNDO }).session.result).toBeNull();
+    expect(loaded.session.prevResult).toBeNull();
+    const undone = reducer(loaded, { type: ACTIONS.UNDO });
+    expect(undone.session.result).toBeNull();
+    expect(undone.session.prevResult).toBeNull();
+  });
+
+  it('labels each table edit distinctly', () => {
+    const timing = reducer(
+      makeInitialState(),
+      { type: ACTIONS.SET_TABLE, table: 'timing', value: [[9]] },
+    );
+    expect(timing.history.past[0].label).toBe('Spark edit');
+
+    const afr = reducer(
+      makeInitialState(),
+      { type: ACTIONS.SET_TABLE, table: 'afr', value: [[9]] },
+    );
+    expect(afr.history.past[0].label).toBe('Fuel edit');
+  });
+
+  it('falls back to a generic label for an unknown preset id', () => {
+    // presetById() finds nothing for an id not in the catalogue — the label must not
+    // blow up or fall through to some OTHER action's label, it names the calibration
+    // generically instead.
+    const unknownPreset = { ...N54_PRESET, presetId: 'not-a-real-preset-id' };
+    const after = reducer(makeInitialState(), { type: ACTIONS.APPLY_PRESET, preset: unknownPreset });
+    expect(after.history.past[0].label).toBe('Preset · factory calibration');
+  });
+
+  it('walks the stack in order across three edits: undo unwinds newest-first, redo replays oldest-first', () => {
+    // The two plausible wrong implementations this guards against:
+    //   (1) undo reading `past[0]`/slicing `past.slice(1)` instead of the LAST entry —
+    //       that would make undo FIFO and reverse the OLDEST edit first;
+    //   (2) redo pushing onto the END of `future` instead of the front — that would
+    //       replay edits in the wrong order.
+    // Every other test in this file operates on a stack of depth <= 1, so none of them
+    // can tell those implementations apart from a correct one.
+    const s0 = makeInitialState();
+    const s1 = reducer(s0, { type: ACTIONS.SET_TABLE, table: 've', value: [[1]] });
+    const s2 = reducer(s1, { type: ACTIONS.SET_TABLE, table: 've', value: [[2]] });
+    const s3 = reducer(s2, { type: ACTIONS.SET_TABLE, table: 've', value: [[3]] });
+    expect(s3.tune.ve).toEqual([[3]]);
+
+    const u1 = reducer(s3, { type: ACTIONS.UNDO });
+    expect(u1.tune.ve).toEqual([[2]]);
+    const u2 = reducer(u1, { type: ACTIONS.UNDO });
+    expect(u2.tune.ve).toEqual([[1]]);
+    const u3 = reducer(u2, { type: ACTIONS.UNDO });
+    // Reference equality against the ORIGINAL table, not merely `toEqual([[...]])` —
+    // proves undo #3 walked all the way back to s0, not just to some equal-looking
+    // value.
+    expect(u3.tune.ve).toBe(s0.tune.ve);
+    expect(u3.history.past).toHaveLength(0);
+    expect(u3.history.future).toHaveLength(3);
+
+    const r1 = reducer(u3, { type: ACTIONS.REDO });
+    expect(r1.tune.ve).toEqual([[1]]);
+    const r2 = reducer(r1, { type: ACTIONS.REDO });
+    expect(r2.tune.ve).toEqual([[2]]);
+    const r3 = reducer(r2, { type: ACTIONS.REDO });
+    expect(r3.tune.ve).toEqual([[3]]);
+    expect(r3.history.past).toHaveLength(3);
+    expect(r3.history.future).toHaveLength(0);
+  });
+});
+
+describe('snapshot field coverage', () => {
+  // Literal, not derived from BUILD_KEYS/TUNE_KEYS: importing the same list the
+  // module iterates over would let a key deleted from both the list AND this
+  // expectation pass vacuously. That is exactly the vulnerability a reviewer found —
+  // cutting BUILD_KEYS to 3 entries and TUNE_KEYS to 2 left all 871 tests green.
+  it('snapshots exactly the documented 13 build and 4 tune fields', () => {
+    const snap = snapshot(makeInitialState());
+    expect(Object.keys(snap.build).sort()).toEqual([
+      'boostCurve', 'compressorIdx', 'ecuInjectorCc', 'engineConfig', 'exhaustDiaIdx',
+      'injIdx', 'mafScalar', 'mods', 'octaneIdx', 'presetId', 'turbineCount',
+      'turbineIdx', 'turboOn',
+    ]);
+    expect(Object.keys(snap.tune).sort()).toEqual(['afr', 'tablesDirty', 'timing', 've']);
+  });
+
+  // Every field below is seeded to a value that differs from BOTH its
+  // makeInitialState() default AND the value APPLY_PRESET's N54_PRESET fixture writes.
+  // That double difference is load-bearing: turbineIdx, compressorIdx and
+  // exhaustDiaIdx all happen to share the SAME value between the default state and
+  // this particular preset (1, 1 and 2 respectively), and mafScalar/tablesDirty are
+  // 1.0/false on both sides too — a seed that collapsed onto either value would let a
+  // dropped BUILD_KEYS/TUNE_KEYS entry go completely unnoticed here.
+  it('round-trips every snapshotted field through APPLY_PRESET + UNDO', () => {
+    /** @type {import('../../../src/sim/index.js').EngineConfig} */
+    const beforeEngineConfig = {
+      configuration: 'V8', bore: 101.1, stroke: 92.2, compression: 8.8,
+      blockMaterial: 'Cast Iron', headMaterial: 'Cast Iron',
+    };
+    const beforeMods = { intake: true, exhaust: true, headers: true, intercooler: true };
+    const beforeBoostCurve = [3, 3, 3, 3, 3, 3, 3, 3];
+    const beforeVe = [[55]];
+    const beforeTiming = [[33]];
+    const beforeAfr = [[7]];
+
+    const start = { ...makeInitialState() };
+    start.build = {
+      ...start.build,
+      engineConfig: beforeEngineConfig,
+      mods: beforeMods,
+      turboOn: false,
+      boostCurve: beforeBoostCurve,
+      turbineIdx: 3,
+      turbineCount: 4,
+      compressorIdx: 3,
+      injIdx: 9,
+      ecuInjectorCc: 999,
+      octaneIdx: 9,
+      exhaustDiaIdx: 6,
+      mafScalar: 0.77,
+      presetId: 'placeholder-preset',
+    };
+    start.tune = {
+      ...start.tune,
+      ve: beforeVe,
+      timing: beforeTiming,
+      afr: beforeAfr,
+      tablesDirty: true,
+    };
+
+    const applied = reducer(start, { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
+    // Sanity: confirm the preset really did overwrite every one of these fields, so a
+    // failure below can only mean undo did not restore them — not that they were
+    // never touched in the first place.
+    expect(applied.build.turboOn).toBe(true);
+    expect(applied.build.turbineIdx).toBe(1);
+    expect(applied.build.compressorIdx).toBe(1);
+    expect(applied.build.exhaustDiaIdx).toBe(2);
+    expect(applied.build.mafScalar).toBe(1.0);
+    expect(applied.tune.tablesDirty).toBe(false);
+
+    const undone = reducer(applied, { type: ACTIONS.UNDO });
+
+    expect(undone.build.engineConfig).toBe(beforeEngineConfig);
+    expect(undone.build.mods).toBe(beforeMods);
+    expect(undone.build.turboOn).toBe(false);
+    expect(undone.build.boostCurve).toBe(beforeBoostCurve);
+    expect(undone.build.turbineIdx).toBe(3);
+    expect(undone.build.turbineCount).toBe(4);
+    expect(undone.build.compressorIdx).toBe(3);
+    expect(undone.build.injIdx).toBe(9);
+    expect(undone.build.ecuInjectorCc).toBe(999);
+    expect(undone.build.octaneIdx).toBe(9);
+    expect(undone.build.exhaustDiaIdx).toBe(6);
+    expect(undone.build.mafScalar).toBe(0.77);
+    expect(undone.build.presetId).toBe('placeholder-preset');
+    expect(undone.tune.ve).toBe(beforeVe);
+    expect(undone.tune.timing).toBe(beforeTiming);
+    expect(undone.tune.afr).toBe(beforeAfr);
+    expect(undone.tune.tablesDirty).toBe(true);
   });
 });

--- a/tests/ui/tune-screens.test.jsx
+++ b/tests/ui/tune-screens.test.jsx
@@ -108,6 +108,15 @@ describe('AirflowScreen', () => {
     expect(screen.getByTestId('selection-dock')).toBeTruthy();
   });
 
+  it('mounts UndoControls above the grid', () => {
+    // Task 2's headline requirement — AIRFLOW, SPARK and FUEL each mount the ↶ ↷
+    // pair — was previously held only incidentally, by TUNE routing to AIRFLOW by
+    // default. Pinned here, standalone, per screen.
+    mount(<AirflowScreen veAdvice={null} veTruth={[]} />);
+    expect(screen.getByRole('button', { name: /^(Undo|Nothing to undo)/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^(Redo|Nothing to redo)/ })).toBeTruthy();
+  });
+
   it('shows the shell-computed veAdvice sync gap, not one it derived itself', () => {
     // Fabricated — not a value `veRecommendations` could produce for the default
     // store's engine, and AirflowScreen never imports that function itself.
@@ -199,6 +208,14 @@ describe('SparkScreen', () => {
     expect(screen.getByTestId('tuning-grid')).toBeTruthy();
   });
 
+  it('mounts UndoControls above the grid', () => {
+    // See the matching test in the AirflowScreen block above for why this is
+    // pinned per screen rather than left to TUNE's default sub-route.
+    mount(<SparkScreen calAdvice={QUIET_CAL_ADVICE} />);
+    expect(screen.getByRole('button', { name: /^(Undo|Nothing to undo)/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^(Redo|Nothing to redo)/ })).toBeTruthy();
+  });
+
   it('shows the shell-computed knock-limit advisory, not one it derived itself', () => {
     // Fabricated cells: no default build's `calibrationAdvice` would report a cell
     // at 999 kPa (off the LOAD axis entirely) or suggest 22° from 11°.
@@ -251,6 +268,14 @@ describe('FuelScreen', () => {
   it('mounts the shared TuningGrid with its test id intact', () => {
     mount(<FuelScreen calAdvice={QUIET_CAL_ADVICE} />);
     expect(screen.getByTestId('tuning-grid')).toBeTruthy();
+  });
+
+  it('mounts UndoControls above the grid', () => {
+    // See the matching test in the AirflowScreen block above for why this is
+    // pinned per screen rather than left to TUNE's default sub-route.
+    mount(<FuelScreen calAdvice={QUIET_CAL_ADVICE} />);
+    expect(screen.getByRole('button', { name: /^(Undo|Nothing to undo)/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /^(Redo|Nothing to redo)/ })).toBeTruthy();
   });
 
   it('shows the shell-computed wrong-mixture advisory, not one it derived itself', () => {

--- a/tests/ui/tune-screens.test.jsx
+++ b/tests/ui/tune-screens.test.jsx
@@ -129,9 +129,15 @@ describe('AirflowScreen', () => {
     // pair — was previously held only incidentally, by TUNE routing to AIRFLOW by
     // default. Pinned here, standalone, per screen.
     mount(<AirflowScreen veAdvice={null} veTruth={[]} />);
+    // `getByRole` throws when the element is absent, so `.toBeTruthy()` on its result
+    // could never fail — and the name alternation matches the populated and empty
+    // states alike, so the query cannot tell them apart either. The rule is stated at
+    // build-screens.test.jsx:305. These screens mount over a fresh store, so pin the
+    // exact empty-state accessible names as literals instead.
     const undo = screen.getByRole('button', { name: /^(Undo|Nothing to undo)/ });
-    expect(undo).toBeTruthy();
-    expect(screen.getByRole('button', { name: /^(Redo|Nothing to redo)/ })).toBeTruthy();
+    expect(undo.getAttribute('aria-label')).toBe('Nothing to undo');
+    expect(screen.getByRole('button', { name: /^(Redo|Nothing to redo)/ }).getAttribute('aria-label'))
+      .toBe('Nothing to redo');
     expectAboveTheGrid(undo);
   });
 
@@ -230,9 +236,15 @@ describe('SparkScreen', () => {
     // See the matching test in the AirflowScreen block above for why this is
     // pinned per screen rather than left to TUNE's default sub-route.
     mount(<SparkScreen calAdvice={QUIET_CAL_ADVICE} />);
+    // `getByRole` throws when the element is absent, so `.toBeTruthy()` on its result
+    // could never fail — and the name alternation matches the populated and empty
+    // states alike, so the query cannot tell them apart either. The rule is stated at
+    // build-screens.test.jsx:305. These screens mount over a fresh store, so pin the
+    // exact empty-state accessible names as literals instead.
     const undo = screen.getByRole('button', { name: /^(Undo|Nothing to undo)/ });
-    expect(undo).toBeTruthy();
-    expect(screen.getByRole('button', { name: /^(Redo|Nothing to redo)/ })).toBeTruthy();
+    expect(undo.getAttribute('aria-label')).toBe('Nothing to undo');
+    expect(screen.getByRole('button', { name: /^(Redo|Nothing to redo)/ }).getAttribute('aria-label'))
+      .toBe('Nothing to redo');
     expectAboveTheGrid(undo);
   });
 
@@ -294,9 +306,15 @@ describe('FuelScreen', () => {
     // See the matching test in the AirflowScreen block above for why this is
     // pinned per screen rather than left to TUNE's default sub-route.
     mount(<FuelScreen calAdvice={QUIET_CAL_ADVICE} />);
+    // `getByRole` throws when the element is absent, so `.toBeTruthy()` on its result
+    // could never fail — and the name alternation matches the populated and empty
+    // states alike, so the query cannot tell them apart either. The rule is stated at
+    // build-screens.test.jsx:305. These screens mount over a fresh store, so pin the
+    // exact empty-state accessible names as literals instead.
     const undo = screen.getByRole('button', { name: /^(Undo|Nothing to undo)/ });
-    expect(undo).toBeTruthy();
-    expect(screen.getByRole('button', { name: /^(Redo|Nothing to redo)/ })).toBeTruthy();
+    expect(undo.getAttribute('aria-label')).toBe('Nothing to undo');
+    expect(screen.getByRole('button', { name: /^(Redo|Nothing to redo)/ }).getAttribute('aria-label'))
+      .toBe('Nothing to redo');
     expectAboveTheGrid(undo);
   });
 

--- a/tests/ui/tune-screens.test.jsx
+++ b/tests/ui/tune-screens.test.jsx
@@ -96,6 +96,22 @@ function SelectionProbe({ value }) {
 // returns, since `sparkReport` and `fuelReport` (added in later tasks) read them.
 const QUIET_CAL_ADVICE = { overAdvanced: [], underAdvanced: [], pastMbt: [], wrongMix: [], spark: [], fuelAdv: [] };
 
+/**
+ * Pins that the undo pair sits in the grid header ABOVE the table, not merely
+ * somewhere on the screen. `getByRole` alone passes with the control moved below
+ * <TuningGrid>, which is not what the plan asked for and not where a player looks
+ * for it. jsdom applies no CSS, so document order is the only position this suite
+ * can observe — which is exactly the property that matters here.
+ * @param {HTMLElement} control
+ */
+function expectAboveTheGrid(control) {
+  const grid = screen.getByTestId('tuning-grid');
+  // querySelectorAll returns elements in document order, so comparing indices says
+  // which comes first without reaching for compareDocumentPosition's bitmask.
+  const inOrder = Array.from(document.querySelectorAll('*'));
+  expect(inOrder.indexOf(control)).toBeLessThan(inOrder.indexOf(grid));
+}
+
 describe('AirflowScreen', () => {
   it('mounts the shared TuningGrid and SelectionDock with their test ids intact', () => {
     mount(<AirflowScreen veAdvice={null} veTruth={[]} />);
@@ -108,13 +124,15 @@ describe('AirflowScreen', () => {
     expect(screen.getByTestId('selection-dock')).toBeTruthy();
   });
 
-  it('mounts UndoControls above the grid', () => {
+  it('mounts UndoControls in the header above the grid', () => {
     // Task 2's headline requirement — AIRFLOW, SPARK and FUEL each mount the ↶ ↷
     // pair — was previously held only incidentally, by TUNE routing to AIRFLOW by
     // default. Pinned here, standalone, per screen.
     mount(<AirflowScreen veAdvice={null} veTruth={[]} />);
-    expect(screen.getByRole('button', { name: /^(Undo|Nothing to undo)/ })).toBeTruthy();
+    const undo = screen.getByRole('button', { name: /^(Undo|Nothing to undo)/ });
+    expect(undo).toBeTruthy();
     expect(screen.getByRole('button', { name: /^(Redo|Nothing to redo)/ })).toBeTruthy();
+    expectAboveTheGrid(undo);
   });
 
   it('shows the shell-computed veAdvice sync gap, not one it derived itself', () => {
@@ -208,12 +226,14 @@ describe('SparkScreen', () => {
     expect(screen.getByTestId('tuning-grid')).toBeTruthy();
   });
 
-  it('mounts UndoControls above the grid', () => {
+  it('mounts UndoControls in the header above the grid', () => {
     // See the matching test in the AirflowScreen block above for why this is
     // pinned per screen rather than left to TUNE's default sub-route.
     mount(<SparkScreen calAdvice={QUIET_CAL_ADVICE} />);
-    expect(screen.getByRole('button', { name: /^(Undo|Nothing to undo)/ })).toBeTruthy();
+    const undo = screen.getByRole('button', { name: /^(Undo|Nothing to undo)/ });
+    expect(undo).toBeTruthy();
     expect(screen.getByRole('button', { name: /^(Redo|Nothing to redo)/ })).toBeTruthy();
+    expectAboveTheGrid(undo);
   });
 
   it('shows the shell-computed knock-limit advisory, not one it derived itself', () => {
@@ -270,12 +290,14 @@ describe('FuelScreen', () => {
     expect(screen.getByTestId('tuning-grid')).toBeTruthy();
   });
 
-  it('mounts UndoControls above the grid', () => {
+  it('mounts UndoControls in the header above the grid', () => {
     // See the matching test in the AirflowScreen block above for why this is
     // pinned per screen rather than left to TUNE's default sub-route.
     mount(<FuelScreen calAdvice={QUIET_CAL_ADVICE} />);
-    expect(screen.getByRole('button', { name: /^(Undo|Nothing to undo)/ })).toBeTruthy();
+    const undo = screen.getByRole('button', { name: /^(Undo|Nothing to undo)/ });
+    expect(undo).toBeTruthy();
     expect(screen.getByRole('button', { name: /^(Redo|Nothing to redo)/ })).toBeTruthy();
+    expectAboveTheGrid(undo);
   });
 
   it('shows the shell-computed wrong-mixture advisory, not one it derived itself', () => {

--- a/tests/ui/undo-controls.test.jsx
+++ b/tests/ui/undo-controls.test.jsx
@@ -629,3 +629,114 @@ describe('the dock slider commits once, on release', () => {
     expect(screen.getByTestId('col0').textContent).toBe('[20,20,20,20,20,20]');
   });
 });
+
+describe('keyboard shortcuts', () => {
+  // `cells[0]` in TuningGrid's DOM order is the RPM=800 COLUMN HEADER button (the
+  // header row is rendered before any data row, and header text is plain digits too,
+  // so it passes the same regex filter) — not a data cell. Its own text never changes
+  // no matter what gets edited, so picking it here would make `edited` equal `before`
+  // by construction, failing every assertion below for the wrong reason before the
+  // keyboard shortcut is even exercised. Mid-array — same fix the preset-label test
+  // above this describe block already uses — lands on a real data cell instead.
+  const dataCell = (list) => list[Math.floor(list.length / 2)];
+
+  // Returns the PRE-edit value, not the post-edit one: the brief's literal version
+  // read `cells[0].textContent` AFTER the `+1` click had already fired, so it handed
+  // back the edited value. The very next line in every test below reads the grid
+  // again with nothing in between, so `edited` and that returned value would always
+  // be identical DOM state — `expect(edited).not.toBe(before)` could never pass, on
+  // any cell, regardless of the keyboard handler. Capturing the value before the
+  // dock dispatch (edit still happens as the documented side effect) is what makes
+  // `before` actually mean "before".
+  function launchWithEdit() {
+    render(<EcuLab />);
+    fireEvent.click(screen.getByRole('button', { name: 'START' }));
+    fireEvent.click(screen.getByRole('button', { name: /TUNE/ }));
+    const grid = within(screen.getByTestId('tuning-grid'));
+    const cells = grid.getAllByRole('button')
+      .filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent));
+    fireEvent.click(dataCell(cells));
+    const before = dataCell(cells).textContent;
+    const dock = within(screen.getByTestId('selection-dock'));
+    fireEvent.click(dock.getByRole('button', { name: '+1' }));
+    return before;
+  }
+
+  it('undoes on Cmd+Z and redoes on Cmd+Shift+Z', () => {
+    const before = launchWithEdit();
+    const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
+    const edited = cell().textContent;
+    expect(edited).not.toBe(before);
+
+    fireEvent.keyDown(window, { key: 'z', metaKey: true });
+    expect(cell().textContent).toBe(before);
+
+    fireEvent.keyDown(window, { key: 'z', metaKey: true, shiftKey: true });
+    expect(cell().textContent).toBe(edited);
+  });
+
+  it('ignores the shortcut while focus is in a text field', () => {
+    // Otherwise the app would steal undo from the field the player is typing in.
+    launchWithEdit();
+    const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
+    const edited = cell().textContent;
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    fireEvent.keyDown(input, { key: 'z', metaKey: true });
+    expect(cell().textContent).toBe(edited);
+    input.remove();
+  });
+
+  it('ignores a bare z with no modifier', () => {
+    launchWithEdit();
+    const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
+    const edited = cell().textContent;
+    fireEvent.keyDown(window, { key: 'z' });
+    expect(cell().textContent).toBe(edited);
+  });
+
+  it('redoes on Ctrl+Y, the Windows spelling', () => {
+    // The handler accepts 'y' as well as shift+z. Nothing else asserts it, so the
+    // `key !== 'y'` half of the guard could be deleted and every other test here would
+    // still pass — leaving Ctrl+Y silently dead for every Windows player.
+    const before = launchWithEdit();
+    const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
+    const edited = cell().textContent;
+
+    fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
+    expect(cell().textContent).toBe(before);
+
+    fireEvent.keyDown(window, { key: 'y', ctrlKey: true });
+    expect(cell().textContent).toBe(edited);
+  });
+
+  it('ignores the shortcut while focus is in a select or a contenteditable', () => {
+    // The INPUT case above is the only guard any other test exercises, so the SELECT
+    // and isContentEditable halves could both be dropped with the suite still green.
+    // SELECT is not hypothetical here: BUILD's preset picker is one, and stealing
+    // Cmd+Z from an open picker takes the browser's own behaviour away from it.
+    launchWithEdit();
+    const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
+    const edited = cell().textContent;
+
+    const select = document.createElement('select');
+    document.body.appendChild(select);
+    fireEvent.keyDown(select, { key: 'z', metaKey: true });
+    expect(cell().textContent).toBe(edited);
+    select.remove();
+
+    const editable = document.createElement('div');
+    editable.contentEditable = 'true';
+    Object.defineProperty(editable, 'isContentEditable', { value: true });
+    document.body.appendChild(editable);
+    fireEvent.keyDown(editable, { key: 'z', metaKey: true });
+    expect(cell().textContent).toBe(edited);
+    editable.remove();
+  });
+});

--- a/tests/ui/undo-controls.test.jsx
+++ b/tests/ui/undo-controls.test.jsx
@@ -78,9 +78,24 @@ function EcuLabTuneHarness() {
       <button onClick={() => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value: { type: 'cell', row: 1, col: 1 } })}>
         SELECT OTHER
       </button>
+      {/* Same row as SELECT (row 0), a different column: isolates selKey's col
+          component from its row component. */}
+      <button onClick={() => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value: { type: 'cell', row: 0, col: 1 } })}>
+        SELECT SAME ROW
+      </button>
+      {/* Same column as SELECT (col 0), a different row: the mirror isolation. */}
+      <button onClick={() => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value: { type: 'cell', row: 3, col: 0 } })}>
+        SELECT SAME COL
+      </button>
+      <button onClick={() => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value: { type: 'row', row: 0 } })}>
+        SELECT ROW
+      </button>
       {/* The cell the first SELECT targets, so a test can assert WHICH value was
           committed rather than only how many entries were recorded. */}
       <output data-testid="cell">{tune.timing[0][0]}</output>
+      {/* Row 0 in full, so a row-selection commit can be pinned across all 8 cells
+          rather than spot-checked at one index. */}
+      <output data-testid="row0">{JSON.stringify(tune.timing[0])}</output>
       <SelectionDock
         data={tune.timing}
         setData={(value) => dispatch({ type: ACTIONS.SET_TABLE, table: 'timing', value })}
@@ -317,16 +332,196 @@ describe('the dock slider commits once, on release', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'SELECT' }));
     const slider = screen.getByRole('slider');
-    const before = screen.getByTestId('cell').textContent;
     fireEvent.change(slider, { target: { value: '40' } });
     expect(/** @type {HTMLInputElement} */ (screen.getByRole('slider')).value).toBe('40');
 
     // Move to a different cell without releasing: the abandoned 40 must not follow.
     fireEvent.click(screen.getByRole('button', { name: 'SELECT OTHER' }));
 
-    expect(/** @type {HTMLInputElement} */ (screen.getByRole('slider')).value).not.toBe('40');
-    // Nothing was ever committed, and the first cell still holds its original value.
+    // Literals, not `not.toBe('40')` (passes for any non-40 value, including another
+    // stale draft) or a value re-read from the component's own earlier render. 14 is
+    // DEFAULT_TIMING[1][1], cell(1,1)'s real committed value.
+    expect(/** @type {HTMLInputElement} */ (screen.getByRole('slider')).value).toBe('14');
+    // Nothing was ever committed, and the first cell still holds its original value —
+    // 10, DEFAULT_TIMING[0][0].
     expect(screen.getByTestId('depth').textContent).toBe('0');
-    expect(screen.getByTestId('cell').textContent).toBe(before);
+    expect(screen.getByTestId('cell').textContent).toBe('10');
+  });
+
+  it('drops an uncommitted draft when the selection moves to a different column in the same row', () => {
+    // T2: selKey must include the column, not just the row. The two prior tests only
+    // ever move (0,0) -> (1,1), which differs in both indices, so a selKey missing
+    // EITHER one would still satisfy them. This isolates the column.
+    render(
+      <StoreProvider>
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' })); // cell(0,0), current 10
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '40' } });
+    expect(/** @type {HTMLInputElement} */ (screen.getByRole('slider')).value).toBe('40');
+
+    // Same row, next column over: cell(0,1), current 14 (DEFAULT_TIMING[0][1]).
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT SAME ROW' }));
+
+    expect(/** @type {HTMLInputElement} */ (screen.getByRole('slider')).value).toBe('14');
+    expect(screen.getByTestId('dock-readout').textContent).toBe('14°');
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+  });
+
+  it('drops an uncommitted draft when the selection moves to a different row in the same column', () => {
+    // T3: the mirror of T2 — selKey must include the row, not just the column.
+    render(
+      <StoreProvider>
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' })); // cell(0,0), current 10
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '40' } });
+    expect(/** @type {HTMLInputElement} */ (screen.getByRole('slider')).value).toBe('40');
+
+    // Same column, a different row: cell(3,0), current 14 (DEFAULT_TIMING[3][0]).
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT SAME COL' }));
+
+    expect(/** @type {HTMLInputElement} */ (screen.getByRole('slider')).value).toBe('14');
+    expect(screen.getByTestId('dock-readout').textContent).toBe('14°');
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+  });
+
+  it('the live readout tracks the drag mid-flight, not just the slider', () => {
+    // T1: the live readout is the stated mitigation for this task's accepted cost
+    // (the grid's heat tint now updates on release, not continuously) — nothing else
+    // in the suite ever reads it. Pins `shown`, not `current`, feeding the big number.
+    render(
+      <StoreProvider>
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' })); // cell(0,0), current 10
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '40' } });
+
+    // Mid-drag: nothing committed yet, but the readout already reads the drag.
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+    expect(screen.getByTestId('dock-readout').textContent).toBe('40°');
+  });
+
+  it('a stepper click clears a draft left over from a drag that never released', () => {
+    // B1: a pointercancel (touch gesture taken over by scroll, mouse released outside
+    // the window) leaves the draft live with no pointerup ever landing. Reaching for a
+    // stepper instead must win outright — not queue behind the abandoned drag.
+    render(
+      <StoreProvider>
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' })); // cell(0,0), current 10
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '40' } });
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+
+    fireEvent.click(within(screen.getByTestId('selection-dock')).getByRole('button', { name: '+1' }));
+
+    // The stepper commits against the TABLE's value (10), not the abandoned draft (40).
+    expect(screen.getByTestId('depth').textContent).toBe('1');
+    expect(screen.getByTestId('cell').textContent).toBe('11');
+    expect(screen.getByTestId('dock-readout').textContent).toBe('11°');
+
+    // The drag's pointerup finally arrives, late. Without the fix this recommits the
+    // abandoned 40 over the stepper's edit; with it, there is nothing left to commit.
+    fireEvent.pointerUp(slider);
+
+    expect(screen.getByTestId('depth').textContent).toBe('1');
+    expect(screen.getByTestId('cell').textContent).toBe('11');
+  });
+
+  it('a drag that ends where it started does not commit', () => {
+    // B2: dragging 10 -> 40 -> back to 10 and releasing must not burn an undo entry
+    // or, via SET_TABLE, clear build.presetId / set tablesDirty for a table that
+    // never actually changed.
+    render(
+      <StoreProvider>
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' })); // cell(0,0), current 10
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '40' } });
+    fireEvent.change(slider, { target: { value: '10' } }); // back to where it started
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+
+    fireEvent.pointerUp(slider);
+
+    // No history entry burned, table untouched...
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+    expect(screen.getByTestId('cell').textContent).toBe('10');
+    // ...and the draft was still cleared on the way out, not left dangling.
+    expect(screen.getByTestId('dock-readout').textContent).toBe('10°');
+  });
+
+  it('clears the draft after a normal commit, so a later change to the table is not masked by it', () => {
+    // T4: `commitDraft` must null the draft on the success path too, not only on the
+    // `draft === null` early return. Deleting that clear leaves the dock pinned to the
+    // last dragged value forever. A later stepper click can't prove this on its own
+    // any more (B1 also clears the draft, from the stepper side) — so this drives the
+    // table out from under the dock a different way: undoing the very commit that
+    // just happened, with the selection never changing.
+    render(
+      <StoreProvider>
+        <UndoControls />
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' })); // cell(0,0), current 10
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '40' } });
+    fireEvent.pointerUp(slider); // commits 40, depth 1
+
+    expect(screen.getByTestId('depth').textContent).toBe('1');
+    expect(screen.getByTestId('cell').textContent).toBe('40');
+
+    fireEvent.click(undoBtn());
+
+    // The table is back to 10. If the draft were never cleared after the commit, the
+    // dock would still show the abandoned 40 here instead of following the table.
+    expect(screen.getByTestId('cell').textContent).toBe('10');
+    expect(screen.getByTestId('dock-readout').textContent).toBe('10°');
+    expect(/** @type {HTMLInputElement} */ (screen.getByRole('slider')).value).toBe('10');
+  });
+
+  it('commits one value across the whole row as a single entry, for a row selection', () => {
+    // M1: all prior tests here select a `cell`. For a row, `current` is a mean and
+    // `setAbs` fans the released value across all 8 cells of the row — verified
+    // correct by the reviewer, but previously unpinned.
+    render(
+      <StoreProvider>
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT ROW' })); // row 0
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '20' } });
+    expect(screen.getByTestId('depth').textContent).toBe('0'); // still just a draft
+
+    fireEvent.pointerUp(slider);
+
+    expect(screen.getByTestId('depth').textContent).toBe('1'); // one entry, not eight
+    expect(screen.getByTestId('row0').textContent).toBe('[20,20,20,20,20,20,20,20]');
   });
 });

--- a/tests/ui/undo-controls.test.jsx
+++ b/tests/ui/undo-controls.test.jsx
@@ -90,12 +90,18 @@ function EcuLabTuneHarness() {
       <button onClick={() => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value: { type: 'row', row: 0 } })}>
         SELECT ROW
       </button>
+      <button onClick={() => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value: { type: 'col', col: 0 } })}>
+        SELECT COL
+      </button>
       {/* The cell the first SELECT targets, so a test can assert WHICH value was
           committed rather than only how many entries were recorded. */}
       <output data-testid="cell">{tune.timing[0][0]}</output>
       {/* Row 0 in full, so a row-selection commit can be pinned across all 8 cells
           rather than spot-checked at one index. */}
       <output data-testid="row0">{JSON.stringify(tune.timing[0])}</output>
+      {/* Column 0 in full (one entry per row), the mirror of row0 for a col-selection
+          commit. */}
+      <output data-testid="col0">{JSON.stringify(tune.timing.map((r) => r[0]))}</output>
       <SelectionDock
         data={tune.timing}
         setData={(value) => dispatch({ type: ACTIONS.SET_TABLE, table: 'timing', value })}
@@ -467,7 +473,45 @@ describe('the dock slider commits once, on release', () => {
     // No history entry burned, table untouched...
     expect(screen.getByTestId('depth').textContent).toBe('0');
     expect(screen.getByTestId('cell').textContent).toBe('10');
-    // ...and the draft was still cleared on the way out, not left dangling.
+    // This does NOT prove the draft was cleared: here draft === current === 10, so
+    // `shown` reads 10 whether or not `setDraft(null)` ran. The test below ("the
+    // draft is cleared even when a no-op drag ends where it started") is the one
+    // that moves `current` after the release and actually bites on that clear.
+    expect(screen.getByTestId('dock-readout').textContent).toBe('10°');
+  });
+
+  it('the draft is cleared even when a no-op drag ends where it started', () => {
+    // NEW-2: commitDraft's early return is `{ setDraft(null); return; }`. The B2 test
+    // above cannot show the `setDraft(null)` half of that matters, because on its path
+    // draft === current === 10 already, so the readout reads 10 either way. This test
+    // moves `current` AFTER the no-op release, with the selection never changing, so a
+    // stale draft and a cleared one disagree.
+    render(
+      <StoreProvider>
+        <UndoControls />
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' })); // cell(0,0), current 10
+    fireEvent.click(within(screen.getByTestId('selection-dock')).getByRole('button', { name: '+1' }));
+    expect(screen.getByTestId('cell').textContent).toBe('11'); // depth 1, current now 11
+
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '40' } });
+    fireEvent.change(slider, { target: { value: '11' } }); // back to where THIS drag started
+    fireEvent.pointerUp(slider);
+
+    // The no-op guard fired: no second entry, table still 11.
+    expect(screen.getByTestId('depth').textContent).toBe('1');
+    expect(screen.getByTestId('cell').textContent).toBe('11');
+
+    fireEvent.click(undoBtn()); // real undo of the +1 -> table back to 10
+
+    // Shipped: the abandoned draft was cleared, so the dock follows the table to 10.
+    // Under a mutant that drops `setDraft(null)` from the no-op branch, the stale
+    // draft (11) is still showing and this reads '11°' instead.
     expect(screen.getByTestId('dock-readout').textContent).toBe('10°');
   });
 
@@ -523,5 +567,65 @@ describe('the dock slider commits once, on release', () => {
 
     expect(screen.getByTestId('depth').textContent).toBe('1'); // one entry, not eight
     expect(screen.getByTestId('row0').textContent).toBe('[20,20,20,20,20,20,20,20]');
+  });
+
+  it('flattening a row onto its own exact mean is still a real edit and must commit', () => {
+    // F1 / NEW-1: for a row/col selection `current` is the MEAN, not a stored value.
+    // The no-op guard in commitDraft compares `draft === current` — correct for a cell,
+    // where equality really does mean nothing changed, but wrong here: landing the
+    // slider exactly on the row's mean and releasing is a genuine edit (it flattens
+    // every cell to that value), and an unscoped guard silently discards it.
+    //
+    // Row 0 starts [10,14,20,26,30,32,33,34] (sum 199). +1 on cell(0,0) makes it
+    // [11,14,20,26,30,32,33,34], sum 200, mean EXACTLY 25 — the row selection's
+    // `current` for the rest of this test.
+    render(
+      <StoreProvider>
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' })); // cell(0,0), current 10
+    fireEvent.click(within(screen.getByTestId('selection-dock')).getByRole('button', { name: '+1' }));
+    expect(screen.getByTestId('row0').textContent).toBe('[11,14,20,26,30,32,33,34]');
+    expect(screen.getByTestId('depth').textContent).toBe('1');
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT ROW' })); // row 0, current (mean) 25
+    expect(screen.getByTestId('dock-readout').textContent).toBe('25°');
+
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '40' } });
+    fireEvent.change(slider, { target: { value: '25' } }); // lands exactly back on the mean
+    fireEvent.pointerUp(slider);
+
+    // An unscoped `draft === current` guard would treat this as a no-op and throw the
+    // fan-out away, leaving depth 1 and the row unchanged. The real behaviour is that
+    // this flattens the row and burns a second undo entry.
+    expect(screen.getByTestId('depth').textContent).toBe('2');
+    expect(screen.getByTestId('row0').textContent).toBe('[25,25,25,25,25,25,25,25]');
+  });
+
+  it('commits one value across the whole column as a single entry, for a column selection', () => {
+    // F3 / NEW-3: M1 pinned the row fan-out but left its mirror, the column branch of
+    // `setAbs`, entirely uncovered. Column 0 starts [10,10,10,14,16,14]
+    // (DEFAULT_TIMING[*][0]).
+    render(
+      <StoreProvider>
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT COL' })); // col 0
+    expect(screen.getByTestId('col0').textContent).toBe('[10,10,10,14,16,14]');
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '20' } });
+    expect(screen.getByTestId('depth').textContent).toBe('0'); // still just a draft
+
+    fireEvent.pointerUp(slider);
+
+    expect(screen.getByTestId('depth').textContent).toBe('1'); // one entry, not six
+    expect(screen.getByTestId('col0').textContent).toBe('[20,20,20,20,20,20]');
   });
 });

--- a/tests/ui/undo-controls.test.jsx
+++ b/tests/ui/undo-controls.test.jsx
@@ -135,9 +135,15 @@ const redoBtn = () => screen.getByRole('button', { name: /^(Redo|Nothing to redo
 
 describe('UndoControls', () => {
   it('starts with both buttons disabled', () => {
-    mount();
-    const undo = /** @type {HTMLButtonElement} */ (undoBtn());
-    const redo = /** @type {HTMLButtonElement} */ (redoBtn());
+    // POSITIONAL, not by accessible name. `undoBtn()`/`redoBtn()` match on the very
+    // strings this test asserts, so swapping the two fallbacks between the buttons
+    // swapped which button each helper found and both literal assertions below held
+    // against the wrong element — the test derived its subject from the string under
+    // test and survived the exact mutation its comment names. The row renders undo
+    // first (pinned by the document-order test below), and the third button belongs
+    // to EditOnce.
+    const { container } = mount();
+    const [undo, redo] = /** @type {HTMLButtonElement[]} */ ([...container.querySelectorAll('button')]);
     expect(undo.disabled).toBe(true);
     expect(redo.disabled).toBe(true);
     // The exact disabled-state strings, not just the prefix the query above
@@ -264,10 +270,15 @@ describe('UndoControls', () => {
 });
 
 describe('the dock slider commits once, on release', () => {
-  /** Reports the undo depth into the DOM so a test can read it. */
+  /** Reports both stack depths into the DOM so a test can read them. */
   function Depth() {
     const [history] = useHistory();
-    return <output data-testid="depth">{history.past.length}</output>;
+    return (
+      <>
+        <output data-testid="depth">{history.past.length}</output>
+        <output data-testid="redo-depth">{history.future.length}</output>
+      </>
+    );
   }
 
   it('records ONE history entry for a drag, not one per intermediate value', () => {
@@ -325,13 +336,18 @@ describe('the dock slider commits once, on release', () => {
     expect(screen.getByTestId('cell').textContent).toBe('22');
   });
 
-  it('does NOT commit on a Cmd/Ctrl+Z keyup, so undo cannot masquerade as an edit', () => {
-    // F4: EcuLab's global keydown handler blocks Cmd/Ctrl+Z on this INPUT, but the
-    // matching KEYUP still bubbles here. Before the fix, that keyup reached
-    // commitDraft unconditionally and committed whatever draft was pending — turning
-    // "press undo" into "commit an edit and burn an undo slot". Reproduced exactly as
-    // in the review: a drag whose pointerup never arrived (e.g. a pointercancel),
-    // then a Cmd+Z keydown+keyup on the slider itself.
+  it('does NOT commit anywhere in the FULL Cmd/Ctrl+Z sequence, modifier release included', () => {
+    // EcuLab's global keydown handler blocks Cmd/Ctrl+Z on this INPUT, but the
+    // matching KEYUPs still bubble here, and an unguarded keyup committed whatever
+    // draft was pending — turning "press undo" into "commit an edit and burn an undo
+    // slot".
+    //
+    // All FOUR events, in the order a browser really produces them. The earlier
+    // version of this test fired only the middle two, and the guard it was written
+    // against (`if (e.metaKey || e.ctrlKey) return;`) passed it while still committing
+    // on the fourth: modifier flags on a keyup report the state AFTER the event, so
+    // `metaKey` is FALSE on the release of Meta itself. Stopping at `keyup z` pins one
+    // case and not the boundary between cases.
     render(
       <StoreProvider>
         <Depth />
@@ -344,18 +360,70 @@ describe('the dock slider commits once, on release', () => {
     fireEvent.change(slider, { target: { value: '42' } }); // drag with no pointerup
     expect(screen.getByTestId('depth').textContent).toBe('0');
 
+    fireEvent.keyDown(slider, { key: 'Meta', metaKey: true });
     fireEvent.keyDown(slider, { key: 'z', metaKey: true });
     fireEvent.keyUp(slider, { key: 'z', metaKey: true });
+    fireEvent.keyUp(slider, { key: 'Meta', metaKey: false });
 
     // The abandoned draft (42) must NOT have been committed.
     expect(screen.getByTestId('depth').textContent).toBe('0');
     expect(screen.getByTestId('cell').textContent).toBe('10');
 
-    // Ctrl+Z (the Windows/Linux spelling) must be caught the same way.
+    // Ctrl+Z (the Windows/Linux spelling) must be caught the same way, release of the
+    // Control key included.
+    fireEvent.keyDown(slider, { key: 'Control', ctrlKey: true });
     fireEvent.keyDown(slider, { key: 'z', ctrlKey: true });
     fireEvent.keyUp(slider, { key: 'z', ctrlKey: true });
+    fireEvent.keyUp(slider, { key: 'Control', ctrlKey: false });
     expect(screen.getByTestId('depth').textContent).toBe('0');
     expect(screen.getByTestId('cell').textContent).toBe('10');
+  });
+
+  it('does NOT commit on the release of a key that cannot move a slider', () => {
+    // The whitelist's other side. The guard names the keys that DO change a range
+    // input's value, so every other release — Tab away, a letter typed with the
+    // control focused, Shift on its own — must leave the draft alone. A blacklist
+    // spelled as "not a modifier" would pass the Cmd+Z test above (once its fourth
+    // event is handled) and still commit on all of these.
+    render(
+      <StoreProvider>
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' })); // cell(0,0), current 10
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '42' } });
+
+    for (const key of ['Tab', 'a', 'Shift', 'Enter', 'Escape']) {
+      fireEvent.keyUp(slider, { key });
+    }
+
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+    expect(screen.getByTestId('cell').textContent).toBe('10');
+  });
+
+  it('commits on every key release that DOES move a range input', () => {
+    // The arrow-release test above covers ArrowRight alone, so a whitelist of exactly
+    // one key would satisfy it and silently break Home/End/PageUp/PageDown — the keys
+    // a range input also responds to. Each is driven from a fresh mount so none can
+    // pass on another's account, and the committed VALUE is asserted, not just depth.
+    for (const key of ['ArrowLeft', 'ArrowUp', 'ArrowDown', 'Home', 'End', 'PageUp', 'PageDown']) {
+      const { unmount } = render(
+        <StoreProvider>
+          <Depth />
+          <EcuLabTuneHarness />
+        </StoreProvider>,
+      );
+      fireEvent.click(screen.getByRole('button', { name: 'SELECT' })); // cell(0,0), current 10
+      fireEvent.change(screen.getByRole('slider'), { target: { value: '27' } });
+      fireEvent.keyUp(screen.getByRole('slider'), { key });
+
+      expect(screen.getByTestId('depth').textContent).toBe('1');
+      expect(screen.getByTestId('cell').textContent).toBe('27');
+      unmount();
+    }
   });
 
   it('drops an uncommitted draft when the selection moves to another cell', () => {
@@ -578,6 +646,49 @@ describe('the dock slider commits once, on release', () => {
     expect(screen.getByTestId('cell').textContent).toBe('10');
     expect(screen.getByTestId('dock-readout').textContent).toBe('10°');
     expect(/** @type {HTMLInputElement} */ (screen.getByRole('slider')).value).toBe('10');
+  });
+
+  it('drops an abandoned draft when an UNDO changes the table under the same cell', () => {
+    // F2. The draft is dropped when the SELECTION moves and when a stepper is clicked,
+    // but an undo changes the table with the selection unchanged — and the abandoned
+    // draft used to survive it. The grid went back to 10 while the dock's big readout,
+    // the stated mitigation for this task's accepted cost, still read 42; a late
+    // pointerup then wrote 42 back over the undo and took the redo branch with it.
+    render(
+      <StoreProvider>
+        <UndoControls />
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' })); // cell(0,0), current 10
+    fireEvent.click(within(screen.getByTestId('selection-dock')).getByRole('button', { name: '+1' }));
+    expect(screen.getByTestId('cell').textContent).toBe('11'); // depth 1, current now 11
+
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '42' } }); // drag with no pointerup
+    expect(screen.getByTestId('dock-readout').textContent).toBe('42°');
+
+    fireEvent.click(undoBtn()); // table back to 10, selection untouched
+
+    // The dock follows the table instead of going on showing the abandoned drag.
+    expect(screen.getByTestId('cell').textContent).toBe('10');
+    expect(screen.getByTestId('dock-readout').textContent).toBe('10°');
+    expect(/** @type {HTMLInputElement} */ (screen.getByRole('slider')).value).toBe('10');
+    expect(screen.getByTestId('redo-depth').textContent).toBe('1');
+
+    // The drag's pointerup finally arrives, late: there is nothing left to commit, so
+    // the undo stands and the redo it created is still there.
+    fireEvent.pointerUp(slider);
+
+    expect(screen.getByTestId('cell').textContent).toBe('10');
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+    expect(screen.getByTestId('redo-depth').textContent).toBe('1');
+    // The other side of this reset — that it does NOT fire mid-drag — is held by the
+    // drag tests at the top of this block, which assert the value the drag committed
+    // on release. A reset that fired while `data` held still would leave the draft
+    // null there and commit nothing. Not duplicated here.
   });
 
   it('commits one value across the whole row as a single entry, for a row selection', () => {

--- a/tests/ui/undo-controls.test.jsx
+++ b/tests/ui/undo-controls.test.jsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+/**
+ * The undo/redo pair on TUNE's table screens.
+ *
+ * The load-bearing test here is the last one: it drives the REAL app through a preset
+ * load, a table edit and a click on the real button, and asserts the header goes back
+ * to claiming the preset. That fails for any implementation which restores the 48
+ * numbers but forgets `presetId` — the exact defect a table-only history would ship.
+ */
+
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import EcuLab from '../../src/ui/EcuLab.jsx';
+import { UndoControls } from '../../src/ui/components/UndoControls.jsx';
+import { ACTIONS } from '../../src/ui/state/reducer.js';
+import { StoreProvider, useTune } from '../../src/ui/state/StoreProvider.jsx';
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+const hadResizeObserver = 'ResizeObserver' in window;
+if (!hadResizeObserver) window.ResizeObserver = ResizeObserverStub;
+
+afterEach(cleanup);
+
+/** Dispatches one VE edit, so the undo stack is non-empty. */
+function EditOnce() {
+  const [, dispatch] = useTune();
+  return (
+    <button onClick={() => dispatch({ type: ACTIONS.SET_TABLE, table: 've', value: [[42]] })}>
+      EDIT
+    </button>
+  );
+}
+
+function mount() {
+  return render(
+    <StoreProvider>
+      <UndoControls />
+      <EditOnce />
+    </StoreProvider>,
+  );
+}
+
+const undoBtn = () => screen.getByRole('button', { name: /^(Undo|Nothing to undo)/ });
+const redoBtn = () => screen.getByRole('button', { name: /^(Redo|Nothing to redo)/ });
+
+describe('UndoControls', () => {
+  it('starts with both buttons disabled', () => {
+    mount();
+    expect(/** @type {HTMLButtonElement} */ (undoBtn()).disabled).toBe(true);
+    expect(/** @type {HTMLButtonElement} */ (redoBtn()).disabled).toBe(true);
+  });
+
+  it('names what it would undo', () => {
+    mount();
+    fireEvent.click(screen.getByRole('button', { name: 'EDIT' }));
+    expect(undoBtn().getAttribute('aria-label')).toBe('Undo VE edit');
+  });
+
+  it('enables redo only after an undo', () => {
+    mount();
+    fireEvent.click(screen.getByRole('button', { name: 'EDIT' }));
+    expect(/** @type {HTMLButtonElement} */ (redoBtn()).disabled).toBe(true);
+    fireEvent.click(undoBtn());
+    expect(/** @type {HTMLButtonElement} */ (redoBtn()).disabled).toBe(false);
+    expect(redoBtn().getAttribute('aria-label')).toBe('Redo VE edit');
+  });
+
+  it('puts the preset label back when a table edit is undone', () => {
+    // The whole point of a snapshot spanning both slices, driven through the real app.
+    render(<EcuLab />);
+    fireEvent.click(screen.getByRole('button', { name: 'START' }));
+
+    const picker = /** @type {HTMLSelectElement[]} */ (screen.getAllByRole('combobox'))
+      .find((el) => el.querySelector('optgroup'));
+    const target = [...picker.querySelectorAll('option')]
+      .map((o) => o.value)
+      .find((v) => v && v !== picker.value);
+    fireEvent.change(picker, { target: { value: target } });
+    // Loading over an untouched default asks for no confirmation, so the preset is on.
+    expect(screen.getByTestId('build-line').textContent).not.toMatch(/^\d\.\dL /);
+
+    fireEvent.click(screen.getByRole('button', { name: /TUNE/ }));
+    const grid = within(screen.getByTestId('tuning-grid'));
+    const cells = grid.getAllByRole('button')
+      .filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent));
+    fireEvent.click(cells[Math.floor(cells.length / 2)]);
+    fireEvent.click(within(screen.getByTestId('selection-dock')).getByRole('button', { name: '+1' }));
+
+    // The edit disowned the preset: the header falls back to the derived "3.0L I6".
+    expect(screen.getByTestId('build-line').textContent).toMatch(/^\d\.\dL /);
+
+    fireEvent.click(undoBtn());
+
+    // ...and undo gives it back.
+    expect(screen.getByTestId('build-line').textContent).not.toMatch(/^\d\.\dL /);
+  });
+});

--- a/tests/ui/undo-controls.test.jsx
+++ b/tests/ui/undo-controls.test.jsx
@@ -14,9 +14,10 @@ import React from 'react';
 import { afterAll, afterEach, describe, expect, it } from 'vitest';
 
 import EcuLab from '../../src/ui/EcuLab.jsx';
+import { SelectionDock } from '../../src/ui/components/SelectionDock.jsx';
 import { UndoControls } from '../../src/ui/components/UndoControls.jsx';
 import { ACTIONS } from '../../src/ui/state/reducer.js';
-import { StoreProvider, useTune } from '../../src/ui/state/StoreProvider.jsx';
+import { StoreProvider, useHistory, useTune } from '../../src/ui/state/StoreProvider.jsx';
 
 class ResizeObserverStub {
   observe() {}
@@ -64,6 +65,30 @@ function EditThree() {
 function ReadVeCell() {
   const [tune] = useTune();
   return <div data-testid="ve-cell">{tune.ve[0][0]}</div>;
+}
+
+/** A bare SelectionDock over the store's timing table, with a cell pre-selectable. */
+function EcuLabTuneHarness() {
+  const [tune, dispatch] = useTune();
+  return (
+    <>
+      <button onClick={() => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value: { type: 'cell', row: 0, col: 0 } })}>
+        SELECT
+      </button>
+      <button onClick={() => dispatch({ type: ACTIONS.SET_TUNE_FIELD, field: 'selection', value: { type: 'cell', row: 1, col: 1 } })}>
+        SELECT OTHER
+      </button>
+      {/* The cell the first SELECT targets, so a test can assert WHICH value was
+          committed rather than only how many entries were recorded. */}
+      <output data-testid="cell">{tune.timing[0][0]}</output>
+      <SelectionDock
+        data={tune.timing}
+        setData={(value) => dispatch({ type: ACTIONS.SET_TABLE, table: 'timing', value })}
+        selection={tune.selection} min={-5} max={50} decimals={0} unit="°"
+        onClose={() => {}} kind="timing"
+      />
+    </>
+  );
 }
 
 function mount() {
@@ -214,5 +239,94 @@ describe('UndoControls', () => {
     // different preset fails here instead of slipping through.
     expect(screen.getByTestId('build-line').textContent).not.toMatch(/^\d\.\dL /);
     expect(screen.getByTestId('build-line').textContent).toMatch(/^Nissan VQ35DE Rev-Up /);
+  });
+});
+
+describe('the dock slider commits once, on release', () => {
+  /** Reports the undo depth into the DOM so a test can read it. */
+  function Depth() {
+    const [history] = useHistory();
+    return <output data-testid="depth">{history.past.length}</output>;
+  }
+
+  it('records ONE history entry for a drag, not one per intermediate value', () => {
+    // React maps onChange on a range input to the `input` event, so a real drag fires
+    // it continuously — roughly 18 times from 12 to 30 degrees. Recorded naively, undo
+    // would walk back one slider pixel at a time.
+    //
+    // Asserting the DEPTH is the point. Asserting only the final table value would
+    // pass just as well with eighteen entries recorded.
+    render(
+      <StoreProvider>
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' }));
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '20' } });
+    fireEvent.change(slider, { target: { value: '25' } });
+    fireEvent.change(slider, { target: { value: '30' } });
+
+    // Mid-drag: nothing committed yet.
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+
+    fireEvent.pointerUp(slider);
+
+    expect(screen.getByTestId('depth').textContent).toBe('1');
+    // ...and it must commit the LAST draft, not the first. Depth alone cannot tell
+    // those apart: an implementation that commits the value it saw when the drag
+    // started records exactly one entry too, and would silently write 20 where the
+    // player released at 30.
+    expect(screen.getByTestId('cell').textContent).toBe('30');
+  });
+
+  it('commits on key release too, so the slider is usable from the keyboard', () => {
+    // A keyboard user arrows the slider instead of dragging it. If only onPointerUp
+    // commits, their edit is held in the draft forever and never reaches the table —
+    // the control looks like it works and silently discards every change.
+    render(
+      <StoreProvider>
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' }));
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '22' } });
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+
+    fireEvent.keyUp(slider, { key: 'ArrowRight' });
+
+    expect(screen.getByTestId('depth').textContent).toBe('1');
+    expect(screen.getByTestId('cell').textContent).toBe('22');
+  });
+
+  it('drops an uncommitted draft when the selection moves to another cell', () => {
+    // The draft is per-cell. Without the reset, selecting a new cell keeps showing the
+    // previous cell's abandoned value, and the next release would write that stale
+    // number into a cell the player never dragged.
+    render(
+      <StoreProvider>
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' }));
+    const slider = screen.getByRole('slider');
+    const before = screen.getByTestId('cell').textContent;
+    fireEvent.change(slider, { target: { value: '40' } });
+    expect(/** @type {HTMLInputElement} */ (screen.getByRole('slider')).value).toBe('40');
+
+    // Move to a different cell without releasing: the abandoned 40 must not follow.
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT OTHER' }));
+
+    expect(/** @type {HTMLInputElement} */ (screen.getByRole('slider')).value).not.toBe('40');
+    // Nothing was ever committed, and the first cell still holds its original value.
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+    expect(screen.getByTestId('cell').textContent).toBe(before);
   });
 });

--- a/tests/ui/undo-controls.test.jsx
+++ b/tests/ui/undo-controls.test.jsx
@@ -98,7 +98,10 @@ describe('UndoControls', () => {
     // matches on.
     expect(undo.getAttribute('aria-label')).toBe('Nothing to undo');
     expect(redo.getAttribute('aria-label')).toBe('Nothing to redo');
-    // The hover tooltip carries the same text as the accessible name.
+    // The hover tooltip carries the same text as the accessible name. Derived on
+    // purpose here — the literals are asserted two lines up, so this pins the
+    // RELATIONSHIP. The populated case is pinned separately, below: in the empty
+    // state a title frozen to the hardcoded fallback would satisfy this too.
     expect(undo.getAttribute('title')).toBe(undo.getAttribute('aria-label'));
     expect(redo.getAttribute('title')).toBe(redo.getAttribute('aria-label'));
   });
@@ -108,6 +111,17 @@ describe('UndoControls', () => {
     const buttons = container.querySelectorAll('button');
     expect(buttons[0]).toBe(undoBtn());
     expect(buttons[1]).toBe(redoBtn());
+  });
+
+  it('keeps the tooltip tracking the entry once there is one to name', () => {
+    // The empty-state test above pins title === aria-label, but BOTH are the
+    // hardcoded fallback there, so a title that never tracks the entry passes it.
+    // Literal, and taken after an edit, so the tooltip has to follow the label.
+    mount();
+    fireEvent.click(screen.getByRole('button', { name: 'EDIT' }));
+    expect(undoBtn().getAttribute('title')).toBe('Undo VE edit');
+    fireEvent.click(undoBtn());
+    expect(redoBtn().getAttribute('title')).toBe('Redo VE edit');
   });
 
   it('names what it would undo', () => {
@@ -188,7 +202,7 @@ describe('UndoControls', () => {
     fireEvent.click(cells[Math.floor(cells.length / 2)]);
     fireEvent.click(within(screen.getByTestId('selection-dock')).getByRole('button', { name: '+1' }));
 
-    // The edit disowned the preset: the header falls back to the derived "3.0L I6".
+    // The edit disowned the preset: the header falls back to the derived "3.5L V6".
     expect(screen.getByTestId('build-line').textContent).toMatch(/^\d\.\dL /);
 
     fireEvent.click(undoBtn());

--- a/tests/ui/undo-controls.test.jsx
+++ b/tests/ui/undo-controls.test.jsx
@@ -38,11 +38,38 @@ function EditOnce() {
   );
 }
 
+/** Dispatches one edit per table, so the stack holds three distinguishable entries. */
+function EditThree() {
+  const [, dispatch] = useTune();
+  return (
+    <>
+      <button onClick={() => dispatch({ type: ACTIONS.SET_TABLE, table: 've', value: [[1]] })}>
+        EDIT VE
+      </button>
+      <button onClick={() => dispatch({ type: ACTIONS.SET_TABLE, table: 'timing', value: [[2]] })}>
+        EDIT SPARK
+      </button>
+      <button onClick={() => dispatch({ type: ACTIONS.SET_TABLE, table: 'afr', value: [[3]] })}>
+        EDIT FUEL
+      </button>
+    </>
+  );
+}
+
 function mount() {
   return render(
     <StoreProvider>
       <UndoControls />
       <EditOnce />
+    </StoreProvider>,
+  );
+}
+
+function mountThree() {
+  return render(
+    <StoreProvider>
+      <UndoControls />
+      <EditThree />
     </StoreProvider>,
   );
 }
@@ -70,6 +97,29 @@ describe('UndoControls', () => {
     fireEvent.click(undoBtn());
     expect(/** @type {HTMLButtonElement} */ (redoBtn()).disabled).toBe(false);
     expect(redoBtn().getAttribute('aria-label')).toBe('Redo VE edit');
+  });
+
+  it('names the MOST RECENT edit to undo, not the oldest', () => {
+    // past is a stack: VE then Spark then Fuel means Fuel is on top, and undo
+    // reverses the top of the stack first. If the label read the wrong end, this
+    // would say "Undo VE edit" instead.
+    mountThree();
+    fireEvent.click(screen.getByRole('button', { name: 'EDIT VE' }));
+    fireEvent.click(screen.getByRole('button', { name: 'EDIT SPARK' }));
+    fireEvent.click(screen.getByRole('button', { name: 'EDIT FUEL' }));
+    expect(undoBtn().getAttribute('aria-label')).toBe('Undo Fuel edit');
+  });
+
+  it('names the NEXT redo after two undos, not the last one undone', () => {
+    // Undoing Fuel then Spark leaves future = [Spark, Fuel] (head-first): Spark is
+    // next in line to be replayed, so redo must name Spark, not Fuel.
+    mountThree();
+    fireEvent.click(screen.getByRole('button', { name: 'EDIT VE' }));
+    fireEvent.click(screen.getByRole('button', { name: 'EDIT SPARK' }));
+    fireEvent.click(screen.getByRole('button', { name: 'EDIT FUEL' }));
+    fireEvent.click(undoBtn()); // undoes Fuel edit -> future = [Fuel]
+    fireEvent.click(undoBtn()); // undoes Spark edit -> future = [Spark, Fuel]
+    expect(redoBtn().getAttribute('aria-label')).toBe('Redo Spark edit');
   });
 
   it('puts the preset label back when a table edit is undone', () => {

--- a/tests/ui/undo-controls.test.jsx
+++ b/tests/ui/undo-controls.test.jsx
@@ -11,7 +11,7 @@
 
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, describe, expect, it } from 'vitest';
 
 import EcuLab from '../../src/ui/EcuLab.jsx';
 import { UndoControls } from '../../src/ui/components/UndoControls.jsx';
@@ -25,6 +25,9 @@ class ResizeObserverStub {
 }
 const hadResizeObserver = 'ResizeObserver' in window;
 if (!hadResizeObserver) window.ResizeObserver = ResizeObserverStub;
+afterAll(() => {
+  if (!hadResizeObserver) delete window.ResizeObserver;
+});
 
 afterEach(cleanup);
 
@@ -56,6 +59,13 @@ function EditThree() {
   );
 }
 
+/** Renders the VE table's top-left cell, so a redo that actually replays SET_TABLE
+ *  is directly observable, not just its label/disabled bookkeeping. */
+function ReadVeCell() {
+  const [tune] = useTune();
+  return <div data-testid="ve-cell">{tune.ve[0][0]}</div>;
+}
+
 function mount() {
   return render(
     <StoreProvider>
@@ -80,8 +90,24 @@ const redoBtn = () => screen.getByRole('button', { name: /^(Redo|Nothing to redo
 describe('UndoControls', () => {
   it('starts with both buttons disabled', () => {
     mount();
-    expect(/** @type {HTMLButtonElement} */ (undoBtn()).disabled).toBe(true);
-    expect(/** @type {HTMLButtonElement} */ (redoBtn()).disabled).toBe(true);
+    const undo = /** @type {HTMLButtonElement} */ (undoBtn());
+    const redo = /** @type {HTMLButtonElement} */ (redoBtn());
+    expect(undo.disabled).toBe(true);
+    expect(redo.disabled).toBe(true);
+    // The exact disabled-state strings, not just the prefix the query above
+    // matches on.
+    expect(undo.getAttribute('aria-label')).toBe('Nothing to undo');
+    expect(redo.getAttribute('aria-label')).toBe('Nothing to redo');
+    // The hover tooltip carries the same text as the accessible name.
+    expect(undo.getAttribute('title')).toBe(undo.getAttribute('aria-label'));
+    expect(redo.getAttribute('title')).toBe(redo.getAttribute('aria-label'));
+  });
+
+  it('renders undo before redo in DOM order', () => {
+    const { container } = mount();
+    const buttons = container.querySelectorAll('button');
+    expect(buttons[0]).toBe(undoBtn());
+    expect(buttons[1]).toBe(redoBtn());
   });
 
   it('names what it would undo', () => {
@@ -97,6 +123,25 @@ describe('UndoControls', () => {
     fireEvent.click(undoBtn());
     expect(/** @type {HTMLButtonElement} */ (redoBtn()).disabled).toBe(false);
     expect(redoBtn().getAttribute('aria-label')).toBe('Redo VE edit');
+  });
+
+  it('redo actually replays the edit it names, not a no-op', () => {
+    // The mirror of undo's own click-handler coverage: undoing then redoing the
+    // same edit must bring the exact edited value back, not merely flip the
+    // disabled flag redo's label already proves it tracks.
+    render(
+      <StoreProvider>
+        <UndoControls />
+        <EditOnce />
+        <ReadVeCell />
+      </StoreProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'EDIT' }));
+    expect(screen.getByTestId('ve-cell').textContent).toBe('42');
+    fireEvent.click(undoBtn());
+    expect(screen.getByTestId('ve-cell').textContent).not.toBe('42');
+    fireEvent.click(redoBtn());
+    expect(screen.getByTestId('ve-cell').textContent).toBe('42');
   });
 
   it('names the MOST RECENT edit to undo, not the oldest', () => {
@@ -148,7 +193,12 @@ describe('UndoControls', () => {
 
     fireEvent.click(undoBtn());
 
-    // ...and undo gives it back.
+    // ...and undo gives it back. The negative regex alone would pass for ANY
+    // preset restored, including the wrong one — this names the specific preset
+    // the picker loaded (the first option in the first optgroup, the Nissan
+    // group, over an untouched default store) so a restore that hands back a
+    // different preset fails here instead of slipping through.
     expect(screen.getByTestId('build-line').textContent).not.toMatch(/^\d\.\dL /);
+    expect(screen.getByTestId('build-line').textContent).toMatch(/^Nissan VQ35DE Rev-Up /);
   });
 });

--- a/tests/ui/undo-controls.test.jsx
+++ b/tests/ui/undo-controls.test.jsx
@@ -11,7 +11,7 @@
 
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import React from 'react';
-import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 
 import EcuLab from '../../src/ui/EcuLab.jsx';
 import { SelectionDock } from '../../src/ui/components/SelectionDock.jsx';
@@ -323,6 +323,39 @@ describe('the dock slider commits once, on release', () => {
 
     expect(screen.getByTestId('depth').textContent).toBe('1');
     expect(screen.getByTestId('cell').textContent).toBe('22');
+  });
+
+  it('does NOT commit on a Cmd/Ctrl+Z keyup, so undo cannot masquerade as an edit', () => {
+    // F4: EcuLab's global keydown handler blocks Cmd/Ctrl+Z on this INPUT, but the
+    // matching KEYUP still bubbles here. Before the fix, that keyup reached
+    // commitDraft unconditionally and committed whatever draft was pending — turning
+    // "press undo" into "commit an edit and burn an undo slot". Reproduced exactly as
+    // in the review: a drag whose pointerup never arrived (e.g. a pointercancel),
+    // then a Cmd+Z keydown+keyup on the slider itself.
+    render(
+      <StoreProvider>
+        <Depth />
+        <EcuLabTuneHarness />
+      </StoreProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'SELECT' })); // cell(0,0), current 10
+    const slider = screen.getByRole('slider');
+    fireEvent.change(slider, { target: { value: '42' } }); // drag with no pointerup
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+
+    fireEvent.keyDown(slider, { key: 'z', metaKey: true });
+    fireEvent.keyUp(slider, { key: 'z', metaKey: true });
+
+    // The abandoned draft (42) must NOT have been committed.
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+    expect(screen.getByTestId('cell').textContent).toBe('10');
+
+    // Ctrl+Z (the Windows/Linux spelling) must be caught the same way.
+    fireEvent.keyDown(slider, { key: 'z', ctrlKey: true });
+    fireEvent.keyUp(slider, { key: 'z', ctrlKey: true });
+    expect(screen.getByTestId('depth').textContent).toBe('0');
+    expect(screen.getByTestId('cell').textContent).toBe('10');
   });
 
   it('drops an uncommitted draft when the selection moves to another cell', () => {
@@ -648,8 +681,11 @@ describe('keyboard shortcuts', () => {
   // any cell, regardless of the keyboard handler. Capturing the value before the
   // dock dispatch (edit still happens as the documented side effect) is what makes
   // `before` actually mean "before".
+  // Returns { before, unmount }, not just the pre-edit value: F7 (listener cleanup)
+  // needs a handle to unmount the real render, and reusing this helper for that test
+  // keeps the same launch path every other test in this block already exercises.
   function launchWithEdit() {
-    render(<EcuLab />);
+    const { unmount } = render(<EcuLab />);
     fireEvent.click(screen.getByRole('button', { name: 'START' }));
     fireEvent.click(screen.getByRole('button', { name: /TUNE/ }));
     const grid = within(screen.getByTestId('tuning-grid'));
@@ -659,11 +695,11 @@ describe('keyboard shortcuts', () => {
     const before = dataCell(cells).textContent;
     const dock = within(screen.getByTestId('selection-dock'));
     fireEvent.click(dock.getByRole('button', { name: '+1' }));
-    return before;
+    return { before, unmount };
   }
 
   it('undoes on Cmd+Z and redoes on Cmd+Shift+Z', () => {
-    const before = launchWithEdit();
+    const { before } = launchWithEdit();
     const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
       .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
     const edited = cell().textContent;
@@ -676,12 +712,79 @@ describe('keyboard shortcuts', () => {
     expect(cell().textContent).toBe(edited);
   });
 
-  it('ignores the shortcut while focus is in a text field', () => {
-    // Otherwise the app would steal undo from the field the player is typing in.
-    launchWithEdit();
+  it('redoes on Cmd+Shift+Z using the real uppercase key browsers report', () => {
+    // Per UI Events, KeyboardEvent.key reflects the character AFTER modifiers are
+    // applied, so Chrome/Firefox/Safari all report key: "Z" (uppercase) for
+    // Cmd+Shift+Z — not lowercase 'z' with shiftKey true, which is what the test
+    // above (and every fabricated event in this file until now) actually fires.
+    // Without .toLowerCase() in the handler this redo would be silently dead in
+    // every real browser while still passing a suite that only ever sends 'z'.
+    const { before } = launchWithEdit();
     const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
       .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
     const edited = cell().textContent;
+    expect(edited).not.toBe(before);
+
+    fireEvent.keyDown(window, { key: 'z', metaKey: true });
+    expect(cell().textContent).toBe(before);
+
+    fireEvent.keyDown(window, { key: 'Z', metaKey: true, shiftKey: true });
+    expect(cell().textContent).toBe(edited);
+  });
+
+  it('leaves Cmd+A and Cmd+C alone: not undo, and not swallowed', () => {
+    // Each half of `key !== 'z' && key !== 'y'` is pinned individually elsewhere in
+    // this file, but nothing proves the guard's EXCLUSIVITY — that a modified key
+    // which is neither z nor y is left alone. Without the whole line, Cmd+A/Cmd+C
+    // (and even a bare Cmd keypress) would dispatch UNDO and swallow the browser's
+    // own select-all/copy via preventDefault(). fireEvent.keyDown returns `true`
+    // exactly when preventDefault() was NOT called, so this checks both at once.
+    const { before } = launchWithEdit();
+    const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
+    const edited = cell().textContent;
+    expect(edited).not.toBe(before);
+
+    expect(fireEvent.keyDown(window, { key: 'a', metaKey: true })).toBe(true);
+    expect(cell().textContent).toBe(edited);
+
+    expect(fireEvent.keyDown(window, { key: 'c', metaKey: true })).toBe(true);
+    expect(cell().textContent).toBe(edited);
+  });
+
+  it('prevents the browser default on the shortcut, so it does not also fire', () => {
+    // fireEvent.keyDown resolves to `false` exactly when preventDefault() was called
+    // on the dispatched event. Without this the app's own undo would fire ALONGSIDE
+    // Firefox's page-level undo / Safari's Cmd+Y History.
+    launchWithEdit();
+    expect(fireEvent.keyDown(window, { key: 'z', metaKey: true })).toBe(false);
+  });
+
+  it('ignores Ctrl+Alt (AltGr), which types a real character on many European layouts', () => {
+    // Windows/Linux report AltGr as Ctrl+Alt together. Without excluding altKey,
+    // AltGr+Z / AltGr+Y on those layouts would undo/redo and swallow the typed
+    // character instead. `toBe(true)` here proves it was NOT swallowed, the same
+    // literal-return technique as the preventDefault test above.
+    const { before } = launchWithEdit();
+    const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
+    const edited = cell().textContent;
+    expect(edited).not.toBe(before);
+
+    expect(fireEvent.keyDown(window, { key: 'z', ctrlKey: true, altKey: true })).toBe(true);
+    expect(cell().textContent).toBe(edited);
+
+    expect(fireEvent.keyDown(window, { key: 'y', ctrlKey: true, altKey: true })).toBe(true);
+    expect(cell().textContent).toBe(edited);
+  });
+
+  it('ignores the shortcut while focus is in a text field', () => {
+    // Otherwise the app would steal undo from the field the player is typing in.
+    const { before } = launchWithEdit();
+    const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
+      .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
+    const edited = cell().textContent;
+    expect(edited).not.toBe(before);
 
     const input = document.createElement('input');
     document.body.appendChild(input);
@@ -691,10 +794,12 @@ describe('keyboard shortcuts', () => {
   });
 
   it('ignores a bare z with no modifier', () => {
-    launchWithEdit();
+    const { before } = launchWithEdit();
     const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
       .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
     const edited = cell().textContent;
+    expect(edited).not.toBe(before);
+
     fireEvent.keyDown(window, { key: 'z' });
     expect(cell().textContent).toBe(edited);
   });
@@ -703,10 +808,11 @@ describe('keyboard shortcuts', () => {
     // The handler accepts 'y' as well as shift+z. Nothing else asserts it, so the
     // `key !== 'y'` half of the guard could be deleted and every other test here would
     // still pass — leaving Ctrl+Y silently dead for every Windows player.
-    const before = launchWithEdit();
+    const { before } = launchWithEdit();
     const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
       .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
     const edited = cell().textContent;
+    expect(edited).not.toBe(before);
 
     fireEvent.keyDown(window, { key: 'z', ctrlKey: true });
     expect(cell().textContent).toBe(before);
@@ -715,21 +821,30 @@ describe('keyboard shortcuts', () => {
     expect(cell().textContent).toBe(edited);
   });
 
-  it('ignores the shortcut while focus is in a select or a contenteditable', () => {
-    // The INPUT case above is the only guard any other test exercises, so the SELECT
-    // and isContentEditable halves could both be dropped with the suite still green.
-    // SELECT is not hypothetical here: BUILD's preset picker is one, and stealing
-    // Cmd+Z from an open picker takes the browser's own behaviour away from it.
-    launchWithEdit();
+  it('ignores the shortcut while focus is in a select, a textarea, or a contenteditable', () => {
+    // The INPUT case above is the only guard any other test exercises, so the SELECT,
+    // TEXTAREA and isContentEditable halves could all be dropped with the suite still
+    // green. SELECT is not hypothetical here: BUILD's preset picker is one, and
+    // stealing Cmd+Z from an open picker takes the browser's own behaviour away from
+    // it. No <textarea> exists anywhere in src/ui today, so TEXTAREA's impact is nil,
+    // but the guard clause should still be held rather than left dead.
+    const { before } = launchWithEdit();
     const cell = () => dataCell(within(screen.getByTestId('tuning-grid'))
       .getAllByRole('button').filter((b) => /^-?\d+(\.\d+)?$/.test(b.textContent)));
     const edited = cell().textContent;
+    expect(edited).not.toBe(before);
 
     const select = document.createElement('select');
     document.body.appendChild(select);
     fireEvent.keyDown(select, { key: 'z', metaKey: true });
     expect(cell().textContent).toBe(edited);
     select.remove();
+
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    fireEvent.keyDown(textarea, { key: 'z', metaKey: true });
+    expect(cell().textContent).toBe(edited);
+    textarea.remove();
 
     const editable = document.createElement('div');
     editable.contentEditable = 'true';
@@ -738,5 +853,34 @@ describe('keyboard shortcuts', () => {
     fireEvent.keyDown(editable, { key: 'z', metaKey: true });
     expect(cell().textContent).toBe(edited);
     editable.remove();
+  });
+
+  it('removes the keydown listener on unmount', () => {
+    // Coverage for the effect's cleanup, not a defect: `return () =>
+    // window.removeEventListener('keydown', onKey)` is already correct today (the
+    // review instrumented it: exactly one add, one matching remove). But replacing
+    // that cleanup with `() => {}` still leaves a fully green suite — every other
+    // test here unmounts via afterEach(cleanup) with nothing left in the DOM to
+    // observe a leaked listener against. Spying on add/removeEventListener directly
+    // is what actually catches it: after unmount, the SAME function reference handed
+    // to addEventListener must come back out of removeEventListener.
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const { unmount } = render(<EcuLab />);
+    fireEvent.click(screen.getByRole('button', { name: 'START' }));
+
+    const keydownAdds = addSpy.mock.calls.filter((call) => call[0] === 'keydown');
+    expect(keydownAdds.length).toBe(1);
+    const handler = keydownAdds[0][1];
+
+    unmount();
+
+    const keydownRemoves = removeSpy.mock.calls.filter((call) => call[0] === 'keydown');
+    expect(keydownRemoves.length).toBe(1);
+    expect(keydownRemoves[0][1]).toBe(handler);
+
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Undo/redo for calibration edits — the first of three PRs from #60.

## Why this first

#60 bundles five features: range selection, bulk operations, undo/redo, keyboard
tuning and a diff-vs-stock overlay. Only two are coupled. This PR ships undo alone,
**before** the bulk operations of PR 4b, because those are what turn a slip into a
wrecked 6×8 table. The issue's own words — "a mis-drag on a 6×8 table is currently
unrecoverable" — describe a hazard that does not fully exist yet. The safety net
goes in before the hazard.

Split agreed up front:

| PR | Contents |
|---|---|
| **4a (this one)** | Undo/redo |
| 4b | Selection rectangle, bulk ops, keyboard tuning |
| 4c | Diff-vs-stock overlay |

Deferring selection to 4b was deliberate: `advisorReports.js`, `TuningGrid`,
`SelectionDock`, `EcuLab.jsx` and the `initialState.js` typedef all read today's
`Selection` shape, so changing it is a migration, not an addition — and it would
have broken the advisor panel merged in #87.

## What changed

A fourth store slice, `history: { past, future }`, holding uniform snapshots.
Capture is uniform; restore is scoped to what the undone action wrote, so undoing a
table edit cannot revert hardware.
`SET_TABLE`, `APPLY_PRESET` and `RESET_TO_STOCK` push an entry; `UNDO`/`REDO` walk
it. Reaching it: ↶ ↷ buttons in the grid header on TUNE's three calibration
screens, an offer on BUILD after a preset load or reset, and Cmd/Ctrl+Z with
Cmd+Shift+Z / Ctrl+Y for redo. The shortcut deliberately stands down whenever an
`<input>`, `<textarea>`, `<select>` or contenteditable has focus, so it never
steals undo from a field the player is typing in — which also means it is inert
while either slider has focus. Narrowing that guard for range inputs, which have no
native undo to protect, is left to a follow-up.

Preset loads and resets are undoable on purpose. Loading a preset over hand-tuned
tables is the most destructive single act in the app, and it already carried a
confirmation prompt — the codebase agreeing the danger is real. Undo that covers
the small mistake but not the large one teaches players not to trust it.

The snapshot is **uniform** — the union of every field any undoable action can
write — rather than per-action. One shape means one restore path; three shapes
would mean a fourth undoable action could later produce a half-restored state no
test thought to cover. Verified mechanically: every field `SET_TABLE`,
`APPLY_PRESET` and `RESET_TO_STOCK` write is in the union, except two cursors
excluded on purpose. `build.presetPrompt` would re-open the "load this preset?"
modal immediately after undoing that preset load; `tune.selection` would move the
player's highlight. The rule is *hardware and calibration, never UI cursors*.

**The slider had to change first.** React maps `onChange` on a range input to the
`input` event, so a drag from 12° to 30° dispatched ~18 `SET_TABLE`s. Recorded
naively, undo would walk back one slider pixel at a time. The slider now holds a
local draft and commits once on release, which keeps the reducer a pure function
of `(state, action)` — no clock, no coalescing keys, no merge logic — which its
existing tests depend on.

## Two things this deliberately does not do

**Undo does not restore dyno results.** `APPLY_PRESET` clears `session.result` so a
factory rating never sits beside a pull logged on whatever was running before it.
The result is lost either way; re-showing a banked score beside a just-reverted
build is the direction that states something false.

**Undo does restore hardware, and the BUILD offer says so.** "Not undoable" for
hardware means *pushes no history entry* — it does not mean undo leaves hardware
alone, because the snapshot carries 13 build fields. So undoing a preset load also
reverts a hardware change made after it. That is correct (a partial restore would
be worse), but it makes the offer's wording load-bearing: it names the tables **and
hardware**. The design doc's original claim here was wrong and has been corrected
in place rather than quietly dropped.

## Verification

954 tests across 32 files; lint (`--max-warnings 0`), typecheck and build clean.
Rebased onto v1.6.0 and re-run in full — a pre-rebase green says nothing about the
post-rebase tree.

No `src/sim/` change of any kind, so the behavioural fingerprint is untouched — it
is byte-identical to main's, which matters because v1.6.0 reworked the fingerprint
machinery. `tests/ui/characterisation.test.jsx` is byte-identical to main.

**Almost every new test was shown to fail under the mutation it targets** — with two
known exceptions, both recorded rather than papered over: the render-time draft
reset in `SelectionDock` cannot be pinned by this suite at all, because the
difference it makes is one paint frame and `act()` flushes effects first. The
mutation discipline was not ceremony here: it caught undo running FIFO (reversing the *oldest* edit) with 871
tests green; the redo button dispatching nothing with 6/6 green; both halves of a
two-part cache key droppable because every test moved the selection diagonally; an
`aria-label` naming a completely wrong preset because the test asserted only a
prefix the implementation satisfied by construction; and `restore` silently
deleting every build field the snapshot does not carry, with all 876 green.

Five real bugs surfaced this way and are fixed. Three were cross-task — no single
piece was wrong on its own, which is exactly what per-task review cannot see:

- **Cmd+Z on the dock slider committed an edit instead of undoing.** The keydown was
  correctly blocked, but the matching *keyup* reached the slider's commit-on-release
  handler. Two separately-correct pieces interacting badly.
- **A no-op guard discarded real edits on row/column selections**, where the
  "current" value is a *mean*, so landing the slider on it is a genuine edit that
  flattens the row — not a no-op.
- **An abandoned slider draft outlived an undo**, so the readout kept showing a
  value the table no longer held, and a later stray release wrote it back.
- **Undoing a table edit reverted hardware installed since.** The snapshot captures
  all 13 build fields, but `SET_TABLE` writes only `presetId` — so undoing a VE
  edit took the turbo back off, under the label "Undo VE edit". Restore is now
  scoped to what the undone action actually wrote.
- **Redo could destroy hardware built after an undo**, because only undoable actions
  cleared the redo stack. Any build or tune write now clears it; `LIVE_STEP` is
  excluded, since at 20 Hz it would empty the stack before a player reached the
  button.

Note on scope of coverage: vitest applies no CSS in this project, so nothing in the
suite observes a colour, a media query, or a layout. The visual result of these
changes is unverified by tests, by construction.

Closes #60 in part — 4b and 4c follow.
