### PR TITLE
Stop tracking a node_modules symlink, and close the hole that let it in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
-node_modules/
+# No trailing slash, deliberately. A pattern ending in `/` matches DIRECTORIES
+# ONLY, and git treats a symlink as a file — so `node_modules/` did not ignore a
+# SYMLINK named node_modules, and one was committed by accident during a merge
+# (3fea1b9). It pointed at its own absolute path inside a contributor's home
+# directory, so every clone since laid down a dangling link and leaked that path.
+# The slashless form ignores the name whatever it is on disk.
+node_modules
 dist/
 coverage/
 

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/danny/Desktop/Projects/cariboutuning/node_modules


### PR DESCRIPTION
`node_modules` has been tracked as a **symlink** (mode `120000`) since the merge 3fea1b9 on 2026-08-15. Its target is `/Users/danny/Desktop/Projects/cariboutuning/node_modules` — an absolute path inside one contributor's home directory, pointing at itself.

## Why .gitignore did not stop it

The pattern was `node_modules/`. A trailing slash restricts a pattern to **directories**, and git records a symlink as a file — so the entry was never matched, and a `git add -A` during a conflict resolution picked it up without complaint.

The slashless `node_modules` ignores the name whatever it is on disk. That is the actual fix: untracking the entry alone would leave the next accidental symlink just as addable.

## What it was costing

Measured with real clones, not reasoned about:

```
BEFORE (main):  node_modules -> /Users/danny/Desktop/Projects/cariboutuning/node_modules
AFTER  (this):  no node_modules entry
```

On the machine that path belongs to, a fresh clone silently pointed at another checkout's real dependencies. Anywhere else it dangles, and the tree published that home path either way. CI survives only incidentally — `npm ci` clears `node_modules` before installing — but `npm install` in a fresh clone writes through a broken link. On any working copy where a real `node_modules` directory has replaced the link, `git status` permanently reports it as `deleted`, which is where this was noticed.

## Verification

- A clone of this branch has no `node_modules` entry at all.
- In that clone, creating a symlink named `node_modules` now shows nothing under `git status -uall`, and `git check-ignore -v` attributes it to `.gitignore:7`.
- No code is touched, so there is no build or test effect. `git rm --cached` leaves the real directory on disk alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Je735zmGJajgLsbWvDDyp