### PR TITLE
Run history and a legible ghost curve (PR 5a of #61)

### DIFF
--- a/docs/superpowers/plans/2026-08-31-run-history-ghost-curve.md
+++ b/docs/superpowers/plans/2026-08-31-run-history-ghost-curve.md
@@ -1,0 +1,1777 @@
+# Run History and the Ghost Curve — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep the last 20 dyno pulls as a persisted, browsable log; let any of them be pinned as the chart's comparison curve; and make that comparison curve legible.
+
+**Architecture:** A pure module (`src/ui/state/runLog.js`) owns the run record and the operations over a list of them. The SESSION slice gains `runs` and `pinnedRunId` and loses `prevResult`. `pullSignature.js` widens from "has any measured input moved?" to also answer "which one", so the run diff cannot drift from the signature. A new DYNO section renders the timeline.
+
+**Tech Stack:** React 18 + `useReducer` (single store, three context hooks), CSS Modules, recharts, vitest + @testing-library/react, JSDoc-typed JS checked by `tsc --noEmit`.
+
+**Spec:** `docs/superpowers/specs/2026-08-31-run-history-ghost-curve-design.md`
+
+## Global Constraints
+
+- **Node 22 only** — `v22.23.2`. Node 26 shifts float results and invalidates the fingerprint hash on its own.
+- **Run the suite as** `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork`. Do **not** use `npx vitest` — it resolves a different cached copy that rejects `--poolOptions`.
+- **No `src/sim/` changes in this PR at all.** `tests/fixtures/fingerprint.sha256` and `tests/ui/characterisation.test.jsx` must be byte-identical to `main` at merge. Verify with `git diff --stat origin/main -- src/sim tests/fixtures/fingerprint.sha256 tests/ui/characterisation.test.jsx` — expect empty output.
+- **Never run `npm run test:fingerprint:update`.**
+- **No hard-coded colours anywhere under `src/ui/`** — no hex, no `rgb()`/`rgba()`, no `hsl()`. `tests/no-hardcoded-colours.test.js` enforces this per file. Use `var(--token)` in CSS Modules and `T.*` from `src/ui/theme.js` in JSX.
+- **Full gate before every commit:** `npm test`, `npm run lint` (`--max-warnings 0`), `npm run typecheck`, `npm run build`. All four must pass.
+- **A raw test total is not a stable baseline.** `no-hardcoded-colours.test.js` generates 2–3 tests per source file under `src/ui/`, so the two files created in Task 7 add ~5 tests on their own. Compare per-file counts, not the grand total.
+- **`RUN_LIMIT` is 20.**
+- **Ghost curve treatment:** ghost WHP is `T.acc` and ghost torque is `T.cyan`, both `strokeWidth={1.5}`, `strokeDasharray="5 4"`, `opacity={0.5}`. Live lines stay `strokeWidth={2}`, solid, full opacity.
+- **`git add` explicit paths only.** Never `git add -A`, never `git add .`.
+
+---
+
+## File Structure
+
+**Create:**
+
+| File | Responsibility |
+|---|---|
+| `src/ui/state/runLog.js` | The run record and every pure operation over a list of runs. Imports nothing from `reducer.js`. |
+| `src/ui/screens/dyno/HistoryScreen.jsx` | DYNO > HISTORY. Renders the timeline, owns the pin control. |
+| `src/ui/screens/dyno/HistoryScreen.module.css` | Its styles. Tokens only. |
+| `tests/ui/state/runLog.test.js` | Unit tests for `runLog.js`. No DOM. |
+
+**Modify:**
+
+| File | Change |
+|---|---|
+| `src/ui/state/pullSignature.js` | Add `measuredInputs` and `diffMeasuredInputs`; rewrite the header for the widened charter. Key arrays stay private. |
+| `src/ui/state/initialState.js` | SESSION typedef and initial value: add `runs`, `pinnedRunId`; remove `prevResult`. |
+| `src/ui/state/reducer.js` | `PIN_RUN`/`UNPIN_RUN` actions and typedefs; `BANK_PULL` records the run; `APPLY_PRESET` drops its `prevResult` line. |
+| `src/storage.js` | Persist and restore `runs` and `pinnedRunId`. |
+| `src/ui/EcuLab.jsx` | Build the run record in `doRun`; ghost via `ghostRun`; RPM-keyed chart join; persistence effect; render the new section. |
+| `src/ui/screens/dyno/ResultScreen.jsx` | Ghost line treatment; takes `ghostLabel` as a prop instead of reading `prevResult`. |
+| `src/ui/routing.js` | `ROUTES.dyno` gains `'history'`. |
+| `tests/ui/state/pullSignature.test.js` | Cover the two new functions. |
+| `tests/ui/state/reducer.test.js` | Cover the new actions and the lifecycle guarantees. |
+| `tests/storage.test.js` | Cover the legacy blob and the new fields. |
+| `tests/ui/session-store.test.jsx` | Cover the persistence effect's mount guard. |
+| `tests/ui/dyno-screens.test.jsx` | Cover the new screen and the ghost. |
+
+---
+
+## Task 1: `runLog.js` — the pure run-log module
+
+**Files:**
+- Create: `src/ui/state/runLog.js`
+- Test: `tests/ui/state/runLog.test.js`
+
+**Interfaces:**
+- Consumes: nothing. This task adds no imports to existing modules.
+- Produces:
+  - `RUN_LIMIT: number` (20)
+  - `makeRunRecord({id, n, at, label, result, scores, pullScore, inputs}) => RunRecord`
+  - `pushRun(runs: RunRecord[], record: RunRecord) => RunRecord[]`
+  - `ghostRun(runs: RunRecord[], pinnedRunId: string|null) => RunRecord|null`
+  - `ghostLabel(run: RunRecord|null, pinnedRunId: string|null) => string|null`
+  - `sparklinePath(points: {rpm,hp,torque}[], width: number, height: number) => string`
+  - `RunRecord` typedef with fields `id, n, at, label, peakHp, peakTq, knocks, scores:{tuning,engineer,pull}, points:[{rpm,hp,torque}], inputs`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/ui/state/runLog.test.js`:
+
+```js
+/**
+ * The run log — pure, no DOM.
+ *
+ * Every test here names the mutation it exists to catch. PR 4a shipped seven suites
+ * that each passed against a broken implementation, always in one of five shapes; the
+ * two that bite hardest here are "asserts a count but not which end" (a FIFO undo
+ * stack passed 871 tests) and "pins one side of a pair". Both are held below by
+ * asserting the surviving IDS, not the surviving length.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { RUN_LIMIT, ghostLabel, ghostRun, makeRunRecord, pushRun, sparklinePath } from '../../../src/ui/state/runLog.js';
+
+/** A minimal sweep result, shaped like `simulateSweep`'s output. */
+function fakeResult({ peakHp = 300, peakTq = 280, knocks = 0 } = {}) {
+  return {
+    peakHp,
+    peakTq,
+    points: [
+      { rpm: 1500, hp: 100, torque: 200, afr: 12.5, timing: 20 },
+      { rpm: 1600, hp: 120, torque: 210, afr: 12.4, timing: 21 },
+      { rpm: 1700, hp: 140, torque: 220, afr: 12.3, timing: 22 },
+    ],
+    events: [
+      ...Array.from({ length: knocks }, () => ({ type: 'knock', severity: 3 })),
+      { type: 'lean', severity: 2 },
+    ],
+  };
+}
+
+/** A run record with a caller-chosen id, so ordering assertions can name it. */
+function run(id, over = {}) {
+  return makeRunRecord({
+    id, n: Number(id), at: 1000 + Number(id), label: 'VQ35DE',
+    result: fakeResult(over.result ?? {}),
+    scores: { tuning: { score: 80 }, engineer: { score: 70 } },
+    pullScore: 640,
+    inputs: { build: {}, tune: {}, loadKpa: 100 },
+  });
+}
+
+describe('makeRunRecord', () => {
+  it('keeps only rpm, hp and torque from each point', () => {
+    // Mutation caught: storing `result.points` whole. That is 50 fields per point
+    // against 3 — a 20x storage cost, which is the reason the record is slim at all.
+    const r = run('1');
+    expect(r.points).toEqual([
+      { rpm: 1500, hp: 100, torque: 200 },
+      { rpm: 1600, hp: 120, torque: 210 },
+      { rpm: 1700, hp: 140, torque: 220 },
+    ]);
+  });
+
+  it('counts knock events only, not every event', () => {
+    // Mutation caught: `result.events.length`. The fixture always carries one 'lean'
+    // event, so a total-count implementation reads 3 where the answer is 2.
+    expect(run('1', { result: { knocks: 2 } }).knocks).toBe(2);
+  });
+
+  it('reduces each score object to its number', () => {
+    // Mutation caught: storing the score OBJECTS, which carry `deductions` arrays and
+    // would roughly double the record.
+    expect(run('1').scores).toEqual({ tuning: 80, engineer: 70, pull: 640 });
+  });
+});
+
+describe('pushRun', () => {
+  it('puts the newest run at index 0', () => {
+    const runs = pushRun(pushRun([], run('1')), run('2'));
+    expect(runs.map((r) => r.id)).toEqual(['2', '1']);
+  });
+
+  it('evicts the OLDEST run, not the newest, at the cap', () => {
+    // Mutation caught: `.slice(-RUN_LIMIT)` or appending instead of prepending —
+    // either keeps the wrong end. Asserting `runs.length === RUN_LIMIT` alone would
+    // pass under both, which is exactly how a FIFO undo stack survived 871 tests.
+    let runs = [];
+    for (let i = 1; i <= RUN_LIMIT + 1; i += 1) runs = pushRun(runs, run(String(i)));
+    expect(runs).toHaveLength(RUN_LIMIT);
+    expect(runs[0].id).toBe(String(RUN_LIMIT + 1));
+    expect(runs[runs.length - 1].id).toBe('2');
+    expect(runs.some((r) => r.id === '1')).toBe(false);
+  });
+
+  it('does not mutate the array it is given', () => {
+    const before = [run('1')];
+    pushRun(before, run('2'));
+    expect(before.map((r) => r.id)).toEqual(['1']);
+  });
+});
+
+describe('ghostRun', () => {
+  const runs = [run('3'), run('2'), run('1')];
+
+  it('returns the pinned run when one is pinned', () => {
+    // Half one of the pair.
+    expect(ghostRun(runs, '1')?.id).toBe('1');
+  });
+
+  it('falls back to the previous run when nothing is pinned', () => {
+    // Half two. Index 1, not 0: index 0 is the pull just banked, which IS the current
+    // result — a ghost of it would draw the live curve twice.
+    expect(ghostRun(runs, null)?.id).toBe('2');
+  });
+
+  it('falls back to the previous run when the pinned run has been evicted', () => {
+    // Mutation caught: `runs.find(...)` returned straight through, which is
+    // `undefined` for an evicted pin and crashes at the first `.points` read.
+    expect(ghostRun(runs, 'gone')?.id).toBe('2');
+  });
+
+  it('returns null when there is no previous run', () => {
+    expect(ghostRun([run('1')], null)).toBe(null);
+    expect(ghostRun([], null)).toBe(null);
+  });
+});
+
+describe('ghostLabel', () => {
+  const runs = [run('3'), run('2'), run('1')];
+
+  it('names the run when it is the pinned one', () => {
+    expect(ghostLabel(ghostRun(runs, '1'), '1')).toBe('Run 1');
+  });
+
+  it('says "Prev" when nothing is pinned', () => {
+    // The other half. A label expression that always produced `Run ${n}` would pass a
+    // test that only checked the pinned case, and the chart would then claim every
+    // default comparison was a deliberate pin.
+    expect(ghostLabel(ghostRun(runs, null), null)).toBe('Prev');
+  });
+
+  it('says "Prev" when the pin points at an evicted run', () => {
+    // The pin is gone, so the ghost is the previous run and must be labelled as one.
+    expect(ghostLabel(ghostRun(runs, 'gone'), 'gone')).toBe('Prev');
+  });
+
+  it('returns null when there is no ghost to label', () => {
+    expect(ghostLabel(null, null)).toBe(null);
+  });
+});
+
+describe('sparklinePath', () => {
+  it('spans the full width and height of the box', () => {
+    const path = sparklinePath(
+      [{ rpm: 1500, hp: 0, torque: 0 }, { rpm: 1600, hp: 50, torque: 0 }, { rpm: 1700, hp: 100, torque: 0 }],
+      100, 20,
+    );
+    // Lowest hp sits on the bottom edge, highest on the top edge, first x at 0 and
+    // last x at the full width.
+    expect(path).toBe('M0.00,20.00 L50.00,10.00 L100.00,0.00');
+  });
+
+  it('draws a flat line rather than dividing by zero when every point is equal', () => {
+    // Mutation caught: `(hp - min) / (max - min)` with no guard is 0/0 = NaN, which
+    // renders nothing and logs no error.
+    const path = sparklinePath(
+      [{ rpm: 1500, hp: 42, torque: 0 }, { rpm: 1600, hp: 42, torque: 0 }],
+      100, 20,
+    );
+    expect(path).not.toMatch(/NaN/);
+    expect(path).toBe('M0.00,20.00 L100.00,20.00');
+  });
+
+  it('returns an empty string for no points', () => {
+    expect(sparklinePath([], 100, 20)).toBe('');
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+```bash
+./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/state/runLog.test.js
+```
+
+Expected: FAIL — `Failed to resolve import "../../../src/ui/state/runLog.js"`.
+
+- [ ] **Step 3: Write the module**
+
+Create `src/ui/state/runLog.js`:
+
+```js
+/**
+ * The dyno run log: what one banked pull keeps, and the operations over a list of them.
+ *
+ * WHY A SLIM RECORD
+ * A full `simulateSweep` result is 46,459 bytes of JSON — 61 points of 50 fields each.
+ * The three things a timeline row and a ghost curve actually need are 2,258 bytes. At
+ * twenty runs that is the difference between ~1 MB of localStorage and ~80 KB, so the
+ * record stores the projection and not the result.
+ *
+ * WHY `knocks` IS A STORED COUNT AND NOT A DERIVED ONE
+ * The delta panel on DYNO compares knock counts between the current pull and the one
+ * before it. A slim record has no `events` array to count, so the count is taken once,
+ * at bank time, from the result that still has one.
+ *
+ * NAMING: this is `runs`, never "history". `state.history` is the undo stack.
+ *
+ * This module imports nothing from `reducer.js`, the same discipline `history.js`
+ * keeps and for the same reason: the reducer imports this.
+ */
+
+/**
+ * How many runs the log keeps. Twenty at ~4 KB each is ~80 KB, comfortably inside a
+ * ~5 MB localStorage budget while leaving room for a career's other state.
+ */
+export const RUN_LIMIT = 20;
+
+/**
+ * @typedef {object} RunPoint
+ * @property {number} rpm
+ * @property {number} hp
+ * @property {number} torque
+ */
+
+/**
+ * @typedef {object} RunRecord
+ * @property {string} id unique and stable for the life of the record. A pin holds an
+ *   id rather than an index precisely so that evicting OTHER runs cannot silently
+ *   repoint it at a run the player never chose.
+ * @property {number} n the career pull ordinal, for display ("Run 12").
+ * @property {number} at epoch ms, for the row's relative timestamp.
+ * @property {string} label the engine's name at the time of the pull.
+ * @property {number} peakHp
+ * @property {number} peakTq
+ * @property {number} knocks how many `type: 'knock'` events the pull logged.
+ * @property {{tuning: number, engineer: number, pull: number}} scores
+ * @property {RunPoint[]} points
+ * @property {{build: object, tune: object, loadKpa: number}} inputs the measured
+ *   configuration, as `measuredInputs` in pullSignature.js projects it.
+ */
+
+/**
+ * Builds a record from a completed pull.
+ *
+ * `id`, `n` and `at` are the CALLER's to supply. The reducer that consumes this is
+ * documented as calling no `Date.now()` — it must stay a pure function of
+ * `(state, action)` — so the clock is read at the dispatch site and travels on the
+ * action, the same "caller computes, reducer applies" split `RESET_TO_STOCK`'s `ve`
+ * and `BANK_PULL`'s `pullScore` already use.
+ *
+ * @param {object} args
+ * @param {string} args.id
+ * @param {number} args.n
+ * @param {number} args.at
+ * @param {string} args.label
+ * @param {{peakHp: number, peakTq: number, points: object[], events: {type?: string}[]}} args.result
+ * @param {{tuning: {score: number}, engineer: {score: number}}} args.scores
+ * @param {number} args.pullScore
+ * @param {{build: object, tune: object, loadKpa: number}} args.inputs
+ * @returns {RunRecord}
+ */
+export function makeRunRecord({ id, n, at, label, result, scores, pullScore, inputs }) {
+  return {
+    id,
+    n,
+    at,
+    label,
+    peakHp: result.peakHp,
+    peakTq: result.peakTq,
+    knocks: result.events.filter((e) => e.type === 'knock').length,
+    scores: { tuning: scores.tuning.score, engineer: scores.engineer.score, pull: pullScore },
+    points: result.points.map((p) => ({ rpm: p.rpm, hp: p.hp, torque: p.torque })),
+    inputs,
+  };
+}
+
+/**
+ * Adds a run to the front of the log, capped at {@link RUN_LIMIT}.
+ *
+ * Newest-first, so the run just banked is index 0 and eviction drops the TAIL — the
+ * oldest run. Returns a new array; the input is never mutated.
+ *
+ * @param {RunRecord[]} runs
+ * @param {RunRecord} record
+ * @returns {RunRecord[]}
+ */
+export function pushRun(runs, record) {
+  return [record, ...runs].slice(0, RUN_LIMIT);
+}
+
+/**
+ * The run the ghost curve should draw.
+ *
+ * A pin wins when the run it names is still in the log. When it is not — the pinned
+ * run has aged out past {@link RUN_LIMIT} — this falls back to the previous run rather
+ * than returning nothing, because a pin quietly expiring should not also take the
+ * default comparison with it.
+ *
+ * `runs[1]`, not `runs[0]`: index 0 is the pull just banked, which is the same pull
+ * the chart is drawing live.
+ *
+ * Pinning `runs[0]` is legitimate and deliberately not special-cased — "make this my
+ * benchmark, now go tune" is the main reason to pin at all, and from the next pull
+ * onward that run is no longer index 0.
+ *
+ * @param {RunRecord[]} runs
+ * @param {string|null} pinnedRunId
+ * @returns {RunRecord|null}
+ */
+export function ghostRun(runs, pinnedRunId) {
+  if (pinnedRunId != null) {
+    const pinned = runs.find((r) => r.id === pinnedRunId);
+    if (pinned) return pinned;
+  }
+  return runs[1] ?? null;
+}
+
+/**
+ * What the chart legend calls the ghost series.
+ *
+ * This lives here rather than as an expression at the JSX call site so that both of
+ * its branches can be watched failing. It has two: a pinned run is named, and anything
+ * else is "Prev". The distinction is load-bearing — a chart that labelled the default
+ * comparison as a pin would tell the player they had chosen a benchmark they had not.
+ *
+ * Takes the already-resolved run rather than the list, so it cannot disagree with
+ * {@link ghostRun} about which run is being drawn: when the pin names an evicted run,
+ * `ghostRun` falls back to the previous run and this labels it "Prev", because that is
+ * what it now is.
+ *
+ * @param {RunRecord|null} run the run {@link ghostRun} resolved
+ * @param {string|null} pinnedRunId
+ * @returns {string|null} null when there is no ghost to draw
+ */
+export function ghostLabel(run, pinnedRunId) {
+  if (!run) return null;
+  return pinnedRunId != null && run.id === pinnedRunId ? `Run ${run.n}` : 'Prev';
+}
+
+/**
+ * SVG path data for a timeline row's power sparkline, scaled to fill the box.
+ *
+ * Pure and DOM-free so the geometry is unit-testable. A flat curve has no range to
+ * scale against, so the span floors at 1 and the line renders along the bottom edge
+ * rather than as `NaN`, which would draw nothing and report nothing.
+ *
+ * @param {RunPoint[]} points
+ * @param {number} width
+ * @param {number} height
+ * @returns {string} path data, or '' when there is nothing to draw
+ */
+export function sparklinePath(points, width, height) {
+  if (!points || points.length === 0) return '';
+  const hps = points.map((p) => p.hp);
+  const min = Math.min(...hps);
+  const span = Math.max(...hps) - min || 1;
+  const stepX = points.length > 1 ? width / (points.length - 1) : 0;
+  return points
+    .map((p, i) => {
+      const x = i * stepX;
+      const y = height - ((p.hp - min) / span) * height;
+      return `${i === 0 ? 'M' : 'L'}${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(' ');
+}
+```
+
+- [ ] **Step 4: Run the tests and watch them pass**
+
+```bash
+./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/state/runLog.test.js
+```
+
+Expected: PASS, 16 tests.
+
+- [ ] **Step 5: Prove the eviction and label tests actually hold**
+
+Run each mutation, confirm the named test fails, then revert it before the next:
+
+1. `pushRun` returns `[record, ...runs].slice(-RUN_LIMIT)` → "evicts the OLDEST run" FAILS.
+2. `ghostLabel` returns `` `Run ${run.n}` `` unconditionally → "says \"Prev\" when nothing is pinned" FAILS.
+3. `ghostRun` returns `runs[0] ?? null` instead of `runs[1] ?? null` → "falls back to the previous run when nothing is pinned" FAILS.
+
+This is not optional. Seven of PR 4a's task suites passed against a broken implementation; a test that cannot be watched failing is not evidence.
+
+- [ ] **Step 6: Run the full gate**
+
+```bash
+npm test && npm run lint && npm run typecheck && npm run build
+```
+
+Expected: all green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/ui/state/runLog.js tests/ui/state/runLog.test.js
+git commit -m "Add the run log's record shape and its pure operations"
+```
+
+---
+
+## Task 2: `diffMeasuredInputs` — widen `pullSignature.js`'s charter
+
+**Files:**
+- Modify: `src/ui/state/pullSignature.js`
+- Test: `tests/ui/state/pullSignature.test.js`
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces:
+  - `measuredInputs(build, tune, loadKpa) => {build: object, tune: object, loadKpa: number}`
+  - `diffMeasuredInputs(a, b) => string[]` — display labels for every differing input, `[]` when identical.
+  - `pullSignature` is unchanged in behaviour and signature.
+
+**Context the brief cannot know:** this file's header currently states, at length, that it answers "has any measured input moved?" and **never** "which one", and gives a reason — a hand-written field-by-field comparison drifts out of sync with the signature. This task deliberately widens that charter. The header must be rewritten to say so. Do not bolt the new function on under a header that still claims the old contract. The key arrays stay **private**: exporting them would let a test derive its expectations from the thing under test, which is the trap `history.js` documents avoiding.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/ui/state/pullSignature.test.js`:
+
+```js
+describe('measuredInputs', () => {
+  it('keeps the measured build fields and drops the label-only ones', () => {
+    const s = makeInitialState();
+    const projected = measuredInputs(
+      { ...s.build, presetId: 'n54', presetPrompt: { open: true }, boostSel: 2 },
+      s.tune,
+      100,
+    );
+    expect(projected.build).toHaveProperty('engineConfig');
+    expect(projected.build).toHaveProperty('boostCurve');
+    // Mutation caught: projecting the whole slice. presetId/presetPrompt/boostSel
+    // reach no simulation, and storing them would make two runs on the same car
+    // diff as different because a dialog was open during one of them.
+    expect(projected.build).not.toHaveProperty('presetId');
+    expect(projected.build).not.toHaveProperty('presetPrompt');
+    expect(projected.build).not.toHaveProperty('boostSel');
+  });
+
+  it('keeps the three tables and drops the tune slice cursors', () => {
+    const s = makeInitialState();
+    const projected = measuredInputs(s.build, { ...s.tune, selection: { r: 1, c: 1 }, tablesDirty: true }, 100);
+    expect(Object.keys(projected.tune).sort()).toEqual(['afr', 'timing', 've']);
+  });
+
+  it('carries loadKpa', () => {
+    const s = makeInitialState();
+    expect(measuredInputs(s.build, s.tune, 140).loadKpa).toBe(140);
+  });
+});
+
+describe('diffMeasuredInputs', () => {
+  /** @returns {ReturnType<typeof measuredInputs>} */
+  const project = (patch = {}) => {
+    const s = makeInitialState();
+    return measuredInputs(
+      { ...s.build, ...(patch.build ?? {}) },
+      { ...s.tune, ...(patch.tune ?? {}) },
+      patch.loadKpa ?? 100,
+    );
+  };
+
+  it('reports nothing for two identical configurations', () => {
+    // Mutation caught: returning every label unconditionally.
+    expect(diffMeasuredInputs(project(), project())).toEqual([]);
+  });
+
+  it('names the one field that moved and nothing else', () => {
+    // Both halves in one assertion: 'boost curve' present AND every other label
+    // absent. Asserting only `toContain('boost curve')` would pass against an
+    // implementation that returns all sixteen labels every time.
+    expect(diffMeasuredInputs(project(), project({ build: { boostCurve: [1, 2, 3, 4, 5, 6, 7, 8] } })))
+      .toEqual(['boost curve']);
+  });
+
+  it('sees a change inside a calibration table', () => {
+    // Mutation caught: comparing tables by reference (`a !== b`) reports a change on
+    // every call because clone2D makes a fresh array; comparing with `===` on the
+    // outer array misses a changed CELL entirely. Only a value compare gets both.
+    const s = makeInitialState();
+    const edited = clone2D(s.tune.ve);
+    edited[0][0] += 5;
+    expect(diffMeasuredInputs(project(), project({ tune: { ve: edited } }))).toEqual(['VE table']);
+  });
+
+  it('reports a table as unchanged when an equal copy is passed', () => {
+    // The other half of the reference-compare pair.
+    const s = makeInitialState();
+    expect(diffMeasuredInputs(project(), project({ tune: { ve: clone2D(s.tune.ve) } }))).toEqual([]);
+  });
+
+  it('names several fields when several moved', () => {
+    expect(diffMeasuredInputs(project(), project({ build: { turboOn: true, octaneIdx: 3 }, loadKpa: 140 })))
+      .toEqual(['turbo', 'fuel', 'dyno load']);
+  });
+
+  it('reports the same fields the signature reports as a change', () => {
+    // The two functions must never disagree about WHETHER anything moved. This is the
+    // property that justifies them living in one file over one private key list.
+    const s = makeInitialState();
+    const other = { ...s.build, mafScalar: 1.15 };
+    expect(pullSignature(s.build, s.tune, 100)).not.toBe(pullSignature(other, s.tune, 100));
+    expect(diffMeasuredInputs(measuredInputs(s.build, s.tune, 100), measuredInputs(other, s.tune, 100)))
+      .not.toEqual([]);
+  });
+});
+```
+
+Update the import at the top of the file:
+
+```js
+import { diffMeasuredInputs, measuredInputs, pullSignature } from '../../../src/ui/state/pullSignature.js';
+```
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+```bash
+./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/state/pullSignature.test.js
+```
+
+Expected: FAIL — `measuredInputs is not a function`.
+
+- [ ] **Step 3: Rewrite the file header**
+
+Replace the first paragraph of `src/ui/state/pullSignature.js`'s header (the block starting `The identity of the configuration a dyno pull was measured on.`) with:
+
+```js
+/**
+ * The identity of a dyno pull's configuration, and the difference between two of them.
+ *
+ * A score is a MEASUREMENT. It is taken once, on one specific car, and it stays what
+ * it was — so the app banks the scores a pull produced (see BANK_PULL) instead of
+ * recomputing them from whatever is selected later. That leaves one question the
+ * banked numbers cannot answer by themselves: is the car on screen still the car they
+ * were measured on? {@link pullSignature} answers exactly that.
+ *
+ * WHY THIS FILE NOW ANSWERS "WHICH ONE" TOO
+ * This header used to state that the module answers "has any measured input moved?"
+ * and never "which one", on the grounds that a hand-written field-by-field comparison
+ * would drift out of sync with the signature as fields were added. That reasoning was
+ * right about the hazard and wrong about the conclusion. The run-history timeline needs
+ * "which one" — it reports what changed between one pull and the one before it — and
+ * the drift is avoided by keeping BOTH answers here, over ONE private key list, rather
+ * than by refusing to answer. Add a field to MEASURED_BUILD_KEYS and it is signed and
+ * diffed in the same edit. The alternative that was rejected — exporting the key arrays
+ * so another module could diff — would have let a test derive its expectations from the
+ * thing under test, which is the trap `history.js` keeps its own key lists private to
+ * avoid.
+ */
+```
+
+Keep the rest of the existing header (WHAT COUNTS AS "THE SAME CAR", WHAT DOES NOT COUNT, WHY A SIGNATURE AND NOT A DEEP COMPARE, THE ERROR IT IS ALLOWED TO MAKE, and the `history.js` cross-reference) exactly as it is. Those paragraphs are all still true.
+
+- [ ] **Step 4: Add the label table and the two functions**
+
+Add below `MEASURED_TUNE_KEYS`:
+
+```js
+/**
+ * Display names for every measured input, for the run-history timeline's "what
+ * changed" line. A key with no label throws rather than rendering a blank row — the
+ * same call `labelFor` makes in reducer.js, and for the same reason: a silently
+ * missing label is a field the player is never told about.
+ */
+const INPUT_LABELS = {
+  engineConfig: 'engine',
+  mods: 'bolt-ons',
+  turboOn: 'turbo',
+  boostCurve: 'boost curve',
+  octaneIdx: 'fuel',
+  injIdx: 'injectors',
+  mafScalar: 'MAF scaling',
+  turbineIdx: 'turbine',
+  turbineCount: 'turbine count',
+  compressorIdx: 'compressor',
+  exhaustDiaIdx: 'exhaust',
+  ecuInjectorCc: 'ECU injector size',
+  ve: 'VE table',
+  timing: 'timing table',
+  afr: 'AFR table',
+  loadKpa: 'dyno load',
+};
+```
+
+Add at the end of the file:
+
+```js
+/**
+ * Projects a configuration down to exactly the inputs a pull is a function of.
+ *
+ * This is the form a {@link import('./runLog.js').RunRecord} stores, so that two runs
+ * can be compared later without keeping the whole build and tune slices — and without
+ * a second list of "what matters" that could disagree with this one.
+ *
+ * @param {import('./initialState.js').BuildState} build
+ * @param {import('./initialState.js').TuneState} tune
+ * @param {number} loadKpa
+ * @returns {{build: object, tune: object, loadKpa: number}}
+ */
+export function measuredInputs(build, tune, loadKpa) {
+  /** @type {Record<string, *>} */
+  const b = {};
+  for (const k of MEASURED_BUILD_KEYS) b[k] = /** @type {any} */ (build)[k];
+  /** @type {Record<string, *>} */
+  const t = {};
+  for (const k of MEASURED_TUNE_KEYS) t[k] = /** @type {any} */ (tune)[k];
+  return { build: b, tune: t, loadKpa };
+}
+
+/**
+ * Names every measured input that differs between two projections.
+ *
+ * Values are compared by their JSON, not by reference: the calibration tables are
+ * cloned on almost every write, so a reference compare would report all three as
+ * changed on every pull, and an `===` on the outer array would miss a changed cell
+ * entirely. This inherits {@link pullSignature}'s documented and acceptable error in
+ * the same direction — two equal objects whose keys were inserted in different orders
+ * compare as different — and, like the signature, it can never report a real change as
+ * no change.
+ *
+ * @param {ReturnType<typeof measuredInputs>} a
+ * @param {ReturnType<typeof measuredInputs>} b
+ * @returns {string[]} display labels, empty when every measured input is equal
+ */
+export function diffMeasuredInputs(a, b) {
+  const changed = [];
+  for (const k of MEASURED_BUILD_KEYS) {
+    if (JSON.stringify(a.build?.[k]) !== JSON.stringify(b.build?.[k])) changed.push(k);
+  }
+  for (const k of MEASURED_TUNE_KEYS) {
+    if (JSON.stringify(a.tune?.[k]) !== JSON.stringify(b.tune?.[k])) changed.push(k);
+  }
+  if (a.loadKpa !== b.loadKpa) changed.push('loadKpa');
+  return changed.map((k) => {
+    const label = INPUT_LABELS[k];
+    if (!label) throw new Error(`diffMeasuredInputs: no label defined for measured input "${k}"`);
+    return label;
+  });
+}
+```
+
+- [ ] **Step 5: Run the tests and watch them pass**
+
+```bash
+./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/state/pullSignature.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Prove the both-sides test holds**
+
+Temporarily make `diffMeasuredInputs` return every label unconditionally:
+
+```js
+return Object.values(INPUT_LABELS);
+```
+
+Re-run. Expected: "reports nothing for two identical configurations" and "names the one field that moved and nothing else" both FAIL. Revert.
+
+Then temporarily change the tune comparison to a reference compare (`a.tune?.[k] !== b.tune?.[k]`) and re-run. Expected: "reports a table as unchanged when an equal copy is passed" FAILS. Revert.
+
+- [ ] **Step 7: Full gate and commit**
+
+```bash
+npm test && npm run lint && npm run typecheck && npm run build
+git add src/ui/state/pullSignature.js tests/ui/state/pullSignature.test.js
+git commit -m "Teach pullSignature which input moved, not just that one did"
+```
+
+---
+
+## Task 3: Store the runs — SESSION slice, `BANK_PULL`, pinning
+
+**Files:**
+- Modify: `src/ui/state/initialState.js`, `src/ui/state/reducer.js`
+- Test: `tests/ui/state/reducer.test.js`
+
+**Interfaces:**
+- Consumes: `pushRun`, `RunRecord` from `src/ui/state/runLog.js` (Task 1).
+- Produces:
+  - `session.runs: RunRecord[]`, `session.pinnedRunId: string|null`
+  - `BANK_PULL` gains a required `run: RunRecord` field
+  - `ACTIONS.PIN_RUN` (`{type, id}`) and `ACTIONS.UNPIN_RUN` (`{type}`)
+
+**This task is additive.** `prevResult` stays exactly as it is; Task 4 removes it. Keeping the two apart is deliberate: "does the store record runs correctly" and "do the readers correctly switch over" are separately rejectable, and splitting them keeps Task 4's diff purely the migration.
+
+**A trap this codebase has already fallen into once:** `KnownStoreAction` is a union with no catch-all member, and its doc comment says "the seventeen specific typedefs above". In PR 4a the union was missed when two actions were added, and `tsc` only surfaced it much later, at the first typed dispatch site. Add both typedefs, add both to the union, **and** update that sentence to "nineteen".
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/ui/state/reducer.test.js`:
+
+```js
+describe('run log', () => {
+  /** @returns {import('../../../src/ui/state/runLog.js').RunRecord} */
+  const rec = (id) => ({
+    id, n: Number(id), at: 1000 + Number(id), label: 'VQ35DE',
+    peakHp: 300, peakTq: 280, knocks: 0,
+    scores: { tuning: 80, engineer: 70, pull: 640 },
+    points: [{ rpm: 1500, hp: 100, torque: 200 }],
+    inputs: { build: {}, tune: {}, loadKpa: 100 },
+  });
+
+  /** BANK_PULL's minimum viable payload. */
+  const bank = (id) => ({
+    type: ACTIONS.BANK_PULL,
+    run: rec(id),
+    result: { peakHp: 300, peakTq: 280, points: [], events: [], wear: { piston: 1, bearing: 1, valve: 1 } },
+    pullScore: 640,
+    scores: { tuning: { score: 80 }, engineer: { score: 70 }, signature: 'sig' },
+  });
+
+  it('records the banked run at the front of the log', () => {
+    const s = reducer(reducer(makeInitialState(), bank('1')), bank('2'));
+    expect(s.session.runs.map((r) => r.id)).toEqual(['2', '1']);
+  });
+
+  it('starts with an empty log and no pin', () => {
+    const s = makeInitialState();
+    expect(s.session.runs).toEqual([]);
+    expect(s.session.pinnedRunId).toBe(null);
+  });
+
+  it('pins and unpins a run', () => {
+    const pinned = reducer(makeInitialState(), { type: ACTIONS.PIN_RUN, id: '7' });
+    expect(pinned.session.pinnedRunId).toBe('7');
+    expect(reducer(pinned, { type: ACTIONS.UNPIN_RUN }).session.pinnedRunId).toBe(null);
+  });
+
+  it('leaves the run log and the pin standing when a preset is loaded', () => {
+    // BOTH halves of the pair. Asserting only that the scorecard clears would pass
+    // against an APPLY_PRESET that also wipes twenty runs of persisted history —
+    // which undo does not cover and the player cannot get back.
+    const withRun = reducer(reducer(makeInitialState(), bank('1')), { type: ACTIONS.PIN_RUN, id: '1' });
+    const after = reducer(withRun, { type: ACTIONS.APPLY_PRESET, preset: PRESET_PATCH });
+    expect(after.session.result).toBe(null);
+    expect(after.session.pullScores).toBe(null);
+    expect(after.session.runs.map((r) => r.id)).toEqual(['1']);
+    expect(after.session.pinnedRunId).toBe('1');
+  });
+
+  it('leaves the whole session slice alone on RESET_TO_STOCK', () => {
+    // Pins today's behaviour so the natural-but-wrong pairing with APPLY_PRESET
+    // cannot be introduced by someone "making them consistent". RESET_TO_STOCK has
+    // never touched session, including result and pullScores.
+    const withRun = reducer(makeInitialState(), bank('1'));
+    const after = reducer(withRun, { type: ACTIONS.RESET_TO_STOCK, ve: withRun.tune.ve });
+    expect(after.session).toBe(withRun.session);
+  });
+});
+```
+
+`PRESET_PATCH` already exists in this file if a preset test is present; if not, add it above the `describe`:
+
+```js
+/** A minimal APPLY_PRESET payload — every field the case reads. */
+const PRESET_PATCH = {
+  presetId: 'test', engineConfig: makeInitialState().build.engineConfig,
+  mods: makeInitialState().build.mods, turboOn: false, boostCurve: [0, 0, 0, 0, 0, 0, 0, 0],
+  turbineIdx: 1, turbineCount: 1, compressorIdx: 1, injIdx: 0, ecuInjectorCc: 315,
+  octaneIdx: 0, exhaustDiaIdx: 0,
+  ve: makeInitialState().tune.ve, timing: makeInitialState().tune.timing, afr: makeInitialState().tune.afr,
+};
+```
+
+- [ ] **Step 2: Run the tests and watch them fail**
+
+```bash
+./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/state/reducer.test.js
+```
+
+Expected: FAIL — `runs` is `undefined`, and `PIN_RUN` is not a known action.
+
+- [ ] **Step 3: Add the state**
+
+In `src/ui/state/initialState.js`, add to the `SessionState` typedef, immediately after the `prevResult` line:
+
+```js
+ * @property {import('./runLog.js').RunRecord[]} runs the last RUN_LIMIT dyno pulls,
+ *   newest first. Named `runs` and not "history" because `state.history` is the undo
+ *   stack — see HistoryState below.
+ * @property {string|null} pinnedRunId the run the ghost curve compares against, or
+ *   null to compare against the previous run
+```
+
+And in `makeInitialState`'s `session` object, immediately after `prevResult: null,`:
+
+```js
+      runs: [],
+      pinnedRunId: null,
+```
+
+- [ ] **Step 4: Add the actions**
+
+In `src/ui/state/reducer.js`, add to `ACTIONS` after `BANK_PULL`:
+
+```js
+  PIN_RUN: 'PIN_RUN',
+  UNPIN_RUN: 'UNPIN_RUN',
+```
+
+Add the import at the top, beside the existing `history.js` import:
+
+```js
+import { pushRun } from './runLog.js';
+```
+
+Add these two typedefs immediately before `LiveStepAction`'s:
+
+```js
+/**
+ * Pins one banked run as the ghost curve's comparison. Holds the run's `id` rather
+ * than its index: eviction shifts every index, so an index-based pin would silently
+ * repoint at a run the player never chose.
+ * @typedef {{type: 'PIN_RUN', id: string}} PinRunAction
+ */
+
+/**
+ * Drops the pin, returning the ghost to the previous run. No payload — there is only
+ * ever one pin.
+ * @typedef {{type: 'UNPIN_RUN'}} UnpinRunAction
+ */
+```
+
+Add both to the `KnownStoreAction` union, and change `the seventeen specific typedefs above` to `the nineteen specific typedefs above`:
+
+```js
+ * @typedef {SetBuildFieldAction | ClearPresetIdAction | SetTurbineAction | SetTableAction |
+ *   SetSessionFieldAction | SetTuneFieldAction | SetBoostSelAction |
+ *   SetPresetPromptAction | SetEngineConfigPatchAction | ApplyPresetAction |
+ *   ResetToStockAction | RepairEngineAction | BankPullAction | PinRunAction |
+ *   UnpinRunAction | LiveStepAction | LivePatchAction | UndoAction | RedoAction
+ * } KnownStoreAction
+ */
+```
+
+Extend `BankPullAction`'s typedef payload:
+
+```js
+ * @typedef {{type: 'BANK_PULL', result: object, pullScore: number, run: import('./runLog.js').RunRecord,
+ *   scores: {tuning: object, engineer: object, signature: string}}} BankPullAction
+```
+
+- [ ] **Step 5: Write the cases**
+
+In `BANK_PULL`'s returned `session` object, add immediately after the `prevResult` line:
+
+```js
+          // The record is built by the caller, not here: it needs `Date.now()` for its
+          // id and timestamp, and this reducer is documented as calling no clock.
+          runs: pushRun(state.session.runs, action.run),
+```
+
+Add the two new cases immediately after `BANK_PULL`:
+
+```js
+    case ACTIONS.PIN_RUN:
+      return { ...state, session: { ...state.session, pinnedRunId: action.id } };
+
+    case ACTIONS.UNPIN_RUN:
+      return { ...state, session: { ...state.session, pinnedRunId: null } };
+```
+
+`APPLY_PRESET` needs no change to keep `runs` and `pinnedRunId` — its `...state.session` spread already carries them. The test in Step 1 is what pins that, so a future edit cannot quietly add them to the clear list.
+
+- [ ] **Step 6: Run the tests and watch them pass**
+
+```bash
+./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/state/reducer.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Prove the APPLY_PRESET test holds**
+
+Temporarily add `runs: [], pinnedRunId: null,` to `APPLY_PRESET`'s session clear and re-run. Expected: "leaves the run log and the pin standing when a preset is loaded" FAILS. Revert.
+
+- [ ] **Step 8: Full gate and commit**
+
+```bash
+npm test && npm run lint && npm run typecheck && npm run build
+git add src/ui/state/initialState.js src/ui/state/reducer.js tests/ui/state/reducer.test.js
+git commit -m "Record every banked pull in the session's run log, and let one be pinned"
+```
+
+---
+
+## Task 4: Migrate the ghost's readers and delete `prevResult`
+
+**Files:**
+- Modify: `src/ui/EcuLab.jsx`, `src/ui/screens/dyno/ResultScreen.jsx`, `src/ui/state/initialState.js`, `src/ui/state/reducer.js`
+- Test: `tests/ui/dyno-screens.test.jsx`
+
+**Interfaces:**
+- Consumes: `ghostRun`, `ghostLabel`, `makeRunRecord` from `runLog.js`; `measuredInputs` from `pullSignature.js`; `session.runs`/`session.pinnedRunId` from Task 3.
+- Produces: `ResultScreen` takes a new prop `ghostLabel: string|null` and no longer reads the store. `session.prevResult` no longer exists.
+
+**Every reader of `prevResult`, so none is missed:**
+
+| Site | Change |
+|---|---|
+| `EcuLab.jsx:220` | destructuring — swap `prevResult` for `runs, pinnedRunId` |
+| `EcuLab.jsx:700` | `chartData`'s ghost columns — join by RPM through a Map |
+| `EcuLab.jsx:994-998` | the delta panel — read `runs[1]`, use its stored `knocks` |
+| `ResultScreen.jsx:37, 55-56` | takes `ghostLabel`; drops `useSession` |
+| `initialState.js:96, 181` | typedef line and initial value |
+| `reducer.js` `APPLY_PRESET` | drop the `prevResult: null` line |
+| `reducer.js` `BANK_PULL` | drop the `prevResult: state.session.result` line and its comment |
+
+`tsc --noEmit` is the backstop: `EcuLab.jsx` no longer carries `@ts-nocheck` (see its header, line 18), so a missed reader of a removed typedef field is a typecheck failure, not a runtime surprise.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/ui/dyno-screens.test.jsx`:
+
+This file already has the harness: `mount(node)` renders a screen inside a real
+`StoreProvider`, and `mountWithResult(node, sessionFields)` seeds session state first.
+Use them. Do **not** add a second harness, and do **not** write one whose "before"
+value is read after the action — two of this project's ten unfailable assertions were
+introduced exactly that way, in briefs written for PR 4a.
+
+The ghost's *source* (pinned vs previous) and its *label* are both pure and already
+unit-tested in Task 1 via `ghostRun` and `ghostLabel`. What is untested until now is
+whether `ResultScreen` actually draws the ghost series, so that is what these tests
+hold — both halves of the present/absent pair:
+
+```js
+describe('ResultScreen ghost curve', () => {
+  const CHART = [{ rpm: 1500, hp: 111, torque: 222, prevHp: 100, prevTorque: 200 }];
+
+  it('draws both ghost series, named for the comparison, when there is one', () => {
+    mount(<ResultScreen chartData={CHART} engineDerived={{ redline: 7000 }} ghostLabel="Run 4" />);
+    expect(screen.getByText('Run 4 WHP')).toBeTruthy();
+    expect(screen.getByText('Run 4 TQ')).toBeTruthy();
+  });
+
+  it('draws no ghost series at all when there is no comparison', () => {
+    // The other half. Rendering the lines unconditionally would still look right on
+    // the first pull — recharts just draws nothing for an all-undefined dataKey — so
+    // the legend is what makes the difference observable.
+    mount(<ResultScreen chartData={[{ rpm: 1500, hp: 111, torque: 222 }]} engineDerived={{ redline: 7000 }} ghostLabel={null} />);
+    expect(screen.queryByText(/WHP$/)).toBeTruthy();
+    expect(screen.queryByText(/ WHP$/)).toBe(null);
+    expect(screen.queryByText(/ TQ$/)).toBe(null);
+  });
+});
+```
+
+Note the two existing `ResultScreen` tests in this file call `mount(<ResultScreen
+chartData={[]} engineDerived={...} />)` with no `ghostLabel`. Leave them as they are —
+an omitted prop is `undefined`, which is falsy, so they keep passing and incidentally
+pin that a missing ghost is the safe default.
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/dyno-screens.test.jsx
+```
+
+Expected: FAIL — `ResultScreen` does not accept a `ghostLabel` prop yet, so the legend
+never names a comparison.
+
+- [ ] **Step 3: Build the run record at the dispatch site**
+
+In `src/ui/EcuLab.jsx`, add the imports:
+
+```js
+import { ghostLabel, ghostRun, makeRunRecord } from './state/runLog.js';
+import { measuredInputs, pullSignature } from './state/pullSignature.js';
+```
+
+(`pullSignature` is already imported — extend that line rather than adding a second import from the same module.)
+
+In `doRun`, replace the `dispatch({ type: ACTIONS.BANK_PULL, ... })` call with:
+
+```js
+    const nextPulls = pullCount + 1;
+    const at = Date.now();
+    dispatch({
+      type: ACTIONS.BANK_PULL, result: r, pullScore: pull,
+      scores: { tuning: ts, engineer: es, signature: buildSignature },
+      // `id` pairs the clock with the career ordinal so two records can never collide,
+      // and `at`/`id` are read HERE because the reducer must call no clock of its own.
+      run: makeRunRecord({
+        id: `${at}-${nextPulls}`, n: nextPulls, at,
+        // `engineDerived` carries no name — it is displacement, cylinder count and
+        // redline. The build's name is the loaded preset's, and a build with no preset
+        // is exactly what "Custom build" means everywhere else in this app.
+        label: presetById(presetId)?.name ?? 'Custom build',
+        result: r, scores: { tuning: ts, engineer: es }, pullScore: pull,
+        inputs: measuredInputs(build, tune, loadKpa),
+      }),
+    });
+```
+
+`presetById` is already imported in this file (`EcuLab.jsx:36`) and `presetId` is
+already destructured from the build slice — neither needs adding. `presetById` is
+`ENGINE_PRESETS.find((p) => p.id === id)` (`src/sim/presets.js:552`), so a `null` id
+returns `undefined` rather than throwing; no guard is needed and the `?.` above is
+belt-and-braces, not a requirement.
+
+- [ ] **Step 4: Join the ghost by RPM**
+
+Replace `chartData` (`EcuLab.jsx:699-702`) with:
+
+```js
+  const ghost = ghostRun(runs, pinnedRunId);
+
+  const chartData = useMemo(() => {
+    if (!result) return [];
+    // Keyed by RPM, not by array position. Today the two are the same thing —
+    // SWEEP_START_RPM and SWEEP_STEP_RPM are constants, so points[i].rpm is always
+    // 1500 + 100i — but a PINNED run may be any length, and the join should state
+    // what it means rather than lean on an invariant two modules away.
+    const ghostByRpm = new Map((ghost?.points ?? []).map((p) => [p.rpm, p]));
+    return result.points.slice(0, running ? revealCount : result.points.length).map((p) => {
+      const g = ghostByRpm.get(p.rpm);
+      return {
+        rpm: p.rpm, hp: p.hp, torque: p.torque, afr: p.afr, afrCommanded: p.afrCommanded,
+        timing: p.timing, commandedTiming: p.commandedTiming, duty: p.duty, trimPct: p.trimPct,
+        prevHp: g?.hp, prevTorque: g?.torque,
+      };
+    });
+  }, [result, ghost, running, revealCount]);
+```
+
+Update the destructure at `EcuLab.jsx:220`: remove `prevResult`, add `runs, pinnedRunId`.
+
+- [ ] **Step 5: Migrate the delta panel**
+
+Replace the `{prevResult && !running && (() => {` block's opening lines so it reads from the log:
+
+```js
+                {runs[1] && !running && (() => {
+                  const prev = runs[1];
+                  const dHp = result.peakHp - prev.peakHp;
+                  const dTq = result.peakTq - prev.peakTq;
+                  const knockNow = result.events.filter((e) => e.type === 'knock').length;
+                  const dKnock = knockNow - prev.knocks;
+```
+
+Delete the now-unused `knockPrev` line. The rest of the block is unchanged.
+
+- [ ] **Step 6: Pass the ghost label to `ResultScreen`**
+
+In `EcuLab.jsx`, at the `ResultScreen` call site:
+
+```js
+                  <ResultScreen
+                    chartData={chartData}
+                    engineDerived={engineDerived}
+                    ghostLabel={ghostLabel(ghost, pinnedRunId)}
+                  />
+```
+
+The label is `ghostLabel` from `runLog.js`, not an expression written inline here. Both
+of its branches are watched failing in Task 1; an inline ternary would be the one piece
+of this feature's logic that no test could reach.
+
+In `src/ui/screens/dyno/ResultScreen.jsx`: delete the `useSession` import and the two lines that read `prevResult`, add `ghostLabel` to the props and its JSDoc, and replace the two ghost `<Line>` elements:
+
+```jsx
+            {ghostLabel && <Line dataKey="prevHp" name={`${ghostLabel} WHP`} stroke={T.acc} strokeWidth={1.5} strokeDasharray="5 4" opacity={0.5} dot={false} isAnimationActive={false} />}
+            {ghostLabel && <Line dataKey="prevTorque" name={`${ghostLabel} TQ`} stroke={T.cyan} strokeWidth={1.5} strokeDasharray="5 4" opacity={0.5} dot={false} isAnimationActive={false} />}
+```
+
+Add to the file header, replacing nothing:
+
+```
+ * The ghost lines take each live series' own colour at half opacity rather than a
+ * neutral grey. `T.ink3` — what they used to use — is also the axis, tick-label and
+ * `afrCommanded` colour, so the previous pull was not too dim to see so much as
+ * indistinguishable from the chart's furniture. Hue now carries series identity and
+ * opacity carries time.
+```
+
+- [ ] **Step 7: Delete `prevResult`**
+
+- `initialState.js`: delete the `@property {object|null} prevResult` line and the `prevResult: null,` line.
+- `reducer.js` `APPLY_PRESET`: delete `prevResult: null,`.
+- `reducer.js` `BANK_PULL`: delete `prevResult: state.session.result,` and the two-line comment above it that explains the rotation ordering. Replace that comment with one on the `runs:` line:
+
+```js
+          // The banked run goes in front, so runs[0] is always the pull `result` now
+          // holds and runs[1] is the one before it — the ordering the old
+          // prevResult-before-result rotation existed to get right.
+```
+
+- [ ] **Step 8: Run the tests and the gate**
+
+```bash
+./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/dyno-screens.test.jsx
+npm test && npm run lint && npm run typecheck && npm run build
+```
+
+Expected: all green. If `tsc` names a `prevResult` reader not in the table above, that is a genuine find — fix it and add the site to the table.
+
+- [ ] **Step 9: Prove the ghost test holds**
+
+Temporarily render the two ghost `<Line>` elements unconditionally (drop the
+`ghostLabel &&` guard, hardcoding the names to `Prev WHP`/`Prev TQ`). Re-run
+`dyno-screens.test.jsx`. Expected: "draws no ghost series at all when there is no
+comparison" FAILS. Revert.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/ui/EcuLab.jsx src/ui/screens/dyno/ResultScreen.jsx src/ui/state/initialState.js src/ui/state/reducer.js tests/ui/dyno-screens.test.jsx
+git commit -m "Draw the ghost from the run log, and retire prevResult"
+```
+
+---
+
+## Task 5: Persist the run log
+
+**Files:**
+- Modify: `src/storage.js`, `src/ui/EcuLab.jsx`
+- Test: `tests/storage.test.js`, `tests/ui/session-store.test.jsx`
+
+**Interfaces:**
+- Consumes: `RUN_LIMIT` from `runLog.js`; `session.runs`/`session.pinnedRunId`.
+- Produces: `loadCareer()` resolves `{best, total, pulls, runs, pinnedRunId}`; `saveCareer` accepts the same shape.
+
+**Two things this task must get right:**
+
+1. **A legacy save has no `runs` key** and must load as `[]` / `null`, not `undefined` and not a throw. The existing per-field coercion (`Number(parsed.best) || 0`) is the pattern.
+2. **The persistence effect must not fire before the load completes.** `loadCareer` is async and dispatches its three values; an effect that saves on mount would write zeroes and an empty log over a real save before those dispatches land. A ref guard set after the load is what prevents it.
+
+`storage.js` stays UI-agnostic — it validates the shape (`Array.isArray`) but does not import `RUN_LIMIT`. The cap is applied by `pushRun` on write and by the load effect in `EcuLab.jsx` on read, where `RUN_LIMIT` is already in scope.
+
+- [ ] **Step 1: Write the failing storage tests**
+
+Append to `tests/storage.test.js`:
+
+```js
+describe('run log persistence', () => {
+  it('returns an empty log when nothing has been saved', async () => {
+    expect(await loadCareer()).toEqual({ best: 0, total: 0, pulls: 0, runs: [], pinnedRunId: null });
+  });
+
+  it('round-trips runs and the pin', async () => {
+    const runs = [{ id: '2', n: 2, at: 2, label: 'VQ', peakHp: 300, peakTq: 280, knocks: 0, scores: { tuning: 1, engineer: 2, pull: 3 }, points: [], inputs: {} }];
+    await saveCareer({ best: 1, total: 2, pulls: 3, runs, pinnedRunId: '2' });
+    const loaded = await loadCareer();
+    expect(loaded.runs).toEqual(runs);
+    expect(loaded.pinnedRunId).toBe('2');
+  });
+
+  it('loads a save written before run history existed', async () => {
+    // The blob every existing player has. It must open, not throw and not yield
+    // `undefined` for a field the UI will immediately call .find() on.
+    await saveCareer({ best: 812, total: 4310, pulls: 27 });
+    const loaded = await loadCareer();
+    expect(loaded.best).toBe(812);
+    expect(loaded.runs).toEqual([]);
+    expect(loaded.pinnedRunId).toBe(null);
+  });
+
+  it('rejects a non-array runs value rather than trusting it', async () => {
+    await saveCareer({ best: 1, total: 1, pulls: 1, runs: /** @type {any} */ ('not an array') });
+    expect((await loadCareer()).runs).toEqual([]);
+  });
+
+  it('rejects a non-string pin rather than trusting it', async () => {
+    await saveCareer({ best: 1, total: 1, pulls: 1, pinnedRunId: /** @type {any} */ (17) });
+    expect((await loadCareer()).pinnedRunId).toBe(null);
+  });
+});
+```
+
+The four existing `toEqual({ best, total, pulls })` assertions in this file will now fail, because the returned object has two more keys. Update each to include `runs: []` and `pinnedRunId: null` — do **not** loosen them to `toMatchObject`, which would stop them holding the shape at all.
+
+- [ ] **Step 2: Run and watch them fail**
+
+```bash
+./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/storage.test.js
+```
+
+Expected: FAIL — `runs` is `undefined`.
+
+- [ ] **Step 3: Extend `storage.js`**
+
+Update the `Career` typedef:
+
+```js
+/**
+ * @typedef {object} Career
+ * @property {number} best highest single Pull Score
+ * @property {number} total sum of every Pull Score
+ * @property {number} pulls how many pulls have been logged
+ * @property {import('./ui/state/runLog.js').RunRecord[]} runs the banked run log,
+ *   newest first. Validated as an array here and capped by its writer — this adapter
+ *   deliberately knows nothing about RUN_LIMIT, which is a UI-layer policy.
+ * @property {string|null} pinnedRunId the run pinned as the ghost comparison
+ */
+
+/** @type {Career} */
+const EMPTY_CAREER = { best: 0, total: 0, pulls: 0, runs: [], pinnedRunId: null };
+```
+
+In `loadCareer`, replace the returned object:
+
+```js
+    return {
+      best: Number(parsed.best) || 0,
+      total: Number(parsed.total) || 0,
+      pulls: Number(parsed.pulls) || 0,
+      // A save written before run history existed has neither key. Both coerce to the
+      // empty case rather than to `undefined`, which the UI would call .find() on.
+      runs: Array.isArray(parsed.runs) ? parsed.runs : [],
+      pinnedRunId: typeof parsed.pinnedRunId === 'string' ? parsed.pinnedRunId : null,
+    };
+```
+
+In `saveCareer`, replace the serialised object:
+
+```js
+  const raw = JSON.stringify({
+    best: career.best ?? 0,
+    total: career.total ?? 0,
+    pulls: career.pulls ?? 0,
+    runs: Array.isArray(career.runs) ? career.runs : [],
+    pinnedRunId: typeof career.pinnedRunId === 'string' ? career.pinnedRunId : null,
+  });
+```
+
+- [ ] **Step 4: Write the failing mount-guard test**
+
+Append to `tests/ui/session-store.test.jsx`:
+
+```js
+it('does not overwrite a saved career before the load completes', async () => {
+  // The hazard: loadCareer is async, so there is a window between first paint and
+  // its dispatches landing. A persistence effect with no guard runs during that
+  // window and writes zeroes over a real save — silently, and on every cold start.
+  await saveCareer({ best: 900, total: 5000, pulls: 30, runs: [], pinnedRunId: null });
+  const spy = vi.spyOn(storage, 'saveCareer');
+  renderApp();
+  // Whatever it writes, it must never be the empty career.
+  for (const call of spy.mock.calls) {
+    expect(call[0]).not.toMatchObject({ best: 0, total: 0, pulls: 0 });
+  }
+});
+```
+
+Use whatever mount helper this file already defines; do not add a second one.
+
+- [ ] **Step 5: Replace the imperative save with a guarded effect**
+
+In `src/ui/EcuLab.jsx`:
+
+Delete the `persistCareer` helper and its call in `doRun`, along with the three locals that existed only to feed it (`nextBest`, `nextTotal`, `nextPulls`) — **except** `nextPulls`, which Task 4's run record still uses. Keep that one, and delete the comment above them that explains why they were computed twice; it no longer applies.
+
+Add a ref beside the other refs:
+
+```js
+  // Guards the persistence effect below: nothing may be written until the saved career
+  // has actually been read back, or a cold start overwrites it with zeroes.
+  const careerLoaded = useRef(false);
+```
+
+In the existing load effect, set the flag after the three dispatches:
+
+```js
+      dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'pullCount', value: c.pulls });
+      dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'runs', value: c.runs.slice(0, RUN_LIMIT) });
+      dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'pinnedRunId', value: c.pinnedRunId });
+      careerLoaded.current = true;
+```
+
+Add `RUN_LIMIT` to the `runLog.js` import.
+
+Add the persistence effect directly below the load effect:
+
+```js
+  // Career state is written back whenever it moves. This replaces a save call inside
+  // `doRun`, which could not cover the pin: pinning is a dispatch like any other and
+  // has no natural "and now save" call site. An effect over the persisted fields does.
+  useEffect(() => {
+    if (!careerLoaded.current) return;
+    saveCareer({ best: bestScore, total: totalScore, pulls: pullCount, runs, pinnedRunId });
+  }, [bestScore, totalScore, pullCount, runs, pinnedRunId]);
+```
+
+- [ ] **Step 6: Run the tests and the gate**
+
+```bash
+./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/storage.test.js tests/ui/session-store.test.jsx
+npm test && npm run lint && npm run typecheck && npm run build
+```
+
+Expected: all green.
+
+- [ ] **Step 7: Prove the guard test holds**
+
+Temporarily delete the `if (!careerLoaded.current) return;` line and re-run `session-store.test.jsx`. Expected: "does not overwrite a saved career before the load completes" FAILS. Restore it.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/storage.js src/ui/EcuLab.jsx tests/storage.test.js tests/ui/session-store.test.jsx
+git commit -m "Persist the run log and the pin, and stop a cold start clobbering the save"
+```
+
+---
+
+## Task 6: The HISTORY screen
+
+**Files:**
+- Create: `src/ui/screens/dyno/HistoryScreen.jsx`, `src/ui/screens/dyno/HistoryScreen.module.css`
+- Modify: `src/ui/routing.js`, `src/ui/EcuLab.jsx`
+- Test: `tests/ui/dyno-screens.test.jsx`
+
+**Interfaces:**
+- Consumes: `sparklinePath`, `RunRecord` from `runLog.js`; `diffMeasuredInputs` from `pullSignature.js`; `session.runs`/`session.pinnedRunId`; `ACTIONS.PIN_RUN`/`UNPIN_RUN`.
+- Produces: nothing later tasks depend on. This is the last task.
+
+**Note on `routing.js`:** its `ROUTES` comment says *"Do not rename tabs or sections here; #83 re-sections these."* Adding a section is not renaming one — append `'history'` to `ROUTES.dyno` and leave the existing four untouched and in order.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/ui/dyno-screens.test.jsx`:
+
+Seed with this file's existing `mountWithResult(node, sessionFields)` — it dispatches
+`SET_SESSION_FIELD` for each key before the screen mounts, which is exactly what `runs`
+and `pinnedRunId` need. There is no store-state getter in this suite and this task must
+not add one: the pin's effect is observable in the DOM, through the button's accessible
+name, and asserting it there tests the thing the player actually gets.
+
+```js
+/** Three records, oldest id last, matching the store's newest-first order. */
+const RUN_1 = makeRunRecord({
+  id: 'a', n: 1, at: 1_000, label: 'VQ35DE',
+  result: { peakHp: 300, peakTq: 280, points: [{ rpm: 1500, hp: 100, torque: 200 }], events: [] },
+  scores: { tuning: { score: 80 }, engineer: { score: 70 } }, pullScore: 640,
+  inputs: measuredInputs(makeInitialState().build, makeInitialState().tune, 100),
+});
+const RUN_2 = { ...RUN_1, id: 'b', n: 2, peakHp: 320 };
+const RUN_3 = { ...RUN_1, id: 'c', n: 3, peakHp: 340 };
+/** Identical to RUN_1 except for one measured input, so the diff has exactly one answer. */
+const RUN_BOOSTED = {
+  ...RUN_1, id: 'd', n: 2, peakHp: 400,
+  inputs: measuredInputs(
+    { ...makeInitialState().build, boostCurve: [1, 2, 3, 4, 5, 6, 7, 8] },
+    makeInitialState().tune, 100,
+  ),
+};
+
+describe('DYNO > HISTORY', () => {
+  it('shows an empty state before any pull', () => {
+    mountWithResult(<HistoryScreen />, { runs: [], pinnedRunId: null });
+    expect(screen.getByText(/no pulls yet/i)).toBeTruthy();
+  });
+
+  it('lists runs newest first', () => {
+    mountWithResult(<HistoryScreen />, { runs: [RUN_3, RUN_2, RUN_1], pinnedRunId: null });
+    const rows = screen.getAllByRole('listitem');
+    // Position, not presence: a screen that rendered the log reversed would pass a
+    // test that only asserted all three runs appear somewhere.
+    expect(rows[0].textContent).toContain('Run 3');
+    expect(rows[2].textContent).toContain('Run 1');
+  });
+
+  it('names what changed between a run and the one before it', () => {
+    mountWithResult(<HistoryScreen />, { runs: [RUN_BOOSTED, RUN_1], pinnedRunId: null });
+    expect(screen.getByText(/boost curve/)).toBeTruthy();
+  });
+
+  it('says nothing changed when nothing did', () => {
+    // The other half of the diff pair. A screen that always rendered the "changed"
+    // line would pass the test above while telling the player a clean re-run had
+    // altered their build.
+    mountWithResult(<HistoryScreen />, { runs: [{ ...RUN_1, id: 'e', n: 2 }, RUN_1], pinnedRunId: null });
+    expect(screen.queryByText(/Changed since/)).toBe(null);
+  });
+
+  it('pins a run and unpins the same run', () => {
+    // Both directions through one control, so a handler that only ever dispatched
+    // PIN_RUN would fail the second half.
+    mountWithResult(<HistoryScreen />, { runs: [RUN_2, RUN_1], pinnedRunId: null });
+    // Full literals, not substrings: "Unpin run 1" CONTAINS "Pin run 1", so a loose
+    // matcher would happily find the wrong button and still pass.
+    fireEvent.click(screen.getByRole('button', { name: 'Pin run 1 as the comparison' }));
+    expect(screen.getByRole('button', { name: 'Unpin run 1' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Unpin run 1' }));
+    expect(screen.getByRole('button', { name: 'Pin run 1 as the comparison' })).toBeTruthy();
+  });
+
+  it('marks only the pinned row as pinned', () => {
+    mountWithResult(<HistoryScreen />, { runs: [RUN_2, RUN_1], pinnedRunId: RUN_1.id });
+    // Anchored for the same reason: /pin run/i matches "Unpin run 1" as well, and
+    // would count two where the answer is one.
+    expect(screen.getAllByRole('button', { name: /^Unpin run/ })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: /^Pin run/ })).toHaveLength(1);
+  });
+});
+```
+
+Add `HistoryScreen`, `makeRunRecord`, `measuredInputs` and `makeInitialState` to this
+file's imports. `mountWithResult` is already defined; do not add a parallel helper.
+
+- [ ] **Step 2: Run and watch them fail**
+
+```bash
+./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/dyno-screens.test.jsx
+```
+
+Expected: FAIL — `HistoryScreen` does not exist.
+
+- [ ] **Step 3: Write the styles**
+
+Create `src/ui/screens/dyno/HistoryScreen.module.css`:
+
+```css
+/* DYNO > HISTORY — the run log timeline. Tokens only; no literal colours. */
+
+.empty {
+  font-size: 12.5px;
+  color: var(--ink2);
+  background: var(--panel2);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 14px;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: var(--panel2);
+  border: 1px solid var(--line);
+}
+.row[data-pinned='true'] {
+  border-color: var(--acc);
+  background: var(--acc-bg);
+}
+
+.ordinal {
+  font-size: 11px;
+  font-weight: 800;
+  color: var(--ink-soft);
+}
+
+.when {
+  font-size: 10px;
+  color: var(--ink3);
+}
+
+.spark {
+  width: 84px;
+  height: 22px;
+}
+.sparkLine {
+  fill: none;
+  stroke: var(--acc);
+  stroke-width: 1.5;
+}
+
+.peaks {
+  font-size: 12px;
+  font-weight: 800;
+  color: var(--ink);
+  white-space: nowrap;
+}
+
+.delta {
+  font-size: 11px;
+  white-space: nowrap;
+}
+.delta[data-tone='up'] { color: var(--ok); }
+.delta[data-tone='down'] { color: var(--danger-ink); }
+.delta[data-tone='flat'] { color: var(--ink2); }
+
+.changed {
+  grid-column: 1 / -1;
+  font-size: 10.5px;
+  color: var(--ink2);
+}
+
+.knocks {
+  font-size: 10.5px;
+  color: var(--danger-ink);
+}
+
+.pin {
+  padding: 6px 9px;
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 800;
+  border: 1px solid var(--line);
+  background: var(--panel3);
+  color: var(--ink2);
+}
+.pin[data-on='true'] {
+  border-color: var(--acc);
+  background: var(--acc-bg);
+  color: var(--acc-ink);
+}
+```
+
+Check every token name against `src/ui/tokens.css` before committing — `--danger-ink`, `--acc-ink`, `--acc-bg`, `--panel3` and `--ink-soft` must all exist there. If one does not, use the nearest that does rather than adding a token in this PR.
+
+- [ ] **Step 4: Write the screen**
+
+Create `src/ui/screens/dyno/HistoryScreen.jsx`:
+
+```jsx
+/**
+ * DYNO > HISTORY (the run log).
+ *
+ * Every pull the career has banked, newest first, with what changed since the one
+ * before it and a control to pin any of them as the chart's comparison.
+ *
+ * `runs` is plain session state and this screen is its only list reader, so it comes
+ * off the store rather than down as a prop — the same call LogScreen makes for
+ * `result`.
+ *
+ * The "what changed" line compares the two runs' stored `inputs` through
+ * `diffMeasuredInputs`, which derives its field list from the same private array the
+ * pull signature is built from. That is the whole reason the diff lives in
+ * pullSignature.js: a new simulation input is signed and reported in one edit.
+ */
+
+import React from 'react';
+
+import { History, Pin } from 'lucide-react';
+
+import { Eyebrow } from '../../primitives/Eyebrow.jsx';
+import { diffMeasuredInputs } from '../../state/pullSignature.js';
+import { ACTIONS } from '../../state/reducer.js';
+import { sparklinePath } from '../../state/runLog.js';
+import { useSession } from '../../state/StoreProvider.jsx';
+
+import styles from './HistoryScreen.module.css';
+
+/** Sparkline box, in the same user units the CSS sizes it in. */
+const SPARK_W = 84;
+const SPARK_H = 22;
+
+/**
+ * "4m ago", "2h ago", "just now" — coarse on purpose. A run log is read for order and
+ * recency, not for timestamps.
+ * @param {number} at epoch ms
+ * @param {number} now epoch ms
+ * @returns {string}
+ */
+function relativeTime(at, now) {
+  const mins = Math.floor((now - at) / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+/**
+ * @returns {React.ReactElement}
+ */
+export function HistoryScreen() {
+  const [session, dispatch] = useSession();
+  const { runs, pinnedRunId } = session;
+  const now = Date.now();
+
+  if (runs.length === 0) {
+    return (
+      <>
+        <Eyebrow icon={History}>Run History</Eyebrow>
+        <div className={styles.empty}>
+          No pulls yet. Run a dyno pull and it lands here, with every pull after it.
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Eyebrow icon={History}>Run History</Eyebrow>
+      <ul className={styles.list}>
+        {runs.map((run, i) => {
+          const prev = runs[i + 1];
+          const dHp = prev ? run.peakHp - prev.peakHp : 0;
+          const tone = !prev || dHp === 0 ? 'flat' : dHp > 0 ? 'up' : 'down';
+          const changed = prev ? diffMeasuredInputs(prev.inputs, run.inputs) : [];
+          const pinned = run.id === pinnedRunId;
+          return (
+            <li key={run.id} className={styles.row} data-pinned={pinned}>
+              <div>
+                <div className={styles.ordinal}>Run {run.n}</div>
+                <div className={styles.when}>{relativeTime(run.at, now)}</div>
+              </div>
+              <svg className={styles.spark} viewBox={`0 0 ${SPARK_W} ${SPARK_H}`} aria-hidden="true">
+                <path className={styles.sparkLine} d={sparklinePath(run.points, SPARK_W, SPARK_H)} />
+              </svg>
+              <div>
+                <div className={styles.peaks}>{Math.round(run.peakHp)} whp · {Math.round(run.peakTq)} lb-ft</div>
+                <div className={styles.delta} data-tone={tone}>
+                  {prev ? `${dHp > 0 ? '+' : ''}${Math.round(dHp)} whp vs Run ${prev.n}` : 'first pull'}
+                  {run.knocks > 0 && <span className={styles.knocks}> · {run.knocks} knock{run.knocks === 1 ? '' : 's'}</span>}
+                </div>
+              </div>
+              <button
+                type="button"
+                className={styles.pin}
+                data-on={pinned}
+                aria-label={pinned ? `Unpin run ${run.n}` : `Pin run ${run.n} as the comparison`}
+                onClick={() => dispatch(pinned ? { type: ACTIONS.UNPIN_RUN } : { type: ACTIONS.PIN_RUN, id: run.id })}
+              >
+                <Pin size={12} />
+              </button>
+              {changed.length > 0 && (
+                <div className={styles.changed}>Changed since Run {prev.n}: {changed.join(', ')}</div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </>
+  );
+}
+```
+
+Confirm `History` and `Pin` exist in the installed `lucide-react` before committing; if either does not, pick another icon already used in this codebase rather than adding a dependency.
+
+- [ ] **Step 5: Register the route and render the screen**
+
+In `src/ui/routing.js`:
+
+```js
+  dyno: ['result', 'data', 'log', 'score', 'history'],
+```
+
+In `src/ui/EcuLab.jsx`, add the import beside the other DYNO screens:
+
+```js
+import { HistoryScreen } from './screens/dyno/HistoryScreen.jsx';
+```
+
+Add `['history', 'HISTORY']` to the section switcher's array, after `['score', 'SCORE']`.
+
+Add the render, after the `ScoreScreen` block, following the same `!running &&` shape the other three use:
+
+```jsx
+                {!running && dynoView === 'history' && (
+                  <HistoryScreen />
+                )}
+```
+
+Do not alter any of the four existing gates — the file's comment above them is explicit that DYNO's irregular gating is deliberate and must be preserved exactly.
+
+- [ ] **Step 6: Run the tests and the gate**
+
+```bash
+./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork tests/ui/dyno-screens.test.jsx
+npm test && npm run lint && npm run typecheck && npm run build
+```
+
+Expected: all green. The total test count rises by ~5 beyond the tests written here, because `no-hardcoded-colours.test.js` generates 2–3 tests for each of the two new files.
+
+- [ ] **Step 7: Prove the ordering test holds**
+
+Temporarily render `[...runs].reverse()` in `HistoryScreen` and re-run. Expected: "lists runs newest first" FAILS. Revert.
+
+- [ ] **Step 8: Confirm the sim is untouched**
+
+```bash
+git diff --stat origin/main -- src/sim tests/fixtures/fingerprint.sha256 tests/ui/characterisation.test.jsx
+```
+
+Expected: no output at all.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/ui/screens/dyno/HistoryScreen.jsx src/ui/screens/dyno/HistoryScreen.module.css src/ui/routing.js src/ui/EcuLab.jsx tests/ui/dyno-screens.test.jsx
+git commit -m "Add the DYNO run-history timeline, with pinning"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Every section of the spec maps to a task: the run record and its operations to Task 1; the diff's placement in `pullSignature.js` to Task 2; the SESSION slice, `BANK_PULL`, pinning and the `APPLY_PRESET`/`RESET_TO_STOCK` lifecycle to Task 3; the `prevResult` removal and the RPM join to Task 4; storage and its backward compatibility to Task 5; the ghost treatment to Task 4 (`ResultScreen`) and the screen to Task 6. Each of the spec's eight required tests appears in the task that owns the code it holds.
+
+**Type consistency.** `RunRecord` is defined once, in Task 1, and every later task refers to it by import. `makeRunRecord` takes `inputs` already projected, and `measuredInputs` (Task 2) is what projects it — the two are used together for the first time in Task 4, which is where a mismatch would surface, so both signatures are restated there.
+
+**Defects found and fixed during this review, recorded because the same mistakes are the ones to watch for while executing:**
+
+- The plan originally had `makeRunRecord` take its label from `engineDerived.name`. **That field does not exist** — `engineDerived` is displacement, cylinder count, redline and overlap. It now reads `presetById(presetId)?.name ?? 'Custom build'`.
+- Tasks 4 and 6 originally invented test helpers (`renderDyno`, `renderHistory`, `store.getState()`) that `tests/ui/dyno-screens.test.jsx` does not have. They now use its real `mount` and `mountWithResult`, and assert the pin through the DOM rather than through a store getter that would have had to be built.
+- The pin-count assertion originally used `/pin run/i`, which **also matches "Unpin run 1"** and would have counted two where the answer is one. Both queries are now anchored or full literals.
+- The ghost label was originally an inline ternary in `EcuLab.jsx`'s JSX — the one piece of this feature's logic no test could reach. It is now `ghostLabel` in `runLog.js`, with both branches watched failing in Task 1.
+
+**Environment note for whoever executes this:** `node_modules` was missing `lucide-react` when this plan was written, so the UI suite could not run at all. `npm ci` fixed it. The verified baseline on this branch is **988 tests across 33 files, all passing**, with lint, typecheck and build clean. Compare against that, and remember that the two files created in Task 6 add ~5 tests on their own via `no-hardcoded-colours.test.js`.

--- a/docs/superpowers/plans/2026-08-31-run-history-ghost-curve.md
+++ b/docs/superpowers/plans/2026-08-31-run-history-ghost-curve.md
@@ -754,7 +754,9 @@ git commit -m "Teach pullSignature which input moved, not just that one did"
   - `BANK_PULL` gains a required `run: RunRecord` field
   - `ACTIONS.PIN_RUN` (`{type, id}`) and `ACTIONS.UNPIN_RUN` (`{type}`)
 
-**This task is additive.** `prevResult` stays exactly as it is; Task 4 removes it. Keeping the two apart is deliberate: "does the store record runs correctly" and "do the readers correctly switch over" are separately rejectable, and splitting them keeps Task 4's diff purely the migration.
+**This task is additive on the READ side.** `prevResult` stays exactly as it is and none of its readers move; Task 4 removes it. Keeping the two apart is deliberate: "does the store record runs correctly" and "do the readers correctly switch over" are separately rejectable, and splitting them keeps Task 4's diff purely the migration.
+
+**It is NOT additive on the write side, and that was a correction made during execution.** This task also updates the single `BANK_PULL` dispatch site in `EcuLab.jsx` to supply the new required `run` field — see Task 4's Step 3 for the exact code. The original split left that in Task 4, which cannot work: `run` is a required field of `BankPullAction`, `EcuLab.jsx` no longer carries `@ts-nocheck`, so a Task 3 that adds the requirement without satisfying it fails `tsc --noEmit`. The alternatives were a temporarily optional field, a defensive reducer guard, or a commit that does not typecheck — all worse. The line is now "Task 3 makes the write path work end to end; Task 4 switches the read path over."
 
 **A trap this codebase has already fallen into once:** `KnownStoreAction` is a union with no catch-all member, and its doc comment says "the seventeen specific typedefs above". In PR 4a the union was missed when two actions were added, and `tsc` only surfaced it much later, at the first typed dispatch site. Add both typedefs, add both to the union, **and** update that sentence to "nineteen".
 
@@ -1032,18 +1034,26 @@ pin that a missing ghost is the safe default.
 Expected: FAIL — `ResultScreen` does not accept a `ghostLabel` prop yet, so the legend
 never names a comparison.
 
-- [ ] **Step 3: Build the run record at the dispatch site**
+- [ ] **Step 3: (Already done in Task 3 — verify only)**
 
-In `src/ui/EcuLab.jsx`, add the imports:
+**This step moved to Task 3 during execution.** Making `run` a required field of
+`BankPullAction` while leaving `EcuLab.jsx`'s dispatch site without it fails
+`tsc --noEmit`, because that file no longer carries `@ts-nocheck`. The three
+alternatives — a temporarily optional field, a defensive reducer guard, or a commit
+that does not typecheck — were all worse than moving one step earlier. Task 3 is
+therefore "the write path works end to end" and Task 4 is "the read path switches over".
+
+Verify it is in place before continuing: `doRun` should already build the record via
+`makeRunRecord`, and `EcuLab.jsx` should already import `makeRunRecord` from
+`./state/runLog.js` and `measuredInputs` from `./state/pullSignature.js`.
+
+This task still adds `ghostRun` and `ghostLabel` to the `runLog.js` import:
 
 ```js
 import { ghostLabel, ghostRun, makeRunRecord } from './state/runLog.js';
-import { measuredInputs, pullSignature } from './state/pullSignature.js';
 ```
 
-(`pullSignature` is already imported — extend that line rather than adding a second import from the same module.)
-
-In `doRun`, replace the `dispatch({ type: ACTIONS.BANK_PULL, ... })` call with:
+The `doRun` change below is recorded for reference; Task 3 already made it.
 
 ```js
     const nextPulls = pullCount + 1;

--- a/docs/superpowers/specs/2026-08-31-run-history-ghost-curve-design.md
+++ b/docs/superpowers/specs/2026-08-31-run-history-ghost-curve-design.md
@@ -212,6 +212,19 @@ extend. Its `try/catch` returning `EMPTY_CAREER` on a corrupt save stays as it i
 A `runs` array longer than `RUN_LIMIT` on load — a save written by a future build, or a
 hand-edited one — is truncated to the cap rather than trusted.
 
+**Correction, made during the final review.** The paragraph above, read together with the
+"extend `loadCareer`'s coercion pattern" sentence before it, reads as truncation happening
+inside `loadCareer` itself. That is stale and was never implemented that way, because it
+contradicts a constraint this document states elsewhere without naming the consequence:
+`storage.js` must not know `RUN_LIMIT` — that is UI-layer policy, and `storage.js`'s own
+header documents deliberately knowing nothing about it (see its `Career.runs` doc:
+"this adapter deliberately knows nothing about `RUN_LIMIT`, which is a UI-layer policy").
+`loadCareer` validates only that `runs` is an array; it does not cap it. The cap is applied
+where `RUN_LIMIT` is actually in scope: in the reducer, inside `RESTORE_CAREER`
+(`runs: [...s.runs, ...c.runs].slice(0, RUN_LIMIT)`), the same way `pushRun` caps
+`BANK_PULL`'s write. The implementation's placement is correct; this section's wording was
+not, and is corrected here rather than silently rewritten.
+
 ## The ghost curve
 
 Treatment: **dimmed series colour, dashed** — each ghost line keeps its live line's hue.

--- a/docs/superpowers/specs/2026-08-31-run-history-ghost-curve-design.md
+++ b/docs/superpowers/specs/2026-08-31-run-history-ghost-curve-design.md
@@ -1,0 +1,309 @@
+# Run History and the Ghost Curve — Design
+
+**Issue:** #61 (UI overhaul PR 5), sub-issue of #6.
+
+**Goal:** Keep every dyno pull as a record the player can see, compare against, and pin as
+the chart's comparison curve — and make that comparison curve legible for the first time.
+
+## Scope
+
+Issue #61 bundles four features. It ships as three PRs:
+
+| PR | Contents |
+|---|---|
+| **5a** | Run-history timeline, the ghost-curve fix, pinning. **This spec.** |
+| 5b | Knock and lean events plotted at the RPM they occurred, clickable through to the log. |
+| 5c | Post-pull scrubber — drag the RPM axis, every gauge replays at that point. |
+
+5b and 5c get their own specs. They are named here only so the boundaries are explicit.
+
+**Out of scope for 5a, deliberately:**
+
+- **Event markers on the curve.** Events carry no structured RPM (see "What the issue got
+  wrong" below); adding it is a `src/sim/sweep.js` change and belongs to 5b.
+- **The scrubber.** It replays the *current* pull, which is already in memory at full
+  fidelity; it needs nothing from this PR.
+- **A shaded band showing the gain between two pulls.** Considered and rejected for 5a: it
+  needs a designed rule for where the tune got *worse* (the band inverts and wants a
+  different colour), and that is a design question, not an implementation detail.
+- **A user-facing "clear history" control.** The 20-run cap evicts on its own. Nothing has
+  asked for manual clearing; YAGNI.
+
+## What the issue got wrong
+
+The issue's citations were written against the pre-PR-3 tree. Verified against `94e8e1c`:
+
+- **The ghost curve is not at `EcuLab.jsx:2105`.** That file is 1083 lines now. The ghost
+  is `ResultScreen.jsx:55-56`, fed by `chartData` at `EcuLab.jsx:700`.
+- **It is not drawn in `#3a4149`.** That literal is gone. It is `T.ink3` (`#5c6880`).
+- **"A grey dark enough to be nearly invisible" is the right conclusion for the wrong
+  reason.** `#5c6880` on the panel (`#131824`) is **3.17:1** — passing the 3:1 floor for
+  non-text graphics. The actual defect is that `T.ink3` is *also* the colour of the X and
+  Y axes, the tick labels, and the `afrCommanded` trace on the chart below. The ghost is
+  not too dim to see; it is indistinguishable from chart furniture.
+- **There is no index-vs-RPM misalignment bug.** `SWEEP_START_RPM` (1500) and
+  `SWEEP_STEP_RPM` (100) are constants and only `endRpm` moves with redline
+  (`sweep.js:86-87`), so `points[i].rpm === 1500 + 100i` always, and the index join at
+  `EcuLab.jsx:700` *is* an RPM join. A higher-redline previous pull truncates; it never
+  misaligns.
+
+These claims hold and are the work:
+
+- `prevResult` remembers exactly one pull back (`reducer.js:476`).
+- Chart and log are separate things the player correlates by hand.
+- A session is a series of disconnected numbers rather than a story.
+
+## Measurements
+
+Taken by running `simulateSweep` on the first `ENGINE_PRESETS` entry, not estimated:
+
+| Quantity | Value |
+|---|---|
+| Points per sweep | 61 (1500 RPM → redline, 100 RPM steps) |
+| Fields per point | 50 |
+| Full result as JSON | **46,459 bytes** |
+| `{rpm, hp, torque}` only | **2,258 bytes** |
+| All three calibration tables (6×8) | **584 bytes** |
+
+A full-fidelity history would cost ~1 MB for 20 runs against a ~5 MB `localStorage`
+budget, and serialise 46 KB on every pull. A slim record costs ~4 KB. The slim record is
+what this design stores.
+
+## Architecture
+
+### Naming
+
+The store already has a top-level `history` slice — `{past, future}`, the undo stack from
+PR 4a. This feature is therefore **`session.runs`**, and its module is
+**`src/ui/state/runLog.js`**. Nothing in this feature is called "history".
+
+### The run record
+
+```js
+/**
+ * @typedef {object} RunRecord
+ * @property {string} id       monotonic, assigned at bank time — NOT an array index,
+ *                             because a pin must survive eviction of other runs
+ * @property {number} at       epoch ms, for the row's relative timestamp
+ * @property {string} label    engine name at the time of the pull
+ * @property {number} peakHp
+ * @property {number} peakTq
+ * @property {number} knocks   count of events with type === 'knock'
+ * @property {{tuning: number, engineer: number, pull: number}} scores
+ * @property {{rpm: number, hp: number, torque: number}[]} points
+ * @property {{build: object, tune: object, loadKpa: number}} inputs
+ */
+```
+
+`knocks` exists because the delta panel at `EcuLab.jsx:994-998` reads
+`prevResult.events` to count them. A slim record has no `events`, so the count is stored
+at bank time instead. It is the only thing that panel needs from the event log.
+
+`inputs` holds exactly the values `pullSignature` signs. That is what makes the run diff
+possible without a second, drifting list of "what matters".
+
+**Size:** ~2.3 KB of points + ~1.5 KB of inputs + scalars ≈ **4 KB per run**, ~80 KB at
+the 20-run cap.
+
+### `src/ui/state/runLog.js`
+
+Pure module. Imports nothing from `reducer.js` — the same cycle `history.js` was written
+to avoid.
+
+```js
+export const RUN_LIMIT = 20;
+
+/** Builds a RunRecord from a completed pull. */
+export function makeRunRecord({ result, scores, build, tune, loadKpa, label, id, at });
+
+/** Newest-first, capped at RUN_LIMIT, evicting the OLDEST. */
+export function pushRun(runs, record);
+
+/** The run the ghost should draw: the pin if it still exists, else the previous run. */
+export function ghostRun(runs, pinnedRunId);
+
+/** SVG path data for a timeline row's sparkline. Pure — no DOM. */
+export function sparklinePath(points, width, height);
+```
+
+`ghostRun` returns `runs.find(r => r.id === pinnedRunId) ?? runs[1] ?? null`. Index 1,
+not 0: `runs[0]` is the pull just banked, which is the *current* result.
+
+### The run diff lives in `pullSignature.js`
+
+`pullSignature.js`'s header states that it answers "has any measured input moved?" and
+**never** "which one", and gives the reason: a hand-written field-by-field comparison
+drifts out of sync with the signature as fields are added.
+
+The timeline needs "which one". Two ways to get it were considered:
+
+1. **Export `MEASURED_BUILD_KEYS`/`MEASURED_TUNE_KEYS`, diff in `runLog.js`.** Rejected.
+   `history.js` deliberately keeps its own key arrays private so that tests cannot derive
+   their expectations from the thing under test. Exporting these reintroduces exactly that
+   hazard one module over, and puts the diff's field list somewhere it can fall out of step
+   with the signature's.
+2. **Add `diffMeasuredInputs(a, b)` to `pullSignature.js`; keys stay private.** ✅ Chosen.
+   The module already owns the lists and documents its own membership rule, so the diff
+   cannot drift from the signature. A new simulation input added to `MEASURED_BUILD_KEYS`
+   is signed *and* diffed in one edit.
+
+This widens the module's charter, so **its header must be rewritten to say so** — from
+"the identity of the configuration a pull was measured on" to identity *and* difference.
+It is a deliberate change to a module with a narrow, well-argued contract, and it should
+read as one rather than as an extension nobody noticed.
+
+```js
+/**
+ * @returns {string[]} human labels for every measured input that differs, e.g.
+ *   ['boost curve', 'VE table']. Empty when the two configurations are identical —
+ *   which is exactly when their signatures are equal.
+ */
+export function diffMeasuredInputs(a, b);
+```
+
+The labels are display strings (`'boost curve'`, not `'boostCurve'`), so the mapping from
+key to label lives beside the key arrays, in the same file, and a key with no label is a
+loud failure rather than a blank row — the same discipline `labelFor` took in `reducer.js`
+after PR 4a.
+
+### State, actions and storage
+
+**SESSION slice.** Adds `runs: RunRecord[]` (newest first) and `pinnedRunId: string|null`.
+**Removes `prevResult`.**
+
+`prevResult` is deleted rather than kept alongside `runs`, because `runs[1]` is the same
+fact and two representations of one fact drift. Its readers migrate:
+
+| Reader | Becomes |
+|---|---|
+| `EcuLab.jsx:700` (`chartData` ghost columns) | reads `ghostRun(runs, pinnedRunId)` |
+| `EcuLab.jsx:994-998` (delta panel) | reads `runs[1]`, using stored `knocks` |
+| `ResultScreen.jsx:37, 55-56` | takes the ghost run as a prop |
+| `initialState.js:96, 181` | typedef and initial value removed |
+| `reducer.js:434` (`APPLY_PRESET` clear) | drops the `prevResult: null` line |
+| `reducer.js:476` (`BANK_PULL` rotation) | replaced by the `pushRun` unshift |
+
+The `BANK_PULL` rotation carries a documented ordering hazard at `reducer.js:474` — the
+old result must be banked *before* the new one overwrites `result`, or the comparison
+becomes a comparison with itself. `pushRun` inherits that hazard and the test that covers
+it.
+
+**New actions:** `PIN_RUN` (`{id}`) and `UNPIN_RUN`.
+
+**Lifecycle.** `APPLY_PRESET` continues to clear `result` and `pullScores` and now
+explicitly leaves `runs` and `pinnedRunId` standing. A scorecard is cleared because it
+would otherwise sit over no curve; a log of pulls the player actually took stays true
+whatever is loaded now, and each record carries its own `inputs`, so it is self-describing.
+Comparing an LS pull against a VQ pull is a legitimate thing to want.
+
+`RESET_TO_STOCK` does **not** touch the `session` slice at all today — it never cleared
+`result` or `prevResult`, and this PR does not change that. (The pairing of the two actions
+is a natural assumption and a wrong one; whether `RESET_TO_STOCK` *should* clear the
+scorecard is a separate question this PR does not answer.)
+
+**Storage.** `storage.js` persists `{best, total, pulls}` under key `career`. It grows to
+`{best, total, pulls, runs, pinnedRunId}`.
+
+Backward compatibility is a hard requirement: an existing save has no `runs` key and must
+load as `[]` with `pinnedRunId: null`, not as `undefined` and not as a thrown error. The
+existing per-field coercion in `loadCareer` (`Number(parsed.best) || 0`) is the pattern to
+extend. Its `try/catch` returning `EMPTY_CAREER` on a corrupt save stays as it is.
+
+A `runs` array longer than `RUN_LIMIT` on load — a save written by a future build, or a
+hand-edited one — is truncated to the cap rather than trusted.
+
+## The ghost curve
+
+Treatment: **dimmed series colour, dashed** — each ghost line keeps its live line's hue.
+
+| Line | Colour | Width | Dash | Opacity |
+|---|---|---|---|---|
+| WHP | `T.acc` `#4c9eff` | 2 | — | 1 |
+| Torque | `T.cyan` `#38d9f0` | 2 | — | 1 |
+| Ghost WHP | `T.acc` | 1.5 | `5 4` | 0.5 |
+| Ghost TQ | `T.cyan` | 1.5 | `5 4` | 0.5 |
+
+Hue carries series identity; opacity carries time. This fixes the actual defect — the
+ghost is no longer the same colour as the axes and the `afrCommanded` trace — without
+introducing a token. It was chosen over lifting the ghost to `T.ink2` (`5.67:1`, legible
+but one colour for both ghost series, so power and torque are indistinguishable where they
+cross) and over a thin solid variant (leans entirely on colour, closer in character to the
+gridlines).
+
+**The join becomes explicit.** `chartData` builds a `Map` from the ghost run's `rpm` to its
+point and looks each row up by RPM, instead of indexing by position. This produces
+identical output today — see "What the issue got wrong" — but a *pinned* run may be any
+length, and the join should state what it means rather than rely on an invariant two
+modules away.
+
+**The legend names the comparison.** Unpinned it reads `Prev WHP` / `Prev TQ`, as now.
+Pinned it names the run, so the chart never silently compares against something other than
+the previous pull.
+
+## The screen
+
+`src/ui/screens/dyno/HistoryScreen.jsx` and `HistoryScreen.module.css`, routed at
+`#/dyno/history` as a fourth DYNO section beside CURVES, DATALOG and SCORE, registered in
+`routing.js` alongside them.
+
+Each row carries: run ordinal and relative time, sparkline, peak WHP and torque, delta
+versus the run before it, knock count, and a pin toggle. The pinned row is visibly marked.
+
+Before the first pull the screen shows an empty state rather than an empty table.
+
+The sparkline is `sparklinePath` from `runLog.js` rendered into an inline `<svg>` — no new
+dependency, and the path maths is unit-tested without a DOM.
+
+## Verification
+
+Full gate on every commit, per `CONTRIBUTING.md`, on Node 22 (`v22.23.2`):
+`npm test`, `npm run lint` (`--max-warnings 0`), `npm run typecheck`, `npm run build`.
+Tests run as `./node_modules/.bin/vitest run --pool=forks --poolOptions.forks.singleFork`.
+
+**No `src/sim/` change in 5a.** `tests/fixtures/fingerprint.sha256` and
+`tests/ui/characterisation.test.jsx` must be byte-identical to `main` at merge.
+
+### Tests, and the failure mode they are written against
+
+PR 4a shipped seven task suites and every one of them failed to hold its implementation, in
+one of five shapes: pinning one side of a pair; pinning each case but not the exclusivity
+between them; moving two variables at once so neither is held; asserting a count or a shape
+but not which end; and a harness that reads post-state for its "before", so the assertion
+cannot fail. The implementation plan carries the discriminating test *into each brief*
+rather than leaving it to the implementer.
+
+Required, each stated as the mutation it must fail under:
+
+- **Eviction asserts which end.** A 21st run drops the *oldest* and the newest is at index
+  0. Reversing `pushRun`'s order must fail the test. (In 4a, a FIFO undo stack passed 871
+  tests.)
+- **Pin fallback holds both halves.** A pinned run wins over the previous run, *and* an
+  absent pin falls back to the previous run. Each half must fail independently.
+- **A pinned run that has been evicted** falls back to the previous run rather than
+  throwing. `ghostRun` returning `undefined` must fail.
+- **`diffMeasuredInputs` holds both sides.** A changed field appears in the result *and* an
+  unchanged one does not. Returning all keys unconditionally, and returning `[]`
+  unconditionally, must each fail.
+- **`APPLY_PRESET` holds both halves.** It clears `result` and `pullScores`, *and* leaves
+  `runs` and `pinnedRunId` untouched. Each half must fail independently.
+- **`RESET_TO_STOCK` leaves the session slice alone**, pinning today's behaviour so the
+  natural-but-wrong pairing with `APPLY_PRESET` cannot be introduced silently.
+- **Storage round-trips a legacy blob.** `{best, total, pulls}` with no `runs` key loads as
+  `runs: []`, `pinnedRunId: null`. An over-length `runs` array loads truncated to
+  `RUN_LIMIT`.
+- **`BANK_PULL` order.** The banked run is the one just completed and `runs[1]` is the one
+  before it — the hazard documented at `reducer.js:474`, carried over to `pushRun`.
+
+Test files: `tests/ui/state/runLog.test.js`, `tests/ui/state/pullSignature.test.js`
+(extended), `tests/ui/state/reducer.test.js` (extended), `tests/storage.test.js`
+(extended), `tests/ui/dyno-screens.test.jsx` (extended for the new screen and the ghost).
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Removing `prevResult` breaks a reader nobody listed | The six sites are enumerated above; `typecheck` fails on any missed one once the typedef is removed |
+| A legacy save breaks on load | Explicit test for the pre-`runs` blob shape; per-field coercion, not a whole-object trust |
+| The diff drifts from the signature | Both derive from one private key list in one file — the reason for choosing option 2 in §"The run diff" |
+| Storage grows unbounded | Hard cap at `RUN_LIMIT`, enforced on write *and* on load |
+| Four lines on one chart is busy | Ghost lines are 1.5px at 0.5 opacity against 2px solid; hue keeps the pairs readable |

--- a/src/storage.js
+++ b/src/storage.js
@@ -35,10 +35,14 @@ export function storageBackend() {
  * @property {number} best highest single Pull Score
  * @property {number} total sum of every Pull Score
  * @property {number} pulls how many pulls have been logged
+ * @property {import('./ui/state/runLog.js').RunRecord[]} runs the banked run log,
+ *   newest first. Validated as an array here and capped by its writer — this adapter
+ *   deliberately knows nothing about RUN_LIMIT, which is a UI-layer policy.
+ * @property {string|null} pinnedRunId the run pinned as the ghost comparison
  */
 
 /** @type {Career} */
-const EMPTY_CAREER = { best: 0, total: 0, pulls: 0 };
+const EMPTY_CAREER = { best: 0, total: 0, pulls: 0, runs: [], pinnedRunId: null };
 
 /**
  * Reads saved career stats.
@@ -59,6 +63,10 @@ export async function loadCareer() {
       best: Number(parsed.best) || 0,
       total: Number(parsed.total) || 0,
       pulls: Number(parsed.pulls) || 0,
+      // A save written before run history existed has neither key. Both coerce to the
+      // empty case rather than to `undefined`, which the UI would call .find() on.
+      runs: Array.isArray(parsed.runs) ? parsed.runs : [],
+      pinnedRunId: typeof parsed.pinnedRunId === 'string' ? parsed.pinnedRunId : null,
     };
   } catch {
     // A corrupt or unreadable save should never stop the app from starting.
@@ -77,6 +85,8 @@ export async function saveCareer(career) {
     best: career.best ?? 0,
     total: career.total ?? 0,
     pulls: career.pulls ?? 0,
+    runs: Array.isArray(career.runs) ? career.runs : [],
+    pinnedRunId: typeof career.pinnedRunId === 'string' ? career.pinnedRunId : null,
   });
   try {
     switch (storageBackend()) {

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -47,7 +47,7 @@ import { ROUTES } from './routing.js';
 import { useRoute } from './useRoute.js';
 import { ACTIONS } from './state/reducer.js';
 import { pullSignature, measuredInputs } from './state/pullSignature.js';
-import { RUN_LIMIT, ghostLabel, ghostRun, makeRunRecord } from './state/runLog.js';
+import { ghostLabel, ghostRun, makeRunRecord } from './state/runLog.js';
 import { Button } from './primitives/Button.jsx';
 import { Eyebrow } from './primitives/Eyebrow.jsx';
 import { Panel } from './primitives/Panel.jsx';
@@ -657,16 +657,21 @@ export function EcuLabApp() {
   }, [dispatch]);
 
   // Career stats persist across sessions so the high score is worth chasing.
+  //
+  // `loadCareer()` is an `await`, so a pull can bank between mount and this resolving
+  // — reachable in practice on the `artifact` storage backend, where the underlying
+  // `window.storage.get` is a real round trip. A single RESTORE_CAREER action, rather
+  // than the five separate `SET_SESSION_FIELD` dispatches this used to fire, is what
+  // keeps that race from rolling a banked pull back to the pre-pull snapshot: the
+  // reducer MERGES the loaded career with whatever the session already holds instead
+  // of overwriting it. See RESTORE_CAREER's own doc in reducer.js for the full case,
+  // including why a skip-instead-of-merge fix would only move the data loss.
   useEffect(() => {
     let cancelled = false;
     (async () => {
       const c = await loadCareer();
       if (cancelled) return;
-      dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'bestScore', value: c.best });
-      dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'totalScore', value: c.total });
-      dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'pullCount', value: c.pulls });
-      dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'runs', value: c.runs.slice(0, RUN_LIMIT) });
-      dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'pinnedRunId', value: c.pinnedRunId });
+      dispatch({ type: ACTIONS.RESTORE_CAREER, career: c });
       careerLoaded.current = true;
     })();
     return () => { cancelled = true; };

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -46,7 +46,8 @@ import { StoreProvider, useBuild, useSession, useTune } from './state/StoreProvi
 import { ROUTES } from './routing.js';
 import { useRoute } from './useRoute.js';
 import { ACTIONS } from './state/reducer.js';
-import { pullSignature } from './state/pullSignature.js';
+import { pullSignature, measuredInputs } from './state/pullSignature.js';
+import { makeRunRecord } from './state/runLog.js';
 import { Button } from './primitives/Button.jsx';
 import { Eyebrow } from './primitives/Eyebrow.jsx';
 import { Panel } from './primitives/Panel.jsx';
@@ -550,16 +551,28 @@ export function EcuLabApp() {
     // `scores` rides along with the result it belongs to: BANK_PULL keeps the numbers
     // this pull actually measured, and `buildSignature` records the setup it measured
     // them on. Nothing recomputes them afterwards — that is the whole fix (issue #29).
+    const nextPulls = pullCount + 1;
+    const at = Date.now();
     dispatch({
       type: ACTIONS.BANK_PULL, result: r, pullScore: pull,
       scores: { tuning: ts, engineer: es, signature: buildSignature },
+      // `id` pairs the clock with the career ordinal so two records can never collide,
+      // and `at`/`id` are read HERE because the reducer must call no clock of its own.
+      run: makeRunRecord({
+        id: `${at}-${nextPulls}`, n: nextPulls, at,
+        // `engineDerived` carries no name — it is displacement, cylinder count and
+        // redline. The build's name is the loaded preset's, and a build with no preset
+        // is exactly what "Custom build" means everywhere else in this app.
+        label: presetById(presetId)?.name ?? 'Custom build',
+        result: r, scores: { tuning: ts, engineer: es }, pullScore: pull,
+        inputs: measuredInputs(build, tune, loadKpa),
+      }),
     });
     // BANK_PULL writes bestScore/totalScore/pullCount itself, from the same three
     // expressions. They are still computed here because `persistCareer` needs the new
     // values NOW: reading them back off `session` would read this render's stale ones.
     const nextBest = Math.max(bestScore, pull);
     const nextTotal = totalScore + pull;
-    const nextPulls = pullCount + 1;
     persistCareer(nextBest, nextTotal, nextPulls);
     const total = r.points.length;
     let i = 0;

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -68,6 +68,7 @@ import { InjectorsScreen } from './screens/tune/InjectorsScreen.jsx';
 import { SensorsScreen } from './screens/tune/SensorsScreen.jsx';
 import { SparkScreen } from './screens/tune/SparkScreen.jsx';
 import { DataScreen } from './screens/dyno/DataScreen.jsx';
+import { HistoryScreen } from './screens/dyno/HistoryScreen.jsx';
 import { LogScreen } from './screens/dyno/LogScreen.jsx';
 import { ResultScreen } from './screens/dyno/ResultScreen.jsx';
 import { ScoreScreen } from './screens/dyno/ScoreScreen.jsx';
@@ -1042,7 +1043,7 @@ export function EcuLabApp() {
 
                 {!running && (
                   <div style={{ display: 'flex', gap: 6, marginBottom: 14 }}>
-                    {[['result', 'CURVES'], ['log', 'PULL LOG'], ['data', 'DATALOG'], ['score', 'SCORE']].map(([id, label]) => {
+                    {[['result', 'CURVES'], ['log', 'PULL LOG'], ['data', 'DATALOG'], ['score', 'SCORE'], ['history', 'HISTORY']].map(([id, label]) => {
                       const on = dynoView === id;
                       const flag = id === 'log' && result.events.length > 0;
                       return (
@@ -1085,6 +1086,10 @@ export function EcuLabApp() {
 
                 {!running && dynoView === 'score' && scores && (
                   <ScoreScreen scores={scores} stale={scoresStale} />
+                )}
+
+                {!running && dynoView === 'history' && (
+                  <HistoryScreen />
                 )}
               </>
             )}

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -1040,26 +1040,39 @@ export function EcuLabApp() {
                     </Panel>
                   );
                 })()}
+              </>
+            )}
 
-                {!running && (
-                  <div style={{ display: 'flex', gap: 6, marginBottom: 14 }}>
-                    {[['result', 'CURVES'], ['log', 'PULL LOG'], ['data', 'DATALOG'], ['score', 'SCORE'], ['history', 'HISTORY']].map(([id, label]) => {
-                      const on = dynoView === id;
-                      const flag = id === 'log' && result.events.length > 0;
-                      return (
-                        <button key={id} onClick={() => goSection('dyno', id)} style={{
-                          flex: 1, padding: '9px 0', borderRadius: 9, fontWeight: 800, fontSize: 10, letterSpacing: 0.3,
-                          border: `1px solid ${on ? T.acc : T.line}`, background: on ? T.accBg : T.panel2,
-                          color: on ? T.accInk : T.ink2, position: 'relative',
-                        }}>
-                          {label}
-                          {flag && <span style={{ position: 'absolute', top: 5, right: 7, width: 5, height: 5, borderRadius: 3, background: T.danger }} />}
-                        </button>
-                      );
-                    })}
-                  </div>
-                )}
+            {/* HISTORY sits outside the `result` gate deliberately: its data (`runs`)
+                outlives `result` — it is restored from storage on a cold start, while
+                `result` is not persisted and is cleared by APPLY_PRESET — so it is the
+                first DYNO section for which that is true. When there is no result yet,
+                the switcher below shows ONLY the history entry, since the other four
+                lead to sections that render nothing without one. */}
+            {!running && (result || runs.length > 0) && (
+              <div style={{ display: 'flex', gap: 6, marginBottom: 14 }}>
+                {(result
+                  ? [['result', 'CURVES'], ['log', 'PULL LOG'], ['data', 'DATALOG'], ['score', 'SCORE'], ['history', 'HISTORY']]
+                  : [['history', 'HISTORY']]
+                ).map(([id, label]) => {
+                  const on = dynoView === id;
+                  const flag = id === 'log' && result && result.events.length > 0;
+                  return (
+                    <button key={id} onClick={() => goSection('dyno', id)} style={{
+                      flex: 1, padding: '9px 0', borderRadius: 9, fontWeight: 800, fontSize: 10, letterSpacing: 0.3,
+                      border: `1px solid ${on ? T.acc : T.line}`, background: on ? T.accBg : T.panel2,
+                      color: on ? T.accInk : T.ink2, position: 'relative',
+                    }}>
+                      {label}
+                      {flag && <span style={{ position: 'absolute', top: 5, right: 7, width: 5, height: 5, borderRadius: 3, background: T.danger }} />}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
 
+            {result && (
+              <>
                 {/* DYNO's gating is irregular ON PURPOSE, not four uniform
                     `dynoView === x` checks like TUNE's. While a pull is running the
                     switcher above is hidden and CURVES is the only view that can show
@@ -1087,11 +1100,11 @@ export function EcuLabApp() {
                 {!running && dynoView === 'score' && scores && (
                   <ScoreScreen scores={scores} stale={scoresStale} />
                 )}
-
-                {!running && dynoView === 'history' && (
-                  <HistoryScreen />
-                )}
               </>
+            )}
+
+            {!running && dynoView === 'history' && (
+              <HistoryScreen />
             )}
           </div>
         )}

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -47,7 +47,7 @@ import { ROUTES } from './routing.js';
 import { useRoute } from './useRoute.js';
 import { ACTIONS } from './state/reducer.js';
 import { pullSignature, measuredInputs } from './state/pullSignature.js';
-import { makeRunRecord } from './state/runLog.js';
+import { ghostLabel, ghostRun, makeRunRecord } from './state/runLog.js';
 import { Button } from './primitives/Button.jsx';
 import { Eyebrow } from './primitives/Eyebrow.jsx';
 import { Panel } from './primitives/Panel.jsx';
@@ -218,7 +218,7 @@ export function EcuLabApp() {
   const [session] = useSession();
   const {
     loadKpa, soundOn, journeyStep, throttleInput, health,
-    result, prevResult, pullScores, running, revealCount, bestScore, totalScore, pullCount,
+    result, runs, pinnedRunId, pullScores, running, revealCount, bestScore, totalScore, pullCount,
     live,
   } = session;
   // One `route.section` serves all four tabs, narrowed per tab so every call site below
@@ -541,13 +541,12 @@ export function EcuLabApp() {
       exhaustDiaError, dutyPreview, displacementL: engineDerived.displacementL, fuel, mods,
     });
     const pull = computePullScore({ peakHp: r.peakHp, peakTq: r.peakTq, tuningScore: ts.score, engineerScore: es.score });
-    // Banking the pull — prevResult rotation, wear, scores, pull count — lands in the
+    // Banking the pull — result, wear, scores, pull count, run log — lands in the
     // store in one pass. `result` and `pullScore` are precomputed here because the
     // reducer has no access to the useMemo-derived hardware `computePullScore` needs.
-    // The local `setPrevResult`/`setResult`/`setHealth` calls that used to sit above
-    // this line, and the `setBestScore`/`setTotalScore`/`setPullCount` trio below it,
-    // were all mirroring writes this one action already makes — including the
-    // prevResult-before-result rotation whose ordering it exists to own.
+    // The local `setResult`/`setHealth` calls that used to sit above this line, and the
+    // `setBestScore`/`setTotalScore`/`setPullCount` trio below it, were all mirroring
+    // writes this one action already makes.
     // `scores` rides along with the result it belongs to: BANK_PULL keeps the numbers
     // this pull actually measured, and `buildSignature` records the setup it measured
     // them on. Nothing recomputes them afterwards — that is the whole fix (issue #29).
@@ -705,14 +704,24 @@ export function EcuLabApp() {
     return () => window.removeEventListener('keydown', onKey);
   }, [dispatch]);
 
+  const ghost = ghostRun(runs, pinnedRunId);
+
   const chartData = useMemo(() => {
     if (!result) return [];
-    return result.points.slice(0, running ? revealCount : result.points.length).map((p, i) => ({
-      rpm: p.rpm, hp: p.hp, torque: p.torque, afr: p.afr, afrCommanded: p.afrCommanded,
-      timing: p.timing, commandedTiming: p.commandedTiming, duty: p.duty, trimPct: p.trimPct,
-      prevHp: prevResult?.points?.[i]?.hp, prevTorque: prevResult?.points?.[i]?.torque,
-    }));
-  }, [result, prevResult, running, revealCount]);
+    // Keyed by RPM, not by array position. Today the two are the same thing —
+    // SWEEP_START_RPM and SWEEP_STEP_RPM are constants, so points[i].rpm is always
+    // 1500 + 100i — but a PINNED run may be any length, and the join should state
+    // what it means rather than lean on an invariant two modules away.
+    const ghostByRpm = new Map((ghost?.points ?? []).map((p) => [p.rpm, p]));
+    return result.points.slice(0, running ? revealCount : result.points.length).map((p) => {
+      const g = ghostByRpm.get(p.rpm);
+      return {
+        rpm: p.rpm, hp: p.hp, torque: p.torque, afr: p.afr, afrCommanded: p.afrCommanded,
+        timing: p.timing, commandedTiming: p.commandedTiming, duty: p.duty, trimPct: p.trimPct,
+        prevHp: g?.hp, prevTorque: g?.torque,
+      };
+    });
+  }, [result, ghost, running, revealCount]);
 
   // `buildHistogram`/`applyHistogram` moved to DataScreen.jsx: DYNO's DATALOG
   // section was their only caller, and everything they touch (result, histogram,
@@ -1004,12 +1013,12 @@ export function EcuLabApp() {
                   <StatTile label="PEAK TQ" value={result.peakTq} unit="lb-ft" tone="alt" />
                 </div>
 
-                {prevResult && !running && (() => {
-                  const dHp = result.peakHp - prevResult.peakHp;
-                  const dTq = result.peakTq - prevResult.peakTq;
+                {runs[1] && !running && (() => {
+                  const prev = runs[1];
+                  const dHp = result.peakHp - prev.peakHp;
+                  const dTq = result.peakTq - prev.peakTq;
                   const knockNow = result.events.filter((e) => e.type === 'knock').length;
-                  const knockPrev = prevResult.events.filter((e) => e.type === 'knock').length;
-                  const dKnock = knockNow - knockPrev;
+                  const dKnock = knockNow - prev.knocks;
                   const fmtDelta = (v, unit) => `${v > 0 ? '+' : ''}${v}${unit}`;
                   return (
                     <Panel tight style={{ marginBottom: 16, display: 'flex', alignItems: 'center', gap: 8 }}>
@@ -1051,7 +1060,11 @@ export function EcuLabApp() {
                     starts instead of falling back to the live curves. Preserve every
                     condition exactly. */}
                 {(running || dynoView === 'result') && (
-                  <ResultScreen chartData={chartData} engineDerived={engineDerived} />
+                  <ResultScreen
+                    chartData={chartData}
+                    engineDerived={engineDerived}
+                    ghostLabel={ghostLabel(ghost, pinnedRunId)}
+                  />
                 )}
 
                 {!running && dynoView === 'data' && (

--- a/src/ui/EcuLab.jsx
+++ b/src/ui/EcuLab.jsx
@@ -47,7 +47,7 @@ import { ROUTES } from './routing.js';
 import { useRoute } from './useRoute.js';
 import { ACTIONS } from './state/reducer.js';
 import { pullSignature, measuredInputs } from './state/pullSignature.js';
-import { ghostLabel, ghostRun, makeRunRecord } from './state/runLog.js';
+import { RUN_LIMIT, ghostLabel, ghostRun, makeRunRecord } from './state/runLog.js';
 import { Button } from './primitives/Button.jsx';
 import { Eyebrow } from './primitives/Eyebrow.jsx';
 import { Panel } from './primitives/Panel.jsx';
@@ -240,6 +240,9 @@ export function EcuLabApp() {
   const liveCfgRef = useRef(null);
   const throttleRef = useRef(0);
   const audioRef = useRef(null);
+  // Guards the persistence effect below: nothing may be written until the saved career
+  // has actually been read back, or a cold start overwrites it with zeroes.
+  const careerLoaded = useRef(false);
 
   // `withPresetField` is gone: SET_BUILD_FIELD clears `presetId` itself, so the
   // invalidation now happens inside the reducer rather than in a wrapper each new
@@ -515,11 +518,6 @@ export function EcuLabApp() {
     [build, tune, loadKpa],
   );
 
-  // Persistence goes through the storage adapter, which picks whichever backend is
-  // available (artifact host, localStorage, or in-memory) so career stats survive a
-  // refresh wherever the app is deployed.
-  const persistCareer = (best, total, pulls) => saveCareer({ best, total, pulls });
-
   const doRun = () => {
     const a = ensureAudio();
     if (a && a.ctx.state === 'suspended') a.ctx.resume();
@@ -567,12 +565,6 @@ export function EcuLabApp() {
         inputs: measuredInputs(build, tune, loadKpa),
       }),
     });
-    // BANK_PULL writes bestScore/totalScore/pullCount itself, from the same three
-    // expressions. They are still computed here because `persistCareer` needs the new
-    // values NOW: reading them back off `session` would read this render's stale ones.
-    const nextBest = Math.max(bestScore, pull);
-    const nextTotal = totalScore + pull;
-    persistCareer(nextBest, nextTotal, nextPulls);
     const total = r.points.length;
     let i = 0;
     revealTimer.current = setInterval(() => {
@@ -673,10 +665,21 @@ export function EcuLabApp() {
       dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'bestScore', value: c.best });
       dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'totalScore', value: c.total });
       dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'pullCount', value: c.pulls });
+      dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'runs', value: c.runs.slice(0, RUN_LIMIT) });
+      dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'pinnedRunId', value: c.pinnedRunId });
+      careerLoaded.current = true;
     })();
     return () => { cancelled = true; };
     // Stable for the life of the store, so this still loads career stats exactly once.
   }, [dispatch]);
+
+  // Career state is written back whenever it moves. This replaces a save call inside
+  // `doRun`, which could not cover the pin: pinning is a dispatch like any other and
+  // has no natural "and now save" call site. An effect over the persisted fields does.
+  useEffect(() => {
+    if (!careerLoaded.current) return;
+    saveCareer({ best: bestScore, total: totalScore, pulls: pullCount, runs, pinnedRunId });
+  }, [bestScore, totalScore, pullCount, runs, pinnedRunId]);
 
   // Cmd/Ctrl+Z and Cmd+Shift+Z / Ctrl+Y. This lives here rather than in AppShell,
   // whose header is explicit that the shell owns chrome only and never dispatches to

--- a/src/ui/routing.js
+++ b/src/ui/routing.js
@@ -23,7 +23,7 @@ export const ROUTES = {
   dash: ['live', 'stats', 'health', 'learn'],
   build: ['engine', 'induction', 'fuel', 'exhaust'],
   tune: ['airflow', 'spark', 'fuel', 'injectors', 'sensors'],
-  dyno: ['result', 'data', 'log', 'score'],
+  dyno: ['result', 'data', 'log', 'score', 'history'],
 };
 
 /**

--- a/src/ui/screens/dyno/HistoryScreen.jsx
+++ b/src/ui/screens/dyno/HistoryScreen.jsx
@@ -14,7 +14,7 @@
  * pullSignature.js: a new simulation input is signed and reported in one edit.
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { History, Pin } from 'lucide-react';
 
@@ -52,7 +52,36 @@ function relativeTime(at, now) {
 export function HistoryScreen() {
   const [session, dispatch] = useSession();
   const { runs, pinnedRunId } = session;
-  const now = Date.now();
+
+  // `diffMeasuredInputs` runs ~32 `JSON.stringify` calls per row and `sparklinePath`
+  // walks up to 61 points; both ran on every render, unmemoized, over up to 20 rows.
+  // The store is a single context and `LIVE_STEP` dispatches into it at 20 Hz, so
+  // with the engine running and HISTORY open that was ~640 `JSON.stringify` calls a
+  // second for numbers that had not changed. `now` is captured in here too — reading
+  // `Date.now()` in the render body made the component impure for no reason a memo
+  // keyed on the same two inputs doesn't already fix.
+  const rows = useMemo(() => {
+    const now = Date.now();
+    return runs.map((run, i) => {
+      const prev = runs[i + 1];
+      const dHp = prev ? run.peakHp - prev.peakHp : 0;
+      const tone = !prev || dHp === 0 ? 'flat' : dHp > 0 ? 'up' : 'down';
+      const changed = prev ? diffMeasuredInputs(prev.inputs, run.inputs) : [];
+      const pinned = run.id === pinnedRunId;
+      // `prev` is undefined for every row with nothing older still in the log, not
+      // only the career's actual first pull — once the log caps at RUN_LIMIT, the
+      // oldest VISIBLE row has no `prev` either, at whatever `n` it happens to be.
+      // "first pull" is keyed on `run.n === 1` so only the real first pull claims it.
+      const deltaText = prev
+        ? `${dHp > 0 ? '+' : ''}${Math.round(dHp)} whp vs Run ${prev.n}`
+        : (run.n === 1 ? 'first pull' : '');
+      return {
+        run, prev, tone, changed, pinned, deltaText,
+        when: relativeTime(run.at, now),
+        spark: sparklinePath(run.points, SPARK_W, SPARK_H),
+      };
+    });
+  }, [runs, pinnedRunId]);
 
   if (runs.length === 0) {
     return (
@@ -69,44 +98,37 @@ export function HistoryScreen() {
     <>
       <Eyebrow icon={History}>Run History</Eyebrow>
       <ul className={styles.list}>
-        {runs.map((run, i) => {
-          const prev = runs[i + 1];
-          const dHp = prev ? run.peakHp - prev.peakHp : 0;
-          const tone = !prev || dHp === 0 ? 'flat' : dHp > 0 ? 'up' : 'down';
-          const changed = prev ? diffMeasuredInputs(prev.inputs, run.inputs) : [];
-          const pinned = run.id === pinnedRunId;
-          return (
-            <li key={run.id} className={styles.row} data-pinned={pinned}>
-              <div>
-                <div className={styles.ordinal}>Run {run.n}</div>
-                <div className={styles.when}>{relativeTime(run.at, now)}</div>
-                <div className={styles.label}>{run.label}</div>
+        {rows.map(({ run, prev, tone, changed, pinned, deltaText, when, spark }) => (
+          <li key={run.id} className={styles.row} data-pinned={pinned}>
+            <div>
+              <div className={styles.ordinal}>Run {run.n}</div>
+              <div className={styles.when}>{when}</div>
+              <div className={styles.label}>{run.label}</div>
+            </div>
+            <svg className={styles.spark} viewBox={`0 0 ${SPARK_W} ${SPARK_H}`} aria-hidden="true">
+              <path className={styles.sparkLine} d={spark} />
+            </svg>
+            <div>
+              <div className={styles.peaks}>{Math.round(run.peakHp)} whp · {Math.round(run.peakTq)} lb-ft</div>
+              <div className={styles.delta} data-tone={tone}>
+                {deltaText}
+                {run.knocks > 0 && <span className={styles.knocks}> · {run.knocks} knock{run.knocks === 1 ? '' : 's'}</span>}
               </div>
-              <svg className={styles.spark} viewBox={`0 0 ${SPARK_W} ${SPARK_H}`} aria-hidden="true">
-                <path className={styles.sparkLine} d={sparklinePath(run.points, SPARK_W, SPARK_H)} />
-              </svg>
-              <div>
-                <div className={styles.peaks}>{Math.round(run.peakHp)} whp · {Math.round(run.peakTq)} lb-ft</div>
-                <div className={styles.delta} data-tone={tone}>
-                  {prev ? `${dHp > 0 ? '+' : ''}${Math.round(dHp)} whp vs Run ${prev.n}` : 'first pull'}
-                  {run.knocks > 0 && <span className={styles.knocks}> · {run.knocks} knock{run.knocks === 1 ? '' : 's'}</span>}
-                </div>
-              </div>
-              <button
-                type="button"
-                className={styles.pin}
-                data-on={pinned}
-                aria-label={pinned ? `Unpin run ${run.n}` : `Pin run ${run.n} as the comparison`}
-                onClick={() => dispatch(pinned ? { type: ACTIONS.UNPIN_RUN } : { type: ACTIONS.PIN_RUN, id: run.id })}
-              >
-                <Pin size={12} />
-              </button>
-              {changed.length > 0 && (
-                <div className={styles.changed}>Changed since Run {prev.n}: {changed.join(', ')}</div>
-              )}
-            </li>
-          );
-        })}
+            </div>
+            <button
+              type="button"
+              className={styles.pin}
+              data-on={pinned}
+              aria-label={pinned ? `Unpin run ${run.n}` : `Pin run ${run.n} as the comparison`}
+              onClick={() => dispatch(pinned ? { type: ACTIONS.UNPIN_RUN } : { type: ACTIONS.PIN_RUN, id: run.id })}
+            >
+              <Pin size={12} />
+            </button>
+            {changed.length > 0 && (
+              <div className={styles.changed}>Changed since Run {prev.n}: {changed.join(', ')}</div>
+            )}
+          </li>
+        ))}
       </ul>
     </>
   );

--- a/src/ui/screens/dyno/HistoryScreen.jsx
+++ b/src/ui/screens/dyno/HistoryScreen.jsx
@@ -80,6 +80,7 @@ export function HistoryScreen() {
               <div>
                 <div className={styles.ordinal}>Run {run.n}</div>
                 <div className={styles.when}>{relativeTime(run.at, now)}</div>
+                <div className={styles.label}>{run.label}</div>
               </div>
               <svg className={styles.spark} viewBox={`0 0 ${SPARK_W} ${SPARK_H}`} aria-hidden="true">
                 <path className={styles.sparkLine} d={sparklinePath(run.points, SPARK_W, SPARK_H)} />

--- a/src/ui/screens/dyno/HistoryScreen.jsx
+++ b/src/ui/screens/dyno/HistoryScreen.jsx
@@ -1,0 +1,112 @@
+/**
+ * DYNO > HISTORY (the run log).
+ *
+ * Every pull the career has banked, newest first, with what changed since the one
+ * before it and a control to pin any of them as the chart's comparison.
+ *
+ * `runs` is plain session state and this screen is its only list reader, so it comes
+ * off the store rather than down as a prop — the same call LogScreen makes for
+ * `result`.
+ *
+ * The "what changed" line compares the two runs' stored `inputs` through
+ * `diffMeasuredInputs`, which derives its field list from the same private array the
+ * pull signature is built from. That is the whole reason the diff lives in
+ * pullSignature.js: a new simulation input is signed and reported in one edit.
+ */
+
+import React from 'react';
+
+import { History, Pin } from 'lucide-react';
+
+import { Eyebrow } from '../../primitives/Eyebrow.jsx';
+import { diffMeasuredInputs } from '../../state/pullSignature.js';
+import { ACTIONS } from '../../state/reducer.js';
+import { sparklinePath } from '../../state/runLog.js';
+import { useSession } from '../../state/StoreProvider.jsx';
+
+import styles from './HistoryScreen.module.css';
+
+/** Sparkline box, in the same user units the CSS sizes it in. */
+const SPARK_W = 84;
+const SPARK_H = 22;
+
+/**
+ * "4m ago", "2h ago", "just now" — coarse on purpose. A run log is read for order and
+ * recency, not for timestamps.
+ * @param {number} at epoch ms
+ * @param {number} now epoch ms
+ * @returns {string}
+ */
+function relativeTime(at, now) {
+  const mins = Math.floor((now - at) / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}
+
+/**
+ * @returns {React.ReactElement}
+ */
+export function HistoryScreen() {
+  const [session, dispatch] = useSession();
+  const { runs, pinnedRunId } = session;
+  const now = Date.now();
+
+  if (runs.length === 0) {
+    return (
+      <>
+        <Eyebrow icon={History}>Run History</Eyebrow>
+        <div className={styles.empty}>
+          No pulls yet. Run a dyno pull and it lands here, with every pull after it.
+        </div>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Eyebrow icon={History}>Run History</Eyebrow>
+      <ul className={styles.list}>
+        {runs.map((run, i) => {
+          const prev = runs[i + 1];
+          const dHp = prev ? run.peakHp - prev.peakHp : 0;
+          const tone = !prev || dHp === 0 ? 'flat' : dHp > 0 ? 'up' : 'down';
+          const changed = prev ? diffMeasuredInputs(prev.inputs, run.inputs) : [];
+          const pinned = run.id === pinnedRunId;
+          return (
+            <li key={run.id} className={styles.row} data-pinned={pinned}>
+              <div>
+                <div className={styles.ordinal}>Run {run.n}</div>
+                <div className={styles.when}>{relativeTime(run.at, now)}</div>
+              </div>
+              <svg className={styles.spark} viewBox={`0 0 ${SPARK_W} ${SPARK_H}`} aria-hidden="true">
+                <path className={styles.sparkLine} d={sparklinePath(run.points, SPARK_W, SPARK_H)} />
+              </svg>
+              <div>
+                <div className={styles.peaks}>{Math.round(run.peakHp)} whp · {Math.round(run.peakTq)} lb-ft</div>
+                <div className={styles.delta} data-tone={tone}>
+                  {prev ? `${dHp > 0 ? '+' : ''}${Math.round(dHp)} whp vs Run ${prev.n}` : 'first pull'}
+                  {run.knocks > 0 && <span className={styles.knocks}> · {run.knocks} knock{run.knocks === 1 ? '' : 's'}</span>}
+                </div>
+              </div>
+              <button
+                type="button"
+                className={styles.pin}
+                data-on={pinned}
+                aria-label={pinned ? `Unpin run ${run.n}` : `Pin run ${run.n} as the comparison`}
+                onClick={() => dispatch(pinned ? { type: ACTIONS.UNPIN_RUN } : { type: ACTIONS.PIN_RUN, id: run.id })}
+              >
+                <Pin size={12} />
+              </button>
+              {changed.length > 0 && (
+                <div className={styles.changed}>Changed since Run {prev.n}: {changed.join(', ')}</div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </>
+  );
+}

--- a/src/ui/screens/dyno/HistoryScreen.module.css
+++ b/src/ui/screens/dyno/HistoryScreen.module.css
@@ -1,0 +1,96 @@
+/* DYNO > HISTORY — the run log timeline. Tokens only; no literal colours. */
+
+.empty {
+  font-size: 12.5px;
+  color: var(--ink2);
+  background: var(--panel2);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 14px;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.row {
+  display: grid;
+  grid-template-columns: auto 1fr auto auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: var(--panel2);
+  border: 1px solid var(--line);
+}
+.row[data-pinned='true'] {
+  border-color: var(--acc);
+  background: var(--acc-bg);
+}
+
+.ordinal {
+  font-size: 11px;
+  font-weight: 800;
+  color: var(--ink-soft);
+}
+
+.when {
+  font-size: 10px;
+  color: var(--ink3);
+}
+
+.spark {
+  width: 84px;
+  height: 22px;
+}
+.sparkLine {
+  fill: none;
+  stroke: var(--acc);
+  stroke-width: 1.5;
+}
+
+.peaks {
+  font-size: 12px;
+  font-weight: 800;
+  color: var(--ink);
+  white-space: nowrap;
+}
+
+.delta {
+  font-size: 11px;
+  white-space: nowrap;
+}
+.delta[data-tone='up'] { color: var(--ok); }
+.delta[data-tone='down'] { color: var(--danger-ink); }
+.delta[data-tone='flat'] { color: var(--ink2); }
+
+.changed {
+  grid-column: 1 / -1;
+  font-size: 10.5px;
+  color: var(--ink2);
+}
+
+.knocks {
+  font-size: 10.5px;
+  color: var(--danger-ink);
+}
+
+.pin {
+  padding: 6px 9px;
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 800;
+  border: 1px solid var(--line);
+  background: var(--panel3);
+  color: var(--ink2);
+}
+.pin[data-on='true'] {
+  border-color: var(--acc);
+  background: var(--acc-bg);
+  color: var(--acc-ink);
+}

--- a/src/ui/screens/dyno/HistoryScreen.module.css
+++ b/src/ui/screens/dyno/HistoryScreen.module.css
@@ -44,6 +44,11 @@
   color: var(--ink3);
 }
 
+.label {
+  font-size: 10px;
+  color: var(--ink3);
+}
+
 .spark {
   width: 84px;
   height: 22px;

--- a/src/ui/screens/dyno/ResultScreen.jsx
+++ b/src/ui/screens/dyno/ResultScreen.jsx
@@ -14,6 +14,12 @@
  * too); `dynoChartMaxRpm` itself has exactly one reader — this screen's two chart
  * axes — so it is computed here off the `engineDerived` prop rather than
  * threaded down as its own value.
+ *
+ * The ghost lines take each live series' own colour at half opacity rather than a
+ * neutral grey. `T.ink3` — what they used to use — is also the axis, tick-label and
+ * `afrCommanded` colour, so the previous pull was not too dim to see so much as
+ * indistinguishable from the chart's furniture. Hue now carries series identity and
+ * opacity carries time.
  */
 
 import React from 'react';
@@ -21,7 +27,6 @@ import React from 'react';
 import { CartesianGrid, Legend, Line, LineChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts';
 
 import { Panel } from '../../primitives/Panel.jsx';
-import { useSession } from '../../state/StoreProvider.jsx';
 import { T } from '../../theme.js';
 
 import styles from './ResultScreen.module.css';
@@ -30,11 +35,11 @@ import styles from './ResultScreen.module.css';
  * @param {object} props
  * @param {Array<object>} props.chartData the shell's, shared with TUNE's ECU screen
  * @param {{redline: number}} props.engineDerived the shell's — see file header
+ * @param {string|null} [props.ghostLabel] what to call the comparison series in the
+ *   legend, or null/undefined to draw no ghost at all — see `ghostLabel` in runLog.js
  * @returns {React.ReactElement}
  */
-export function ResultScreen({ chartData, engineDerived }) {
-  const [session] = useSession();
-  const { prevResult } = session;
+export function ResultScreen({ chartData, engineDerived, ghostLabel }) {
   // The live tach needle and this chart's RPM axis both used to top out at a
   // hardcoded 7500 — correct only for the one preset whose redline happened to
   // match it. 1.05x redline gives the sweep's last point a little headroom
@@ -52,8 +57,8 @@ export function ResultScreen({ chartData, engineDerived }) {
             <YAxis stroke={T.ink3} fontSize={10} />
             <Tooltip contentStyle={{ background: T.panel2, border: `1px solid ${T.line}`, fontSize: 11 }} />
             <Legend wrapperStyle={{ fontSize: 11 }} />
-            {prevResult && <Line dataKey="prevHp" name="Prev WHP" stroke={T.ink3} strokeDasharray="4 3" dot={false} isAnimationActive={false} />}
-            {prevResult && <Line dataKey="prevTorque" name="Prev TQ" stroke={T.ink3} strokeDasharray="4 3" dot={false} isAnimationActive={false} />}
+            {ghostLabel && <Line dataKey="prevHp" name={`${ghostLabel} WHP`} stroke={T.acc} strokeWidth={1.5} strokeDasharray="5 4" opacity={0.5} dot={false} isAnimationActive={false} />}
+            {ghostLabel && <Line dataKey="prevTorque" name={`${ghostLabel} TQ`} stroke={T.cyan} strokeWidth={1.5} strokeDasharray="5 4" opacity={0.5} dot={false} isAnimationActive={false} />}
             <Line dataKey="hp" name="WHP" stroke={T.acc} strokeWidth={2} dot={false} isAnimationActive={false} />
             <Line dataKey="torque" name="Torque" stroke={T.cyan} strokeWidth={2} dot={false} isAnimationActive={false} />
           </LineChart>

--- a/src/ui/state/initialState.js
+++ b/src/ui/state/initialState.js
@@ -94,6 +94,11 @@ import {
  * @property {boolean} running true while a dyno pull is sweeping
  * @property {object|null} result the most recent dyno pull's result
  * @property {object|null} prevResult the dyno pull before that, for comparison
+ * @property {import('./runLog.js').RunRecord[]} runs the last RUN_LIMIT dyno pulls,
+ *   newest first. Named `runs` and not "history" because `state.history` is the undo
+ *   stack — see HistoryState below.
+ * @property {string|null} pinnedRunId the run the ghost curve compares against, or
+ *   null to compare against the previous run
  * @property {PullScores|null} pullScores the scores the last pull MEASURED, banked at
  *   pull time and never recomputed — see the typedef, and BANK_PULL in reducer.js
  * @property {number} revealCount how much of the current result has been revealed
@@ -179,6 +184,8 @@ export function makeInitialState() {
       running: false,
       result: null,
       prevResult: null,
+      runs: [],
+      pinnedRunId: null,
       pullScores: null,
       revealCount: 0,
       bestScore: 0,

--- a/src/ui/state/initialState.js
+++ b/src/ui/state/initialState.js
@@ -93,7 +93,6 @@ import {
  * @typedef {object} SessionState
  * @property {boolean} running true while a dyno pull is sweeping
  * @property {object|null} result the most recent dyno pull's result
- * @property {object|null} prevResult the dyno pull before that, for comparison
  * @property {import('./runLog.js').RunRecord[]} runs the last RUN_LIMIT dyno pulls,
  *   newest first. Named `runs` and not "history" because `state.history` is the undo
  *   stack — see HistoryState below.
@@ -183,7 +182,6 @@ export function makeInitialState() {
     session: {
       running: false,
       result: null,
-      prevResult: null,
       runs: [],
       pinnedRunId: null,
       pullScores: null,

--- a/src/ui/state/pullSignature.js
+++ b/src/ui/state/pullSignature.js
@@ -1,11 +1,24 @@
 /**
- * The identity of the configuration a dyno pull was measured on.
+ * The identity of a dyno pull's configuration, and the difference between two of them.
  *
  * A score is a MEASUREMENT. It is taken once, on one specific car, and it stays what
  * it was — so the app banks the scores a pull produced (see BANK_PULL) instead of
  * recomputing them from whatever is selected later. That leaves one question the
  * banked numbers cannot answer by themselves: is the car on screen still the car they
- * were measured on? This module answers exactly that and nothing else.
+ * were measured on? {@link pullSignature} answers exactly that.
+ *
+ * WHY THIS FILE NOW ANSWERS "WHICH ONE" TOO
+ * This header used to state that the module answers "has any measured input moved?"
+ * and never "which one", on the grounds that a hand-written field-by-field comparison
+ * would drift out of sync with the signature as fields were added. That reasoning was
+ * right about the hazard and wrong about the conclusion. The run-history timeline needs
+ * "which one" — it reports what changed between one pull and the one before it — and
+ * the drift is avoided by keeping BOTH answers here, over ONE private key list, rather
+ * than by refusing to answer. Add a field to MEASURED_BUILD_KEYS and it is signed and
+ * diffed in the same edit. The alternative that was rejected — exporting the key arrays
+ * so another module could diff — would have let a test derive its expectations from the
+ * thing under test, which is the trap `history.js` keeps its own key lists private to
+ * avoid.
  *
  * WHAT COUNTS AS "THE SAME CAR"
  * Every input the pull was actually computed from — everything `simulateSweep` reads
@@ -22,7 +35,6 @@
  * simulation, so none of them can change a number.
  *
  * WHY A SIGNATURE AND NOT A DEEP COMPARE
- * The only question asked of it is "has any measured input moved?", never "which one".
  * A string compare answers that in one operation and cannot drift out of sync with a
  * hand-written field-by-field comparison as fields are added.
  *
@@ -58,6 +70,31 @@ const MEASURED_BUILD_KEYS = [
 const MEASURED_TUNE_KEYS = ['ve', 'timing', 'afr'];
 
 /**
+ * Display names for every measured input, for the run-history timeline's "what
+ * changed" line. A key with no label throws rather than rendering a blank row — the
+ * same call `labelFor` makes in reducer.js, and for the same reason: a silently
+ * missing label is a field the player is never told about.
+ */
+const INPUT_LABELS = {
+  engineConfig: 'engine',
+  mods: 'bolt-ons',
+  turboOn: 'turbo',
+  boostCurve: 'boost curve',
+  octaneIdx: 'fuel',
+  injIdx: 'injectors',
+  mafScalar: 'MAF scaling',
+  turbineIdx: 'turbine',
+  turbineCount: 'turbine count',
+  compressorIdx: 'compressor',
+  exhaustDiaIdx: 'exhaust',
+  ecuInjectorCc: 'ECU injector size',
+  ve: 'VE table',
+  timing: 'timing table',
+  afr: 'AFR table',
+  loadKpa: 'dyno load',
+};
+
+/**
  * Signs the configuration a pull would be — or was — run on.
  *
  * `loadKpa` is passed as a bare value rather than the SESSION slice it lives on, and
@@ -79,4 +116,57 @@ export function pullSignature(build, tune, loadKpa) {
     MEASURED_TUNE_KEYS.map((k) => /** @type {any} */ (tune)[k]),
     loadKpa,
   ]);
+}
+
+/**
+ * Projects a configuration down to exactly the inputs a pull is a function of.
+ *
+ * This is the form a {@link import('./runLog.js').RunRecord} stores, so that two runs
+ * can be compared later without keeping the whole build and tune slices — and without
+ * a second list of "what matters" that could disagree with this one.
+ *
+ * @param {import('./initialState.js').BuildState} build
+ * @param {import('./initialState.js').TuneState} tune
+ * @param {number} loadKpa
+ * @returns {{build: object, tune: object, loadKpa: number}}
+ */
+export function measuredInputs(build, tune, loadKpa) {
+  /** @type {Record<string, *>} */
+  const b = {};
+  for (const k of MEASURED_BUILD_KEYS) b[k] = /** @type {any} */ (build)[k];
+  /** @type {Record<string, *>} */
+  const t = {};
+  for (const k of MEASURED_TUNE_KEYS) t[k] = /** @type {any} */ (tune)[k];
+  return { build: b, tune: t, loadKpa };
+}
+
+/**
+ * Names every measured input that differs between two projections.
+ *
+ * Values are compared by their JSON, not by reference: the calibration tables are
+ * cloned on almost every write, so a reference compare would report all three as
+ * changed on every pull, and an `===` on the outer array would miss a changed cell
+ * entirely. This inherits {@link pullSignature}'s documented and acceptable error in
+ * the same direction — two equal objects whose keys were inserted in different orders
+ * compare as different — and, like the signature, it can never report a real change as
+ * no change.
+ *
+ * @param {ReturnType<typeof measuredInputs>} a
+ * @param {ReturnType<typeof measuredInputs>} b
+ * @returns {string[]} display labels, empty when every measured input is equal
+ */
+export function diffMeasuredInputs(a, b) {
+  const changed = [];
+  for (const k of MEASURED_BUILD_KEYS) {
+    if (JSON.stringify(a.build?.[k]) !== JSON.stringify(b.build?.[k])) changed.push(k);
+  }
+  for (const k of MEASURED_TUNE_KEYS) {
+    if (JSON.stringify(a.tune?.[k]) !== JSON.stringify(b.tune?.[k])) changed.push(k);
+  }
+  if (a.loadKpa !== b.loadKpa) changed.push('loadKpa');
+  return changed.map((k) => {
+    const label = INPUT_LABELS[k];
+    if (!label) throw new Error(`diffMeasuredInputs: no label defined for measured input "${k}"`);
+    return label;
+  });
 }

--- a/src/ui/state/pullSignature.js
+++ b/src/ui/state/pullSignature.js
@@ -161,12 +161,12 @@ export function measuredInputs(build, tune, loadKpa) {
 export function diffMeasuredInputs(a, b) {
   const changed = [];
   for (const k of MEASURED_BUILD_KEYS) {
-    if (JSON.stringify(a.build?.[k]) !== JSON.stringify(b.build?.[k])) changed.push(k);
+    if (JSON.stringify(a?.build?.[k]) !== JSON.stringify(b?.build?.[k])) changed.push(k);
   }
   for (const k of MEASURED_TUNE_KEYS) {
-    if (JSON.stringify(a.tune?.[k]) !== JSON.stringify(b.tune?.[k])) changed.push(k);
+    if (JSON.stringify(a?.tune?.[k]) !== JSON.stringify(b?.tune?.[k])) changed.push(k);
   }
-  if (a.loadKpa !== b.loadKpa) changed.push('loadKpa');
+  if (a?.loadKpa !== b?.loadKpa) changed.push('loadKpa');
   return changed.map((k) => {
     const label = INPUT_LABELS[k];
     if (!label) throw new Error(`diffMeasuredInputs: no label defined for measured input "${k}"`);

--- a/src/ui/state/pullSignature.js
+++ b/src/ui/state/pullSignature.js
@@ -35,8 +35,11 @@
  * simulation, so none of them can change a number.
  *
  * WHY A SIGNATURE AND NOT A DEEP COMPARE
- * A string compare answers that in one operation and cannot drift out of sync with a
- * hand-written field-by-field comparison as fields are added.
+ * The only question asked of `pullSignature` itself is "has any measured input moved?",
+ * never "which one" — {@link diffMeasuredInputs} answers that separately, and over the
+ * same key lists so the two can never disagree. A string compare answers the "has it
+ * moved" question in one operation and cannot drift out of sync with a hand-written
+ * field-by-field comparison as fields are added.
  *
  * THE ERROR IT IS ALLOWED TO MAKE, AND THE ONE IT IS NOT
  * `JSON.stringify` serialises object keys in insertion order, so two `engineConfig`

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -571,7 +571,12 @@ function baseReducer(state, action) {
           // front — same newest-first convention `pushRun` keeps for BANK_PULL.
           runs: [...s.runs, ...c.runs].slice(0, RUN_LIMIT),
           // A pin set THIS session (impossible before the restore lands, except during
-          // the very race this action exists to survive) wins over a restored one.
+          // the very race this action exists to survive) wins over a restored one. NOTE:
+          // null means both "never touched" and "deliberately cleared", so an unpin
+          // performed between BANK_PULL and RESTORE_CAREER is indistinguishable from no
+          // pin ever being set, and a stale saved pin will resurface. This edge is
+          // accepted rather than fixed with a tri-state; the restore race is rare and
+          // the workaround (clicking the pin again) is trivial.
           pinnedRunId: s.pinnedRunId ?? c.pinnedRunId,
         },
       };

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -186,16 +186,15 @@ export const ACTIONS = Object.freeze({
  */
 
 /**
- * Finalises a completed dyno pull: banks the score, wears the engine, and rotates
- * `result` into `prevResult`. Mirrors the tail of `doRun` (`EcuLab.jsx:868-896`) —
+ * Finalises a completed dyno pull: banks the score, wears the engine, installs the
+ * new `result`, and pushes a slim record of it to the front of `runs` (Task 4;
+ * `runLog.js`'s `ghostRun` reads that log for the comparison the old `prevResult`
+ * field used to hold directly). Mirrors the tail of `doRun` (`EcuLab.jsx:868-896`) —
  * NOT the whole function, which also flips `running`/`revealCount` for the reveal
  * animation before and after an interval-driven timer runs; that is time-based UI
  * state with no atomicity hazard and stays as plain `SET_SESSION_FIELD` dispatches in
- * the component (Task 4). The part that DOES have an ordering hazard, and is what this
- * action removes: `doRun` used to call `setPrevResult(result)` (the OLD result)
- * before `setResult(r)` (the new one) — reversing those two lines would silently have
- * made `prevResult` equal the new result instead of the old one. `action.result` and
- * `action.pullScore` are precomputed by the caller: `result` comes from
+ * the component. `action.result` and `action.pullScore` are precomputed by the
+ * caller: `result` comes from
  * `simulateSweep`, and `pullScore` from `computePullScore`, which needs derived
  * hardware objects (`turbine`, `compressor`, `dutyPreview`, `exhaustDiaError`) that
  * are `useMemo` values in the component, not raw state the reducer holds — the same
@@ -447,7 +446,6 @@ function baseReducer(state, action) {
           // result they belong to — leaving them behind would put a scorecard on
           // screen with no dyno curve under it.
           result: null,
-          prevResult: null,
           pullScores: null,
         },
       };
@@ -487,12 +485,13 @@ function baseReducer(state, action) {
         ...state,
         session: {
           ...state.session,
-          // The OLD result becomes prevResult BEFORE the new one overwrites `result` —
-          // reversing this order would silently make prevResult equal the new result.
-          prevResult: state.session.result,
           result: action.result,
           // The record is built by the caller, not here: it needs `Date.now()` for its
           // id and timestamp, and this reducer is documented as calling no clock.
+          //
+          // The banked run goes in front, so runs[0] is always the pull `result` now
+          // holds and runs[1] is the one before it — the ordering the old
+          // prevResult-before-result rotation existed to get right.
           runs: pushRun(state.session.runs, action.run),
           health: {
             piston: clamp(state.session.health.piston - action.result.wear.piston, 0, 100),

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -30,7 +30,7 @@ import { clamp, clone2D, DEFAULT_AFR, DEFAULT_MODS, DEFAULT_TIMING, liveStep, pr
 import {
   HISTORY_LIMIT, RESTORE_ALL, RESTORE_CALIBRATION, restore, snapshot, snapshotsTuneField,
 } from './history.js';
-import { pushRun } from './runLog.js';
+import { pushRun, RUN_LIMIT } from './runLog.js';
 
 /** @typedef {import('./initialState.js').StoreState} StoreState */
 /** @typedef {import('./initialState.js').BuildState} BuildState */
@@ -56,6 +56,7 @@ export const ACTIONS = Object.freeze({
   RESET_TO_STOCK: 'RESET_TO_STOCK',
   REPAIR_ENGINE: 'REPAIR_ENGINE',
   BANK_PULL: 'BANK_PULL',
+  RESTORE_CAREER: 'RESTORE_CAREER',
   PIN_RUN: 'PIN_RUN',
   UNPIN_RUN: 'UNPIN_RUN',
   LIVE_STEP: 'LIVE_STEP',
@@ -216,6 +217,47 @@ export const ACTIONS = Object.freeze({
  */
 
 /**
+ * Merges a career loaded from storage into the CURRENT session, rather than
+ * overwriting it. Replaces five `SET_SESSION_FIELD` dispatches EcuLab.jsx used to fire
+ * after `await loadCareer()` resolved — the same reasoning `BANK_PULL` and
+ * `APPLY_PRESET` already document for why a cross-field write is one action instead of
+ * a sequence: five separate dispatches have an ordering hazard a single pass does not.
+ *
+ * Here the hazard is a race, not intra-render ordering: `loadCareer()` is an `await`,
+ * so a pull can bank (`BANK_PULL`) between mount and this action landing. On the
+ * `artifact` storage backend `window.storage.get` is a real round trip a human
+ * interaction can land inside, not just a stray microtask, so this is reachable in
+ * practice, not merely in theory. Overwriting the session with the loaded snapshot in
+ * that window would roll a real, already-banked pull back to whatever was saved before
+ * it — and because career persistence is itself a reactive effect over these same
+ * fields (not the old imperative call inside `doRun`), the rollback would not stop at
+ * the screen: the persistence effect would write the rolled-back snapshot straight
+ * back to disk, destroying the banked pull permanently.
+ *
+ * The fix is a merge, not a skip. Skipping the restore when something banked first
+ * would leave the session holding ONLY this-session values — a `bestScore` from one
+ * pull, a `totalScore` from one pull — and the persistence effect would then write
+ * that truncated career over the real saved one, which is the same data loss by a
+ * different door. Merging instead means every term below combines "what was saved"
+ * with "what happened this session since mount":
+ *  - `bestScore`: the higher of the two.
+ *  - `totalScore` / `pullCount`: summed — the session started at zero, so its value
+ *    IS what happened since mount.
+ *  - `runs`: the session's own runs (newer) in front of the loaded ones, capped at
+ *    {@link RUN_LIMIT} the same way `pushRun` caps `BANK_PULL`'s write.
+ *  - `pinnedRunId`: a pin the player set this session wins over a restored one — they
+ *    cannot have pinned anything before the restore lands, so a non-null session value
+ *    here can only mean they pinned it AFTER banking, during the same race window.
+ *
+ * In the common case — nothing banked before the load resolves — the session is still
+ * at its zeroed initial values, so every one of those merges reduces to the loaded
+ * value exactly: `max(loaded, 0) === loaded`, `loaded + 0 === loaded`,
+ * `[...[], ...loaded] === loaded`-shaped, `null ?? loaded === loaded`. One code path
+ * handles both, with no `if (pristine)` branch to fall out of sync with the other.
+ * @typedef {{type: 'RESTORE_CAREER', career: import('../../storage.js').Career}} RestoreCareerAction
+ */
+
+/**
  * Pins one banked run as the ghost curve's comparison. Holds the run's `id` rather
  * than its index: eviction shifts every index, so an index-based pin would silently
  * repoint at a run the player never chose.
@@ -284,14 +326,15 @@ export const ACTIONS = Object.freeze({
 /**
  * The union of every action shape the reducer actually understands. Deliberately has
  * NO catch-all `{type: string, [key: string]: *}` member: with one, every object
- * shape is assignable to `StoreAction` and the nineteen specific typedefs above become
+ * shape is assignable to `StoreAction` and the twenty specific typedefs above become
  * decorative — a typo'd payload key (`presset` instead of `preset`) would typecheck
  * clean. Without the catch-all, `tsc` must reject it.
  * @typedef {SetBuildFieldAction | ClearPresetIdAction | SetTurbineAction | SetTableAction |
  *   SetSessionFieldAction | SetTuneFieldAction | SetBoostSelAction |
  *   SetPresetPromptAction | SetEngineConfigPatchAction | ApplyPresetAction |
- *   ResetToStockAction | RepairEngineAction | BankPullAction | PinRunAction |
- *   UnpinRunAction | LiveStepAction | LivePatchAction | UndoAction | RedoAction
+ *   ResetToStockAction | RepairEngineAction | BankPullAction | RestoreCareerAction |
+ *   PinRunAction | UnpinRunAction | LiveStepAction | LivePatchAction | UndoAction |
+ *   RedoAction
  * } KnownStoreAction
  */
 
@@ -513,6 +556,26 @@ function baseReducer(state, action) {
           pullCount: state.session.pullCount + 1,
         },
       };
+
+    case ACTIONS.RESTORE_CAREER: {
+      const c = action.career;
+      const s = state.session;
+      return {
+        ...state,
+        session: {
+          ...s,
+          bestScore: Math.max(c.best, s.bestScore),
+          totalScore: c.total + s.totalScore,
+          pullCount: c.pulls + s.pullCount,
+          // Anything banked this session is newer than anything loaded, so it goes in
+          // front — same newest-first convention `pushRun` keeps for BANK_PULL.
+          runs: [...s.runs, ...c.runs].slice(0, RUN_LIMIT),
+          // A pin set THIS session (impossible before the restore lands, except during
+          // the very race this action exists to survive) wins over a restored one.
+          pinnedRunId: s.pinnedRunId ?? c.pinnedRunId,
+        },
+      };
+    }
 
     case ACTIONS.PIN_RUN:
       return { ...state, session: { ...state.session, pinnedRunId: action.id } };

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -30,6 +30,7 @@ import { clamp, clone2D, DEFAULT_AFR, DEFAULT_MODS, DEFAULT_TIMING, liveStep, pr
 import {
   HISTORY_LIMIT, RESTORE_ALL, RESTORE_CALIBRATION, restore, snapshot, snapshotsTuneField,
 } from './history.js';
+import { pushRun } from './runLog.js';
 
 /** @typedef {import('./initialState.js').StoreState} StoreState */
 /** @typedef {import('./initialState.js').BuildState} BuildState */
@@ -55,6 +56,8 @@ export const ACTIONS = Object.freeze({
   RESET_TO_STOCK: 'RESET_TO_STOCK',
   REPAIR_ENGINE: 'REPAIR_ENGINE',
   BANK_PULL: 'BANK_PULL',
+  PIN_RUN: 'PIN_RUN',
+  UNPIN_RUN: 'UNPIN_RUN',
   LIVE_STEP: 'LIVE_STEP',
   LIVE_PATCH: 'LIVE_PATCH',
   UNDO: 'UNDO',
@@ -209,8 +212,21 @@ export const ACTIONS = Object.freeze({
  * `wasBest` is decided HERE rather than by the caller because this case is where
  * `bestScore` moves: the comparison has to happen against the value as it stands
  * BEFORE this pull is folded in, and this is the only place that still holds it.
- * @typedef {{type: 'BANK_PULL', result: object, pullScore: number,
+ * @typedef {{type: 'BANK_PULL', result: object, pullScore: number, run: import('./runLog.js').RunRecord,
  *   scores: {tuning: object, engineer: object, signature: string}}} BankPullAction
+ */
+
+/**
+ * Pins one banked run as the ghost curve's comparison. Holds the run's `id` rather
+ * than its index: eviction shifts every index, so an index-based pin would silently
+ * repoint at a run the player never chose.
+ * @typedef {{type: 'PIN_RUN', id: string}} PinRunAction
+ */
+
+/**
+ * Drops the pin, returning the ghost to the previous run. No payload — there is only
+ * ever one pin.
+ * @typedef {{type: 'UNPIN_RUN'}} UnpinRunAction
  */
 
 /**
@@ -269,14 +285,14 @@ export const ACTIONS = Object.freeze({
 /**
  * The union of every action shape the reducer actually understands. Deliberately has
  * NO catch-all `{type: string, [key: string]: *}` member: with one, every object
- * shape is assignable to `StoreAction` and the seventeen specific typedefs above become
+ * shape is assignable to `StoreAction` and the nineteen specific typedefs above become
  * decorative — a typo'd payload key (`presset` instead of `preset`) would typecheck
  * clean. Without the catch-all, `tsc` must reject it.
  * @typedef {SetBuildFieldAction | ClearPresetIdAction | SetTurbineAction | SetTableAction |
  *   SetSessionFieldAction | SetTuneFieldAction | SetBoostSelAction |
  *   SetPresetPromptAction | SetEngineConfigPatchAction | ApplyPresetAction |
- *   ResetToStockAction | RepairEngineAction | BankPullAction | LiveStepAction |
- *   LivePatchAction | UndoAction | RedoAction
+ *   ResetToStockAction | RepairEngineAction | BankPullAction | PinRunAction |
+ *   UnpinRunAction | LiveStepAction | LivePatchAction | UndoAction | RedoAction
  * } KnownStoreAction
  */
 
@@ -475,6 +491,9 @@ function baseReducer(state, action) {
           // reversing this order would silently make prevResult equal the new result.
           prevResult: state.session.result,
           result: action.result,
+          // The record is built by the caller, not here: it needs `Date.now()` for its
+          // id and timestamp, and this reducer is documented as calling no clock.
+          runs: pushRun(state.session.runs, action.run),
           health: {
             piston: clamp(state.session.health.piston - action.result.wear.piston, 0, 100),
             bearing: clamp(state.session.health.bearing - action.result.wear.bearing, 0, 100),
@@ -495,6 +514,12 @@ function baseReducer(state, action) {
           pullCount: state.session.pullCount + 1,
         },
       };
+
+    case ACTIONS.PIN_RUN:
+      return { ...state, session: { ...state.session, pinnedRunId: action.id } };
+
+    case ACTIONS.UNPIN_RUN:
+      return { ...state, session: { ...state.session, pinnedRunId: null } };
 
     case ACTIONS.LIVE_STEP: {
       const prev = state.session.live;

--- a/src/ui/state/reducer.js
+++ b/src/ui/state/reducer.js
@@ -254,6 +254,23 @@ export const ACTIONS = Object.freeze({
  * value exactly: `max(loaded, 0) === loaded`, `loaded + 0 === loaded`,
  * `[...[], ...loaded] === loaded`-shaped, `null ?? loaded === loaded`. One code path
  * handles both, with no `if (pristine)` branch to fall out of sync with the other.
+ *
+ * NOT IDEMPOTENT. `bestScore`/`totalScore`/`pullCount` SUM, and `runs` concatenates —
+ * dispatching this twice with the same `career` double-counts every one of them and
+ * duplicates every loaded run. It must be dispatched exactly once per mount. The
+ * safety net for that today is entirely in `EcuLab.jsx`: the career-restore effect's
+ * `cancelled` flag (set on cleanup) stops a second `loadCareer()` from a re-mounted
+ * effect from ever reaching `dispatch`, and `careerLoaded.current` gates the SEPARATE
+ * save effect from writing before a restore has landed. Neither guard lives in this
+ * reducer, so a future caller of this action has nothing here stopping it from
+ * breaking that invariant.
+ *
+ * One more edge alongside the `pinnedRunId` one above, and equally rare: a pull banked
+ * DURING the restore window (between mount and `loadCareer()` resolving) gets whatever
+ * `n` the session's own pull counter was on — typically a low one, since nothing has
+ * been played yet — and can sort oddly next to the restored runs' much higher `n`
+ * values once merged. Cosmetic; the run itself is correct and in the right position
+ * (newest-first, at index 0), only its ordinal can look out of sequence.
  * @typedef {{type: 'RESTORE_CAREER', career: import('../../storage.js').Career}} RestoreCareerAction
  */
 

--- a/src/ui/state/runLog.js
+++ b/src/ui/state/runLog.js
@@ -1,0 +1,174 @@
+/**
+ * The dyno run log: what one banked pull keeps, and the operations over a list of them.
+ *
+ * WHY A SLIM RECORD
+ * A full `simulateSweep` result is 46,459 bytes of JSON — 61 points of 50 fields each.
+ * The three things a timeline row and a ghost curve actually need are 2,258 bytes. At
+ * twenty runs that is the difference between ~1 MB of localStorage and ~80 KB, so the
+ * record stores the projection and not the result.
+ *
+ * WHY `knocks` IS A STORED COUNT AND NOT A DERIVED ONE
+ * The delta panel on DYNO compares knock counts between the current pull and the one
+ * before it. A slim record has no `events` array to count, so the count is taken once,
+ * at bank time, from the result that still has one.
+ *
+ * NAMING: this is `runs`, never "history". `state.history` is the undo stack.
+ *
+ * This module imports nothing from `reducer.js`, the same discipline `history.js`
+ * keeps and for the same reason: the reducer imports this.
+ */
+
+/**
+ * How many runs the log keeps. Twenty at ~4 KB each is ~80 KB, comfortably inside a
+ * ~5 MB localStorage budget while leaving room for a career's other state.
+ */
+export const RUN_LIMIT = 20;
+
+/**
+ * @typedef {object} RunPoint
+ * @property {number} rpm
+ * @property {number} hp
+ * @property {number} torque
+ */
+
+/**
+ * @typedef {object} RunRecord
+ * @property {string} id unique and stable for the life of the record. A pin holds an
+ *   id rather than an index precisely so that evicting OTHER runs cannot silently
+ *   repoint it at a run the player never chose.
+ * @property {number} n the career pull ordinal, for display ("Run 12").
+ * @property {number} at epoch ms, for the row's relative timestamp.
+ * @property {string} label the engine's name at the time of the pull.
+ * @property {number} peakHp
+ * @property {number} peakTq
+ * @property {number} knocks how many `type: 'knock'` events the pull logged.
+ * @property {{tuning: number, engineer: number, pull: number}} scores
+ * @property {RunPoint[]} points
+ * @property {{build: object, tune: object, loadKpa: number}} inputs the measured
+ *   configuration, as `measuredInputs` in pullSignature.js projects it.
+ */
+
+/**
+ * Builds a record from a completed pull.
+ *
+ * `id`, `n` and `at` are the CALLER's to supply. The reducer that consumes this is
+ * documented as calling no `Date.now()` — it must stay a pure function of
+ * `(state, action)` — so the clock is read at the dispatch site and travels on the
+ * action, the same "caller computes, reducer applies" split `RESET_TO_STOCK`'s `ve`
+ * and `BANK_PULL`'s `pullScore` already use.
+ *
+ * @param {object} args
+ * @param {string} args.id
+ * @param {number} args.n
+ * @param {number} args.at
+ * @param {string} args.label
+ * @param {{peakHp: number, peakTq: number, points: object[], events: {type?: string}[]}} args.result
+ * @param {{tuning: {score: number}, engineer: {score: number}}} args.scores
+ * @param {number} args.pullScore
+ * @param {{build: object, tune: object, loadKpa: number}} args.inputs
+ * @returns {RunRecord}
+ */
+export function makeRunRecord({ id, n, at, label, result, scores, pullScore, inputs }) {
+  return {
+    id,
+    n,
+    at,
+    label,
+    peakHp: result.peakHp,
+    peakTq: result.peakTq,
+    knocks: result.events.filter((e) => e.type === 'knock').length,
+    scores: { tuning: scores.tuning.score, engineer: scores.engineer.score, pull: pullScore },
+    points: result.points.map((p) => ({ rpm: p.rpm, hp: p.hp, torque: p.torque })),
+    inputs,
+  };
+}
+
+/**
+ * Adds a run to the front of the log, capped at {@link RUN_LIMIT}.
+ *
+ * Newest-first, so the run just banked is index 0 and eviction drops the TAIL — the
+ * oldest run. Returns a new array; the input is never mutated.
+ *
+ * @param {RunRecord[]} runs
+ * @param {RunRecord} record
+ * @returns {RunRecord[]}
+ */
+export function pushRun(runs, record) {
+  return [record, ...runs].slice(0, RUN_LIMIT);
+}
+
+/**
+ * The run the ghost curve should draw.
+ *
+ * A pin wins when the run it names is still in the log. When it is not — the pinned
+ * run has aged out past {@link RUN_LIMIT} — this falls back to the previous run rather
+ * than returning nothing, because a pin quietly expiring should not also take the
+ * default comparison with it.
+ *
+ * `runs[1]`, not `runs[0]`: index 0 is the pull just banked, which is the same pull
+ * the chart is drawing live.
+ *
+ * Pinning `runs[0]` is legitimate and deliberately not special-cased — "make this my
+ * benchmark, now go tune" is the main reason to pin at all, and from the next pull
+ * onward that run is no longer index 0.
+ *
+ * @param {RunRecord[]} runs
+ * @param {string|null} pinnedRunId
+ * @returns {RunRecord|null}
+ */
+export function ghostRun(runs, pinnedRunId) {
+  if (pinnedRunId != null) {
+    const pinned = runs.find((r) => r.id === pinnedRunId);
+    if (pinned) return pinned;
+  }
+  return runs[1] ?? null;
+}
+
+/**
+ * What the chart legend calls the ghost series.
+ *
+ * This lives here rather than as an expression at the JSX call site so that both of
+ * its branches can be watched failing. It has two: a pinned run is named, and anything
+ * else is "Prev". The distinction is load-bearing — a chart that labelled the default
+ * comparison as a pin would tell the player they had chosen a benchmark they had not.
+ *
+ * Takes the already-resolved run rather than the list, so it cannot disagree with
+ * {@link ghostRun} about which run is being drawn: when the pin names an evicted run,
+ * `ghostRun` falls back to the previous run and this labels it "Prev", because that is
+ * what it now is.
+ *
+ * @param {RunRecord|null} run the run {@link ghostRun} resolved
+ * @param {string|null} pinnedRunId
+ * @returns {string|null} null when there is no ghost to draw
+ */
+export function ghostLabel(run, pinnedRunId) {
+  if (!run) return null;
+  return pinnedRunId != null && run.id === pinnedRunId ? `Run ${run.n}` : 'Prev';
+}
+
+/**
+ * SVG path data for a timeline row's power sparkline, scaled to fill the box.
+ *
+ * Pure and DOM-free so the geometry is unit-testable. A flat curve has no range to
+ * scale against, so the span floors at 1 and the line renders along the bottom edge
+ * rather than as `NaN`, which would draw nothing and report nothing.
+ *
+ * @param {RunPoint[]} points
+ * @param {number} width
+ * @param {number} height
+ * @returns {string} path data, or '' when there is nothing to draw
+ */
+export function sparklinePath(points, width, height) {
+  if (!points || points.length === 0) return '';
+  const hps = points.map((p) => p.hp);
+  const min = Math.min(...hps);
+  const span = Math.max(...hps) - min || 1;
+  const stepX = points.length > 1 ? width / (points.length - 1) : 0;
+  return points
+    .map((p, i) => {
+      const x = i * stepX;
+      const y = height - ((p.hp - min) / span) * height;
+      return `${i === 0 ? 'M' : 'L'}${x.toFixed(2)},${y.toFixed(2)}`;
+    })
+    .join(' ');
+}

--- a/src/ui/state/runLog.js
+++ b/src/ui/state/runLog.js
@@ -42,7 +42,10 @@ export const RUN_LIMIT = 20;
  * @property {number} peakHp
  * @property {number} peakTq
  * @property {number} knocks how many `type: 'knock'` events the pull logged.
- * @property {{tuning: number, engineer: number, pull: number}} scores
+ * @property {{tuning: number, engineer: number, pull: number}} scores banked so a
+ *   later PR can show a run's scorecard from the log without re-deriving it. Nothing
+ *   under `src/` reads this field yet — HISTORY's own row shows `peakHp`/`peakTq`, not
+ *   these — it is deliberately here ahead of its reader for PR 5b/5c, not dead weight.
  * @property {RunPoint[]} points
  * @property {{build: object, tune: object, loadKpa: number}} inputs the measured
  *   configuration, as `measuredInputs` in pullSignature.js projects it.

--- a/tests/storage.test.js
+++ b/tests/storage.test.js
@@ -23,17 +23,17 @@ describe('storage adapter', () => {
   });
 
   it('returns zeroed stats when nothing has been saved', async () => {
-    expect(await loadCareer()).toEqual({ best: 0, total: 0, pulls: 0 });
+    expect(await loadCareer()).toEqual({ best: 0, total: 0, pulls: 0, runs: [], pinnedRunId: null });
   });
 
   it('round-trips career stats', async () => {
     expect(await saveCareer({ best: 812, total: 4310, pulls: 27 })).toBe(true);
-    expect(await loadCareer()).toEqual({ best: 812, total: 4310, pulls: 27 });
+    expect(await loadCareer()).toEqual({ best: 812, total: 4310, pulls: 27, runs: [], pinnedRunId: null });
   });
 
   it('coerces missing fields rather than persisting undefined', async () => {
     await saveCareer({ best: 100 });
-    expect(await loadCareer()).toEqual({ best: 100, total: 0, pulls: 0 });
+    expect(await loadCareer()).toEqual({ best: 100, total: 0, pulls: 0, runs: [], pinnedRunId: null });
   });
 
   it('survives a corrupt save instead of crashing the app', async () => {
@@ -41,7 +41,7 @@ describe('storage adapter', () => {
     // Simulate a truncated or hand-edited value.
     const localish = { getItem: () => '{not json', setItem: () => {}, removeItem: () => {} };
     vi.stubGlobal('localStorage', localish);
-    expect(await loadCareer()).toEqual({ best: 0, total: 0, pulls: 0 });
+    expect(await loadCareer()).toEqual({ best: 0, total: 0, pulls: 0, runs: [], pinnedRunId: null });
   });
 
   it('uses localStorage when it is available and writable', async () => {
@@ -53,7 +53,7 @@ describe('storage adapter', () => {
     });
     expect(storageBackend()).toBe('local');
     await saveCareer({ best: 42, total: 42, pulls: 1 });
-    expect(JSON.parse(store.get('career'))).toEqual({ best: 42, total: 42, pulls: 1 });
+    expect(JSON.parse(store.get('career'))).toEqual({ best: 42, total: 42, pulls: 1, runs: [], pinnedRunId: null });
   });
 
   it('degrades to memory when localStorage throws on write (Safari private mode)', () => {
@@ -75,7 +75,7 @@ describe('storage adapter', () => {
     });
     expect(storageBackend()).toBe('artifact');
     await saveCareer({ best: 7, total: 9, pulls: 2 });
-    expect(await loadCareer()).toEqual({ best: 7, total: 9, pulls: 2 });
+    expect(await loadCareer()).toEqual({ best: 7, total: 9, pulls: 2, runs: [], pinnedRunId: null });
   });
 
   it('reports failure rather than throwing when a backend rejects', async () => {
@@ -86,6 +86,40 @@ describe('storage adapter', () => {
       },
     });
     expect(await saveCareer({ best: 1, total: 1, pulls: 1 })).toBe(false);
-    expect(await loadCareer()).toEqual({ best: 0, total: 0, pulls: 0 });
+    expect(await loadCareer()).toEqual({ best: 0, total: 0, pulls: 0, runs: [], pinnedRunId: null });
+  });
+});
+
+describe('run log persistence', () => {
+  it('returns an empty log when nothing has been saved', async () => {
+    expect(await loadCareer()).toEqual({ best: 0, total: 0, pulls: 0, runs: [], pinnedRunId: null });
+  });
+
+  it('round-trips runs and the pin', async () => {
+    const runs = [{ id: '2', n: 2, at: 2, label: 'VQ', peakHp: 300, peakTq: 280, knocks: 0, scores: { tuning: 1, engineer: 2, pull: 3 }, points: [], inputs: { build: {}, tune: {}, loadKpa: 100 } }];
+    await saveCareer({ best: 1, total: 2, pulls: 3, runs, pinnedRunId: '2' });
+    const loaded = await loadCareer();
+    expect(loaded.runs).toEqual(runs);
+    expect(loaded.pinnedRunId).toBe('2');
+  });
+
+  it('loads a save written before run history existed', async () => {
+    // The blob every existing player has. It must open, not throw and not yield
+    // `undefined` for a field the UI will immediately call .find() on.
+    await saveCareer({ best: 812, total: 4310, pulls: 27 });
+    const loaded = await loadCareer();
+    expect(loaded.best).toBe(812);
+    expect(loaded.runs).toEqual([]);
+    expect(loaded.pinnedRunId).toBe(null);
+  });
+
+  it('rejects a non-array runs value rather than trusting it', async () => {
+    await saveCareer({ best: 1, total: 1, pulls: 1, runs: /** @type {any} */ ('not an array') });
+    expect((await loadCareer()).runs).toEqual([]);
+  });
+
+  it('rejects a non-string pin rather than trusting it', async () => {
+    await saveCareer({ best: 1, total: 1, pulls: 1, pinnedRunId: /** @type {any} */ (17) });
+    expect((await loadCareer()).pinnedRunId).toBe(null);
   });
 });

--- a/tests/ui/dyno-screens.test.jsx
+++ b/tests/ui/dyno-screens.test.jsx
@@ -423,6 +423,20 @@ describe('DYNO > HISTORY', () => {
     expect(rows[2].textContent).toContain('Run 1');
   });
 
+  it('calls the real first pull "first pull"', () => {
+    mountWithResult(<HistoryScreen />, { runs: [RUN_1], pinnedRunId: null });
+    expect(screen.getByText('first pull')).toBeTruthy();
+  });
+
+  it('does not call a capped-off log\'s oldest VISIBLE row "first pull" when it is not run 1', () => {
+    // Once the log caps at RUN_LIMIT, the bottom row has no `prev` either, at
+    // whatever `n` it happens to be — `prev === undefined` alone is not "this was
+    // the career's first pull".
+    const oldButNotFirst = { ...RUN_1, id: 'old', n: 137 };
+    mountWithResult(<HistoryScreen />, { runs: [oldButNotFirst], pinnedRunId: null });
+    expect(screen.queryByText('first pull')).toBeNull();
+  });
+
   it('signs a gain over the previous run as positive', () => {
     // RUN_3 is 340 whp, RUN_2 is 320: a real 20 whp gain must read "+20", not "-20".
     mountWithResult(<HistoryScreen />, { runs: [RUN_3, RUN_2], pinnedRunId: null });

--- a/tests/ui/dyno-screens.test.jsx
+++ b/tests/ui/dyno-screens.test.jsx
@@ -29,7 +29,7 @@ import { measuredInputs } from '../../src/ui/state/pullSignature.js';
 import { ACTIONS } from '../../src/ui/state/reducer.js';
 import { makeRunRecord } from '../../src/ui/state/runLog.js';
 import { StoreProvider, useSession } from '../../src/ui/state/StoreProvider.jsx';
-import EcuLab from '../../src/ui/EcuLab.jsx';
+import EcuLab, { EcuLabApp } from '../../src/ui/EcuLab.jsx';
 
 // jsdom has no ResizeObserver. recharts' <ResponsiveContainer> (ResultScreen's two
 // charts) needs one to mount at all. Same stub as characterisation.test.jsx.
@@ -328,6 +328,59 @@ describe('DYNO while a pull is running', () => {
       () => expect(screen.getByRole('button', { name: 'RUN DYNO PULL' })).toBeTruthy(),
       { timeout: 10000 },
     );
+  });
+});
+
+// ---------------------------------------------------------------------------------
+// The other regression this task exists to pin: DYNO's body used to be wrapped
+// wholesale in `{result && (...)}`, which hid the section switcher — HISTORY
+// included — on a cold start, because `result` is never persisted while `runs`
+// is. A restored session has a populated run log and a null `result`, so this
+// mounts exactly that combination without ever running a pull.
+// ---------------------------------------------------------------------------------
+describe('DYNO body gating — HISTORY outlives result', () => {
+  it('shows HISTORY (and only HISTORY) when runs exist but no pull has landed yet', () => {
+    let dispatch;
+    render(
+      <StoreProvider>
+        <Capture onDispatch={(d) => { dispatch = d; }} />
+        <EcuLabApp />
+      </StoreProvider>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'START' }));
+    fireEvent.click(screen.getByRole('button', { name: /DYNO/ }));
+
+    // Seed a restored run directly, the way RESTORE_CAREER would on a cold start —
+    // `result` stays at its initial `null`, exactly as it is after a page reload.
+    const restoredRun = makeRunRecord({
+      id: 'restored', n: 1, at: 1000, label: 'VQ35DE',
+      result: { peakHp: 300, peakTq: 280, points: [{ rpm: 1500, hp: 100, torque: 200 }], events: [] },
+      scores: { tuning: { score: 80 }, engineer: { score: 70 } }, pullScore: 640,
+      inputs: measuredInputs(makeInitialState().build, makeInitialState().tune, 100),
+    });
+    act(() => dispatch({ type: ACTIONS.SET_SESSION_FIELD, field: 'runs', value: [restoredRun] }));
+
+    expect(screen.getByRole('button', { name: 'HISTORY' })).toBeTruthy();
+    // Only HISTORY: the other four sections lead to screens that render nothing
+    // without a result, so they must not be offered.
+    expect(screen.queryByRole('button', { name: 'CURVES' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'PULL LOG' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'DATALOG' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'SCORE' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'HISTORY' }));
+    expect(screen.getByText('Run 1')).toBeTruthy();
+  });
+
+  it('shows no DYNO nav row at all for a pristine session with no runs and no result', () => {
+    // The converse: a brand-new career has neither `runs` nor `result`, and the
+    // switcher — HISTORY included — must not appear for it to click into.
+    render(<EcuLab />);
+    fireEvent.click(screen.getByRole('button', { name: 'START' }));
+    fireEvent.click(screen.getByRole('button', { name: /DYNO/ }));
+
+    expect(screen.queryByRole('button', { name: 'HISTORY' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'CURVES' })).toBeNull();
   });
 });
 

--- a/tests/ui/dyno-screens.test.jsx
+++ b/tests/ui/dyno-screens.test.jsx
@@ -17,7 +17,7 @@
 
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import React from 'react';
-import { afterAll, afterEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { DataScreen } from '../../src/ui/screens/dyno/DataScreen.jsx';
 import { LogScreen } from '../../src/ui/screens/dyno/LogScreen.jsx';
@@ -38,6 +38,22 @@ const hadResizeObserver = 'ResizeObserver' in window;
 if (!hadResizeObserver) window.ResizeObserver = ResizeObserverStub;
 afterAll(() => {
   if (!hadResizeObserver) delete window.ResizeObserver;
+});
+
+// jsdom does no layout, so every element's getBoundingClientRect() is all zeros —
+// which recharts' <ResponsiveContainer> (a percentage-width box) reads as "no space",
+// and passes a 0 width down to <LineChart>, whose own `validateWidthHeight` guard then
+// renders nothing at all. The ghost-curve tests below assert on Legend item NAMES,
+// which only exist once the chart actually renders, so this file needs a non-zero
+// rect where the two DYNO/DataScreen tests above it never did.
+const origGetBoundingClientRect = window.Element.prototype.getBoundingClientRect;
+beforeAll(() => {
+  window.Element.prototype.getBoundingClientRect = () => (
+    { width: 400, height: 200, top: 0, left: 0, bottom: 200, right: 400, x: 0, y: 0, toJSON() {} }
+  );
+});
+afterAll(() => {
+  window.Element.prototype.getBoundingClientRect = origGetBoundingClientRect;
 });
 
 afterEach(cleanup);
@@ -120,6 +136,26 @@ describe('ResultScreen', () => {
     // instead of trusting this one, `engineDerived` would never be undefined and
     // this render would stop throwing.
     expect(() => mount(<ResultScreen chartData={[]} engineDerived={undefined} />)).toThrow();
+  });
+});
+
+describe('ResultScreen ghost curve', () => {
+  const CHART = [{ rpm: 1500, hp: 111, torque: 222, prevHp: 100, prevTorque: 200 }];
+
+  it('draws both ghost series, named for the comparison, when there is one', () => {
+    mount(<ResultScreen chartData={CHART} engineDerived={{ redline: 7000 }} ghostLabel="Run 4" />);
+    expect(screen.getByText('Run 4 WHP')).toBeTruthy();
+    expect(screen.getByText('Run 4 TQ')).toBeTruthy();
+  });
+
+  it('draws no ghost series at all when there is no comparison', () => {
+    // The other half. Rendering the lines unconditionally would still look right on
+    // the first pull — recharts just draws nothing for an all-undefined dataKey — so
+    // the legend is what makes the difference observable.
+    mount(<ResultScreen chartData={[{ rpm: 1500, hp: 111, torque: 222 }]} engineDerived={{ redline: 7000 }} ghostLabel={null} />);
+    expect(screen.queryByText(/WHP$/)).toBeTruthy();
+    expect(screen.queryByText(/ WHP$/)).toBe(null);
+    expect(screen.queryByText(/ TQ$/)).toBe(null);
   });
 });
 

--- a/tests/ui/dyno-screens.test.jsx
+++ b/tests/ui/dyno-screens.test.jsx
@@ -431,6 +431,17 @@ describe('DYNO > HISTORY', () => {
     expect(screen.getByText(/-20 whp vs Run 3/)).toBeTruthy();
   });
 
+  it("shows each run's engine label, so a swap does not read as an unexplained gain", () => {
+    // APPLY_PRESET clears `result` but keeps `runs`, so a pull right after an LS -> VQ
+    // swap can sit next to a run banked on the old engine. `label` is the only cue
+    // that tells the two apart.
+    const LS_RUN = { ...RUN_1, id: 'ls', n: 1, label: 'LS3', peakHp: 300 };
+    const VQ_RUN = { ...RUN_1, id: 'vq', n: 2, label: 'VQ35DE', peakHp: 420 };
+    mountWithResult(<HistoryScreen />, { runs: [VQ_RUN, LS_RUN], pinnedRunId: null });
+    expect(screen.getByText('LS3')).toBeTruthy();
+    expect(screen.getByText('VQ35DE')).toBeTruthy();
+  });
+
   it('names what changed between a run and the one before it', () => {
     mountWithResult(<HistoryScreen />, { runs: [RUN_BOOSTED, RUN_1], pinnedRunId: null });
     expect(screen.getByText(/boost curve/)).toBeTruthy();

--- a/tests/ui/dyno-screens.test.jsx
+++ b/tests/ui/dyno-screens.test.jsx
@@ -20,10 +20,14 @@ import React from 'react';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { DataScreen } from '../../src/ui/screens/dyno/DataScreen.jsx';
+import { HistoryScreen } from '../../src/ui/screens/dyno/HistoryScreen.jsx';
 import { LogScreen } from '../../src/ui/screens/dyno/LogScreen.jsx';
 import { ResultScreen } from '../../src/ui/screens/dyno/ResultScreen.jsx';
 import { ScoreScreen } from '../../src/ui/screens/dyno/ScoreScreen.jsx';
+import { makeInitialState } from '../../src/ui/state/initialState.js';
+import { measuredInputs } from '../../src/ui/state/pullSignature.js';
 import { ACTIONS } from '../../src/ui/state/reducer.js';
+import { makeRunRecord } from '../../src/ui/state/runLog.js';
 import { StoreProvider, useSession } from '../../src/ui/state/StoreProvider.jsx';
 import EcuLab from '../../src/ui/EcuLab.jsx';
 
@@ -324,5 +328,73 @@ describe('DYNO while a pull is running', () => {
       () => expect(screen.getByRole('button', { name: 'RUN DYNO PULL' })).toBeTruthy(),
       { timeout: 10000 },
     );
+  });
+});
+
+// ---------------------------------------------------------------------------------
+/** Three records, oldest id last, matching the store's newest-first order. */
+const RUN_1 = makeRunRecord({
+  id: 'a', n: 1, at: 1_000, label: 'VQ35DE',
+  result: { peakHp: 300, peakTq: 280, points: [{ rpm: 1500, hp: 100, torque: 200 }], events: [] },
+  scores: { tuning: { score: 80 }, engineer: { score: 70 } }, pullScore: 640,
+  inputs: measuredInputs(makeInitialState().build, makeInitialState().tune, 100),
+});
+const RUN_2 = { ...RUN_1, id: 'b', n: 2, peakHp: 320 };
+const RUN_3 = { ...RUN_1, id: 'c', n: 3, peakHp: 340 };
+/** Identical to RUN_1 except for one measured input, so the diff has exactly one answer. */
+const RUN_BOOSTED = {
+  ...RUN_1, id: 'd', n: 2, peakHp: 400,
+  inputs: measuredInputs(
+    { ...makeInitialState().build, boostCurve: [1, 2, 3, 4, 5, 6, 7, 8] },
+    makeInitialState().tune, 100,
+  ),
+};
+
+describe('DYNO > HISTORY', () => {
+  it('shows an empty state before any pull', () => {
+    mountWithResult(<HistoryScreen />, { runs: [], pinnedRunId: null });
+    expect(screen.getByText(/no pulls yet/i)).toBeTruthy();
+  });
+
+  it('lists runs newest first', () => {
+    mountWithResult(<HistoryScreen />, { runs: [RUN_3, RUN_2, RUN_1], pinnedRunId: null });
+    const rows = screen.getAllByRole('listitem');
+    // Position, not presence: a screen that rendered the log reversed would pass a
+    // test that only asserted all three runs appear somewhere.
+    expect(rows[0].textContent).toContain('Run 3');
+    expect(rows[2].textContent).toContain('Run 1');
+  });
+
+  it('names what changed between a run and the one before it', () => {
+    mountWithResult(<HistoryScreen />, { runs: [RUN_BOOSTED, RUN_1], pinnedRunId: null });
+    expect(screen.getByText(/boost curve/)).toBeTruthy();
+  });
+
+  it('says nothing changed when nothing did', () => {
+    // The other half of the diff pair. A screen that always rendered the "changed"
+    // line would pass the test above while telling the player a clean re-run had
+    // altered their build.
+    mountWithResult(<HistoryScreen />, { runs: [{ ...RUN_1, id: 'e', n: 2 }, RUN_1], pinnedRunId: null });
+    expect(screen.queryByText(/Changed since/)).toBe(null);
+  });
+
+  it('pins a run and unpins the same run', () => {
+    // Both directions through one control, so a handler that only ever dispatched
+    // PIN_RUN would fail the second half.
+    mountWithResult(<HistoryScreen />, { runs: [RUN_2, RUN_1], pinnedRunId: null });
+    // Full literals, not substrings: "Unpin run 1" CONTAINS "Pin run 1", so a loose
+    // matcher would happily find the wrong button and still pass.
+    fireEvent.click(screen.getByRole('button', { name: 'Pin run 1 as the comparison' }));
+    expect(screen.getByRole('button', { name: 'Unpin run 1' })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Unpin run 1' }));
+    expect(screen.getByRole('button', { name: 'Pin run 1 as the comparison' })).toBeTruthy();
+  });
+
+  it('marks only the pinned row as pinned', () => {
+    mountWithResult(<HistoryScreen />, { runs: [RUN_2, RUN_1], pinnedRunId: RUN_1.id });
+    // Anchored for the same reason: /pin run/i matches "Unpin run 1" as well, and
+    // would count two where the answer is one.
+    expect(screen.getAllByRole('button', { name: /^Unpin run/ })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: /^Pin run/ })).toHaveLength(1);
   });
 });

--- a/tests/ui/dyno-screens.test.jsx
+++ b/tests/ui/dyno-screens.test.jsx
@@ -418,6 +418,19 @@ describe('DYNO > HISTORY', () => {
     expect(rows[2].textContent).toContain('Run 1');
   });
 
+  it('signs a gain over the previous run as positive', () => {
+    // RUN_3 is 340 whp, RUN_2 is 320: a real 20 whp gain must read "+20", not "-20".
+    mountWithResult(<HistoryScreen />, { runs: [RUN_3, RUN_2], pinnedRunId: null });
+    expect(screen.getByText(/\+20 whp vs Run 2/)).toBeTruthy();
+  });
+
+  it('signs a loss under the previous run as negative', () => {
+    // The converse ordering of the same two fixtures — RUN_2 (320) now the current
+    // run, RUN_3 (340) the one before it — so a real 20 whp loss must read "-20".
+    mountWithResult(<HistoryScreen />, { runs: [RUN_2, RUN_3], pinnedRunId: null });
+    expect(screen.getByText(/-20 whp vs Run 3/)).toBeTruthy();
+  });
+
   it('names what changed between a run and the one before it', () => {
     mountWithResult(<HistoryScreen />, { runs: [RUN_BOOSTED, RUN_1], pinnedRunId: null });
     expect(screen.getByText(/boost curve/)).toBeTruthy();
@@ -445,9 +458,19 @@ describe('DYNO > HISTORY', () => {
 
   it('marks only the pinned row as pinned', () => {
     mountWithResult(<HistoryScreen />, { runs: [RUN_2, RUN_1], pinnedRunId: RUN_1.id });
+    // Names the end, not just the count: an implementation that marked runs[0]
+    // pinned whenever anything is pinned would produce the same 1/1 counts below.
+    expect(screen.getByRole('button', { name: 'Unpin run 1' })).toBeTruthy();
     // Anchored for the same reason: /pin run/i matches "Unpin run 1" as well, and
     // would count two where the answer is one.
     expect(screen.getAllByRole('button', { name: /^Unpin run/ })).toHaveLength(1);
     expect(screen.getAllByRole('button', { name: /^Pin run/ })).toHaveLength(1);
+
+    // `data-pinned` is the row's only visual mark and is otherwise asserted
+    // nowhere. Rows render newest first, so index 0 is RUN_2 (unpinned) and
+    // index 1 is RUN_1 (the pinned one).
+    const rows = screen.getAllByRole('listitem');
+    expect(rows[0].getAttribute('data-pinned')).toBe('false');
+    expect(rows[1].getAttribute('data-pinned')).toBe('true');
   });
 });

--- a/tests/ui/dyno-screens.test.jsx
+++ b/tests/ui/dyno-screens.test.jsx
@@ -157,7 +157,12 @@ describe('ResultScreen ghost curve', () => {
     // the first pull — recharts just draws nothing for an all-undefined dataKey — so
     // the legend is what makes the difference observable.
     mount(<ResultScreen chartData={[{ rpm: 1500, hp: 111, torque: 222 }]} engineDerived={{ redline: 7000 }} ghostLabel={null} />);
-    expect(screen.queryByText(/WHP$/)).toBeTruthy();
+    // `queryByText` throws (Testing Library's "multiple elements found") under the
+    // ghost mutation, which the ghost mutation reads as a failure of THIS line —
+    // never letting the two load-bearing `toBe(null)` assertions below it run at
+    // all. `queryAllByText` never throws on multiple matches, so a real regression
+    // lands on the assertion that actually names it.
+    expect(screen.queryAllByText(/WHP$/)).toHaveLength(1);
     expect(screen.queryByText(/ WHP$/)).toBe(null);
     expect(screen.queryByText(/ TQ$/)).toBe(null);
   });

--- a/tests/ui/session-store.test.jsx
+++ b/tests/ui/session-store.test.jsx
@@ -24,12 +24,26 @@
 
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import React from 'react';
-import { afterAll, afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { loadCareer } from '../../src/storage.js';
+import { loadCareer, saveCareer } from '../../src/storage.js';
 import EcuLab, { EcuLabApp } from '../../src/ui/EcuLab.jsx';
 import { StoreProvider, useSession } from '../../src/ui/state/StoreProvider.jsx';
 import { ACTIONS } from '../../src/ui/state/reducer.js';
+
+// Records every saveCareer call (arguments, not return value) while keeping the real
+// implementation, so the guard test below can assert on what was WRITTEN and not just
+// on the final state — a final-state assertion cannot catch the guard's absence, because
+// the write-zeroes-then-write-the-real-values sequence lands on the correct value either
+// way; only the intermediate call is wrong.
+const { saveCalls } = vi.hoisted(() => ({ saveCalls: /** @type {any[]} */ ([]) }));
+vi.mock('../../src/storage.js', async (importOriginal) => {
+  const actual = /** @type {any} */ (await importOriginal());
+  return {
+    ...actual,
+    saveCareer: (career) => { saveCalls.push(career); return actual.saveCareer(career); },
+  };
+});
 
 // jsdom has no ResizeObserver. recharts' <ResponsiveContainer> (used on the DYNO
 // results panel) needs one to mount at all, so any test that reaches a rendered dyno
@@ -387,23 +401,32 @@ describe('the guided first run', () => {
 
 describe('banking a pull', () => {
   it('writes the career through to storage, not just to the store', async () => {
-    // `BANK_PULL` updates bestScore/totalScore/pullCount in the store; `persistCareer`
-    // (EcuLab.jsx:873) is a SEPARATE synchronous call that writes them through to the
-    // storage adapter. It is deliberately not in the reducer — reducers do no I/O — and
-    // deliberately not in a useEffect keyed on the score fields, because the restore
-    // effect is async and a score-watching effect would fire with 0,0,0 on mount,
-    // BEFORE loadCareer() resolves, and overwrite a real save with zeroes.
+    // `BANK_PULL` updates bestScore/totalScore/pullCount/runs in the store; a
+    // `useEffect` over those fields (EcuLab.jsx, below the career-restore effect) is
+    // what writes them through to the storage adapter. It is deliberately not in the
+    // reducer — reducers do no I/O — and it is guarded by a `careerLoaded` ref set
+    // only once the restore effect's own dispatches land, because that effect is
+    // async and an unguarded persistence effect would fire with 0,0,0 on mount,
+    // before `loadCareer()` resolves, and overwrite a real save with zeroes.
     //
-    // That left the call itself pinned by nothing. Deleting the persistCareer line
-    // passes all 169 other tests: the session plays perfectly, the HOME panel shows the
-    // right figures from the store, and the career is simply gone at the next refresh.
-    // A whole-branch break sweep found this; every earlier review confirmed the call
-    // site was CORRECT without checking a regression would be caught.
+    // Deleting the persistence effect passes every other test: the session plays
+    // perfectly, the HOME panel shows the right figures from the store, and the
+    // career is simply gone at the next refresh. A whole-branch break sweep found
+    // the equivalent gap in the pre-Task-5 design; every earlier review confirmed the
+    // call site was CORRECT without checking a regression would be caught.
     launch();
     fireEvent.click(screen.getByRole('button', { name: 'DYNO' }));
-    // Guard the setup: nothing is saved before a pull is banked, so if the pull below
-    // silently failed to run, the assertion afterwards would be comparing zero to zero.
-    expect(localStorage.getItem('career')).toBeNull();
+    // Let the mount's async career-restore effect resolve before banking a pull.
+    // Racing it — as a synchronous `fireEvent` chain otherwise would — lets its
+    // pre-pull snapshot land AFTER `BANK_PULL` and overwrite the just-banked pull
+    // count with zero, in the store and (through the persistence effect) on disk.
+    // Real usage can never hit this: the load settles on the very next microtask
+    // tick, long before any human reacts to the mounted screen.
+    await waitFor(async () => expect((await loadCareer()).pulls).toBe(0));
+    // Guard the setup: nothing MEANINGFUL is saved before a pull is banked (the
+    // restore effect above re-persists the empty career it just read, which is
+    // legitimate and asserted on the line above), so if the pull below silently
+    // failed to run, the assertion afterwards would be comparing zero to zero.
 
     fireEvent.click(screen.getByRole('button', { name: 'RUN DYNO PULL' }));
     await waitFor(
@@ -560,6 +583,23 @@ describe('career stats saved from a previous session', () => {
     fireEvent.click(screen.getByText('Career & Last Pull'));
     expect(statTile('BEST PULL')).toBe('812');
     expect(statTile('CAREER TOTAL')).toBe('3405');
+  });
+
+  it('does not overwrite a saved career before the load completes', async () => {
+    // The hazard: loadCareer is async, so there is a window between first paint and
+    // its dispatches landing. A persistence effect with no guard runs during that
+    // window and writes zeroes over a real save — silently, and on every cold start.
+    // A final-state assertion cannot catch this: the zeroes get overwritten by the
+    // real values a moment later either way, so this asserts on every call made, not
+    // on where things end up.
+    await saveCareer({ best: 900, total: 5000, pulls: 30, runs: [], pinnedRunId: null });
+    saveCalls.length = 0;
+    launch();
+
+    await waitFor(() => expect(saveCalls.length).toBeGreaterThan(0));
+    for (const call of saveCalls) {
+      expect(call).not.toMatchObject({ best: 0, total: 0, pulls: 0 });
+    }
   });
 });
 

--- a/tests/ui/session-store.test.jsx
+++ b/tests/ui/session-store.test.jsx
@@ -414,20 +414,15 @@ describe('banking a pull', () => {
     // career is simply gone at the next refresh. A whole-branch break sweep found
     // the equivalent gap in the pre-Task-5 design; every earlier review confirmed the
     // call site was CORRECT without checking a regression would be caught.
+    // No settle-wait for the mount's async career-restore effect before banking: a
+    // synchronous `fireEvent` chain CAN still land `BANK_PULL` before that effect's
+    // `RESTORE_CAREER` dispatch resolves, but RESTORE_CAREER merges the loaded
+    // (empty, on this fresh a `localStorage`) career with whatever the session
+    // already banked rather than overwriting it — see reducer.js. So racing it here
+    // is no longer a hazard this test needs to dodge; it exercises the actual
+    // ordering a real fast-clicking player can produce instead of avoiding it.
     launch();
     fireEvent.click(screen.getByRole('button', { name: 'DYNO' }));
-    // Let the mount's async career-restore effect resolve before banking a pull.
-    // Racing it — as a synchronous `fireEvent` chain otherwise would — lets its
-    // pre-pull snapshot land AFTER `BANK_PULL` and overwrite the just-banked pull
-    // count with zero, in the store and (through the persistence effect) on disk.
-    // Real usage can never hit this: the load settles on the very next microtask
-    // tick, long before any human reacts to the mounted screen.
-    await waitFor(async () => expect((await loadCareer()).pulls).toBe(0));
-    // Guard the setup: nothing MEANINGFUL is saved before a pull is banked (the
-    // restore effect above re-persists the empty career it just read, which is
-    // legitimate and asserted on the line above), so if the pull below silently
-    // failed to run, the assertion afterwards would be comparing zero to zero.
-
     fireEvent.click(screen.getByRole('button', { name: 'RUN DYNO PULL' }));
     await waitFor(
       () => expect(screen.getByRole('button', { name: 'RUN DYNO PULL' })).toBeTruthy(),

--- a/tests/ui/state/pullSignature.test.js
+++ b/tests/ui/state/pullSignature.test.js
@@ -98,7 +98,7 @@ describe('pullSignature', () => {
     // the same pass the scores are banked in.
     expect(sign({
       session: {
-        result: { peakHp: 410 }, prevResult: { peakHp: 380 }, revealCount: 40,
+        result: { peakHp: 410 }, revealCount: 40,
         bestScore: 500, totalScore: 900, pullCount: 3,
         health: { piston: 90, bearing: 95, valve: 99 },
       },

--- a/tests/ui/state/pullSignature.test.js
+++ b/tests/ui/state/pullSignature.test.js
@@ -189,6 +189,16 @@ describe('diffMeasuredInputs', () => {
       .toEqual(['turbo', 'fuel', 'dyno load']);
   });
 
+  it('does not throw when a projection is missing entirely, not just a key inside it', () => {
+    // storage.js validates that `runs` is an array but not that its elements are
+    // records, so a hand-edited save's `runs: [1, 2, 3]` can reach this function with
+    // an operand that has no `.build`/`.tune` at all — not merely a missing key
+    // inside them. `a.build?.[k]` guards the missing KEY but still throws reading
+    // `.build` off an `a` that is itself undefined.
+    expect(() => diffMeasuredInputs(undefined, project())).not.toThrow();
+    expect(() => diffMeasuredInputs(project(), undefined)).not.toThrow();
+  });
+
   it('reports the same fields the signature reports as a change', () => {
     // The two functions must never disagree about WHETHER anything moved. This is the
     // property that justifies them living in one file over one private key list.

--- a/tests/ui/state/pullSignature.test.js
+++ b/tests/ui/state/pullSignature.test.js
@@ -18,7 +18,7 @@ import { describe, expect, it } from 'vitest';
 
 import { clone2D } from '../../../src/sim/index.js';
 import { makeInitialState } from '../../../src/ui/state/initialState.js';
-import { pullSignature } from '../../../src/ui/state/pullSignature.js';
+import { diffMeasuredInputs, measuredInputs, pullSignature } from '../../../src/ui/state/pullSignature.js';
 
 /**
  * Signs a state tree, optionally with one slice patched.
@@ -111,5 +111,91 @@ describe('pullSignature', () => {
     // nobody had touched.
     expect(sign({ session: { live: { rpm: 3200, running: true }, throttleInput: 100 } }))
       .toBe(sign());
+  });
+});
+
+describe('measuredInputs', () => {
+  it('keeps the measured build fields and drops the label-only ones', () => {
+    const s = makeInitialState();
+    const projected = measuredInputs(
+      { ...s.build, presetId: 'n54', presetPrompt: { open: true }, boostSel: 2 },
+      s.tune,
+      100,
+    );
+    expect(projected.build).toHaveProperty('engineConfig');
+    expect(projected.build).toHaveProperty('boostCurve');
+    // Mutation caught: projecting the whole slice. presetId/presetPrompt/boostSel
+    // reach no simulation, and storing them would make two runs on the same car
+    // diff as different because a dialog was open during one of them.
+    expect(projected.build).not.toHaveProperty('presetId');
+    expect(projected.build).not.toHaveProperty('presetPrompt');
+    expect(projected.build).not.toHaveProperty('boostSel');
+  });
+
+  it('keeps the three tables and drops the tune slice cursors', () => {
+    const s = makeInitialState();
+    const projected = measuredInputs(s.build, { ...s.tune, selection: { type: 'cell', row: 1, col: 1 }, tablesDirty: true }, 100);
+    expect(Object.keys(projected.tune).sort()).toEqual(['afr', 'timing', 've']);
+  });
+
+  it('carries loadKpa', () => {
+    const s = makeInitialState();
+    expect(measuredInputs(s.build, s.tune, 140).loadKpa).toBe(140);
+  });
+});
+
+describe('diffMeasuredInputs', () => {
+  /** @returns {ReturnType<typeof measuredInputs>} */
+  const project = (patch = {}) => {
+    const s = makeInitialState();
+    return measuredInputs(
+      { ...s.build, ...(patch.build ?? {}) },
+      { ...s.tune, ...(patch.tune ?? {}) },
+      patch.loadKpa ?? 100,
+    );
+  };
+
+  it('reports nothing for two identical configurations', () => {
+    // Mutation caught: returning every label unconditionally.
+    expect(diffMeasuredInputs(project(), project())).toEqual([]);
+  });
+
+  it('names the one field that moved and nothing else', () => {
+    // Both halves in one assertion: 'boost curve' present AND every other label
+    // absent. Asserting only `toContain('boost curve')` would pass against an
+    // implementation that returns all sixteen labels every time.
+    expect(diffMeasuredInputs(project(), project({ build: { boostCurve: [1, 2, 3, 4, 5, 6, 7, 8] } })))
+      .toEqual(['boost curve']);
+  });
+
+  it('sees a change inside a calibration table', () => {
+    // Mutation caught: comparing tables by reference (`a !== b`) reports a change on
+    // every call because clone2D makes a fresh array; comparing with `===` on the
+    // outer array misses a changed CELL entirely. Only a value compare gets both.
+    const s = makeInitialState();
+    const edited = clone2D(s.tune.ve);
+    edited[0][0] += 5;
+    expect(diffMeasuredInputs(project(), project({ tune: { ve: edited } }))).toEqual(['VE table']);
+  });
+
+  it('reports a table as unchanged when an equal copy is passed', () => {
+    // The other half of the reference-compare pair.
+    const s = makeInitialState();
+    expect(diffMeasuredInputs(project(), project({ tune: { ve: clone2D(s.tune.ve) } }))).toEqual([]);
+  });
+
+  it('names several fields when several moved', () => {
+    expect(diffMeasuredInputs(project(), project({ build: { turboOn: true, octaneIdx: 3 }, loadKpa: 140 })))
+      .toEqual(['turbo', 'fuel', 'dyno load']);
+  });
+
+  it('reports the same fields the signature reports as a change', () => {
+    // The two functions must never disagree about WHETHER anything moved. This is the
+    // property that justifies them living in one file over one private key list.
+    const s = makeInitialState();
+    const other = { ...s.build, mafScalar: 1.15 };
+    expect(pullSignature(s.build, s.tune, 100)).not.toBe(pullSignature(other, s.tune, 100));
+    expect(diffMeasuredInputs(measuredInputs(s.build, s.tune, 100), measuredInputs(other, s.tune, 100)))
+      .not.toEqual([]);
   });
 });

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -20,6 +20,7 @@ import {
 } from '../../../src/ui/state/history.js';
 import { makeInitialState } from '../../../src/ui/state/initialState.js';
 import { ACTIONS, reducer } from '../../../src/ui/state/reducer.js';
+import { RUN_LIMIT } from '../../../src/ui/state/runLog.js';
 
 /**
  * A state where EVERY field of EVERY slice holds a value no real APPLY_PRESET write
@@ -929,7 +930,7 @@ describe('RESTORE_CAREER', () => {
     // Bank a pull FIRST — simulating a pull landing before loadCareer() resolves —
     // then pin it, then restore. A restore that overwrites instead of merges fails
     // every assertion below.
-    const banked = reducer(makeInitialState(), bank('new', 500));
+    const banked = reducer(makeInitialState(), bank('new', 900));
     const pinned = reducer(banked, { type: ACTIONS.PIN_RUN, id: 'new' });
 
     const career = {
@@ -938,15 +939,49 @@ describe('RESTORE_CAREER', () => {
     const s = reducer(pinned, { type: ACTIONS.RESTORE_CAREER, career });
 
     // bestScore: the max of the two, not the loaded value replacing the banked one.
-    expect(s.session.bestScore).toBe(700);
+    expect(s.session.bestScore).toBe(900);
     // totalScore / pullCount: summed, not replaced.
-    expect(s.session.totalScore).toBe(1500);
+    expect(s.session.totalScore).toBe(1900);
     expect(s.session.pullCount).toBe(6);
     // The banked run survives the restore AND stays at index 0 — it is newer than
     // anything loaded from storage.
     expect(s.session.runs.map((r) => r.id)).toEqual(['new', 'loaded']);
     // A pin set this session survives a restore that names a different run.
     expect(s.session.pinnedRunId).toBe('new');
+  });
+
+  it('caps total runs at RUN_LIMIT during merge, evicting oldest loaded runs', () => {
+    // Session holds 1 banked run; loaded career holds RUN_LIMIT runs. The merge
+    // should cap at RUN_LIMIT total, evicting only from the LOADED side (the older
+    // runs), not from the banked side. This test proves the merge respects the cap
+    // and evicts from the correct end.
+    const banked = reducer(makeInitialState(), bank('session', 500));
+
+    // Build a career with exactly RUN_LIMIT runs (20), with IDs like 'loaded-0' through
+    // 'loaded-19', in newest-first order (most recent at index 0).
+    const loadedRuns = [];
+    for (let i = 0; i < RUN_LIMIT; i += 1) {
+      loadedRuns.push({
+        id: `loaded-${i}`, n: i + 100, at: 1000 + i, label: 'VQ35DE',
+        peakHp: 300 + i, peakTq: 260 + i, knocks: 0,
+        scores: { tuning: 70, engineer: 65, pull: 400 + i },
+        points: [], inputs: { build: {}, tune: {}, loadKpa: 100 },
+      });
+    }
+
+    const career = {
+      best: 500, total: 5000, pulls: 50, runs: loadedRuns, pinnedRunId: null,
+    };
+    const s = reducer(banked, { type: ACTIONS.RESTORE_CAREER, career });
+
+    // Total runs should be capped at RUN_LIMIT (20).
+    expect(s.session.runs).toHaveLength(RUN_LIMIT);
+    // The banked run is newest and should survive, always at index 0.
+    expect(s.session.runs[0].id).toBe('session');
+    // The oldest loaded run ('loaded-19') should be evicted because it's the least recent.
+    expect(s.session.runs.map((r) => r.id)).not.toContain('loaded-19');
+    // The second-oldest loaded run ('loaded-18') should survive.
+    expect(s.session.runs.map((r) => r.id)).toContain('loaded-18');
   });
 });
 

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -791,11 +791,18 @@ describe('BANK_PULL', () => {
     engineer: { score: 71, label: 'SOLID', deductions: [] },
     signature: 'FABRICATED-BUILD-SIGNATURE',
   };
+  /** A minimal RunRecord — this describe block predates the run log and never asserts on it. */
+  const run = /** @type {import('../../../src/ui/state/runLog.js').RunRecord} */ ({
+    id: 'x', n: 1, at: 1000, label: 'VQ35DE', peakHp: 410, peakTq: 280, knocks: 0,
+    scores: { tuning: 88, engineer: 71, pull: 50 },
+    points: [], inputs: { build: {}, tune: {}, loadKpa: 100 },
+  });
+
   /**
    * @param {number} pullScore
    * @returns {import('../../../src/ui/state/reducer.js').StoreAction}
    */
-  const bank = (pullScore) => ({ type: ACTIONS.BANK_PULL, result, pullScore, scores });
+  const bank = (pullScore) => ({ type: ACTIONS.BANK_PULL, result, pullScore, scores, run });
 
   it('rotates the previous result into prevResult and installs the new one', () => {
     const ran = { ...makeInitialState() };
@@ -1514,5 +1521,63 @@ describe('snapshot field coverage', () => {
     expect(undone.tune.timing).toBe(beforeTiming);
     expect(undone.tune.afr).toBe(beforeAfr);
     expect(undone.tune.tablesDirty).toBe(true);
+  });
+});
+
+describe('run log', () => {
+  /** @returns {import('../../../src/ui/state/runLog.js').RunRecord} */
+  const rec = (id) => ({
+    id, n: Number(id), at: 1000 + Number(id), label: 'VQ35DE',
+    peakHp: 300, peakTq: 280, knocks: 0,
+    scores: { tuning: 80, engineer: 70, pull: 640 },
+    points: [{ rpm: 1500, hp: 100, torque: 200 }],
+    inputs: { build: {}, tune: {}, loadKpa: 100 },
+  });
+
+  /** BANK_PULL's minimum viable payload. */
+  const bank = (id) => ({
+    type: ACTIONS.BANK_PULL,
+    run: rec(id),
+    result: { peakHp: 300, peakTq: 280, points: [], events: [], wear: { piston: 1, bearing: 1, valve: 1 } },
+    pullScore: 640,
+    scores: { tuning: { score: 80 }, engineer: { score: 70 }, signature: 'sig' },
+  });
+
+  it('records the banked run at the front of the log', () => {
+    const s = reducer(reducer(makeInitialState(), bank('1')), bank('2'));
+    expect(s.session.runs.map((r) => r.id)).toEqual(['2', '1']);
+  });
+
+  it('starts with an empty log and no pin', () => {
+    const s = makeInitialState();
+    expect(s.session.runs).toEqual([]);
+    expect(s.session.pinnedRunId).toBe(null);
+  });
+
+  it('pins and unpins a run', () => {
+    const pinned = reducer(makeInitialState(), { type: ACTIONS.PIN_RUN, id: '7' });
+    expect(pinned.session.pinnedRunId).toBe('7');
+    expect(reducer(pinned, { type: ACTIONS.UNPIN_RUN }).session.pinnedRunId).toBe(null);
+  });
+
+  it('leaves the run log and the pin standing when a preset is loaded', () => {
+    // BOTH halves of the pair. Asserting only that the scorecard clears would pass
+    // against an APPLY_PRESET that also wipes twenty runs of persisted history —
+    // which undo does not cover and the player cannot get back.
+    const withRun = reducer(reducer(makeInitialState(), bank('1')), { type: ACTIONS.PIN_RUN, id: '1' });
+    const after = reducer(withRun, { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
+    expect(after.session.result).toBe(null);
+    expect(after.session.pullScores).toBe(null);
+    expect(after.session.runs.map((r) => r.id)).toEqual(['1']);
+    expect(after.session.pinnedRunId).toBe('1');
+  });
+
+  it('leaves the whole session slice alone on RESET_TO_STOCK', () => {
+    // Pins today's behaviour so the natural-but-wrong pairing with APPLY_PRESET
+    // cannot be introduced by someone "making them consistent". RESET_TO_STOCK has
+    // never touched session, including result and pullScores.
+    const withRun = reducer(makeInitialState(), bank('1'));
+    const after = reducer(withRun, { type: ACTIONS.RESET_TO_STOCK, ve: withRun.tune.ve });
+    expect(after.session).toBe(withRun.session);
   });
 });

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -885,6 +885,71 @@ describe('BANK_PULL', () => {
   });
 });
 
+describe('RESTORE_CAREER', () => {
+  // `EcuLab.jsx`'s career-restore effect is `await loadCareer()` followed by a single
+  // dispatch of this action. `loadCareer()` is async, so a pull can bank
+  // (`BANK_PULL`) — and, on the `artifact` storage backend, a real round trip means a
+  // human interaction genuinely can land inside that window. Overwriting the session
+  // with the loaded snapshot in that case would roll a real, already-banked pull back
+  // to whatever was saved before it. RESTORE_CAREER exists to merge instead.
+
+  /** A loaded run, distinct from anything a pull banked this session. */
+  const loadedRun = /** @type {import('../../../src/ui/state/runLog.js').RunRecord} */ ({
+    id: 'loaded', n: 4, at: 500, label: 'VQ35DE', peakHp: 300, peakTq: 260, knocks: 0,
+    scores: { tuning: 70, engineer: 65, pull: 400 },
+    points: [], inputs: { build: {}, tune: {}, loadKpa: 100 },
+  });
+
+  /** BANK_PULL's minimum viable payload — mirrors the 'run log' describe block above. */
+  const bank = (id, pullScore) => ({
+    type: ACTIONS.BANK_PULL,
+    run: /** @type {import('../../../src/ui/state/runLog.js').RunRecord} */ ({
+      id, n: Number(id), at: 1000, label: 'VQ35DE', peakHp: 320, peakTq: 300, knocks: 0,
+      scores: { tuning: 90, engineer: 85, pull: pullScore },
+      points: [], inputs: { build: {}, tune: {}, loadKpa: 100 },
+    }),
+    result: { peakHp: 320, peakTq: 300, points: [], events: [], wear: { piston: 1, bearing: 1, valve: 1 } },
+    pullScore,
+    scores: { tuning: { score: 90 }, engineer: { score: 85 }, signature: 'sig' },
+  });
+
+  it('into a pristine session, yields exactly the loaded values', () => {
+    const career = {
+      best: 812, total: 3405, pulls: 7, runs: [loadedRun], pinnedRunId: 'loaded',
+    };
+    const s = reducer(makeInitialState(), { type: ACTIONS.RESTORE_CAREER, career });
+    expect(s.session.bestScore).toBe(812);
+    expect(s.session.totalScore).toBe(3405);
+    expect(s.session.pullCount).toBe(7);
+    expect(s.session.runs).toEqual([loadedRun]);
+    expect(s.session.pinnedRunId).toBe('loaded');
+  });
+
+  it('merges, rather than overwrites, a career banked between mount and load — the race', () => {
+    // Bank a pull FIRST — simulating a pull landing before loadCareer() resolves —
+    // then pin it, then restore. A restore that overwrites instead of merges fails
+    // every assertion below.
+    const banked = reducer(makeInitialState(), bank('new', 500));
+    const pinned = reducer(banked, { type: ACTIONS.PIN_RUN, id: 'new' });
+
+    const career = {
+      best: 700, total: 1000, pulls: 5, runs: [loadedRun], pinnedRunId: 'loaded',
+    };
+    const s = reducer(pinned, { type: ACTIONS.RESTORE_CAREER, career });
+
+    // bestScore: the max of the two, not the loaded value replacing the banked one.
+    expect(s.session.bestScore).toBe(700);
+    // totalScore / pullCount: summed, not replaced.
+    expect(s.session.totalScore).toBe(1500);
+    expect(s.session.pullCount).toBe(6);
+    // The banked run survives the restore AND stays at index 0 — it is newer than
+    // anything loaded from storage.
+    expect(s.session.runs.map((r) => r.id)).toEqual(['new', 'loaded']);
+    // A pin set this session survives a restore that names a different run.
+    expect(s.session.pinnedRunId).toBe('new');
+  });
+});
+
 describe('UNDO / REDO', () => {
   /** A state with one hand VE edit already applied. */
   const edited = () => reducer(

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -28,7 +28,7 @@ import { ACTIONS, reducer } from '../../../src/ui/state/reducer.js';
  * list, so a field added to a slice in a later PR is swept automatically.
  *
  * Because each sentinel is a fresh string unique to its own field, no real preset
- * value — a number, an array, a plain object, `null`, a boolean, ANY type the 22 real
+ * value — a number, an array, a plain object, `null`, a boolean, ANY type the 21 real
  * writes use — can ever equal it. That makes a single strict `!==` check exact for
  * "did the reducer touch this field", for every field type in play, with no deep-
  * equality helper needed: the starting value is never deep-equal to a real written
@@ -459,7 +459,6 @@ describe('APPLY_PRESET', () => {
     ran.session = {
       ...ran.session,
       result: { peakHp: 400 },
-      prevResult: { peakHp: 380 },
       pullScores: {
         pull: 400, wasBest: true, signature: 'x',
         tuning: { score: 90, label: 'CLEAN', deductions: [] },
@@ -468,7 +467,6 @@ describe('APPLY_PRESET', () => {
     };
     const s = reducer(ran, { type: ACTIONS.APPLY_PRESET, preset });
     expect(s.session.result).toBeNull();
-    expect(s.session.prevResult).toBeNull();
     // The scores go with the result they grade. Left behind, they would put a
     // scorecard on screen with no dyno curve under it — and one measured on an engine
     // the player has just replaced wholesale.
@@ -507,11 +505,11 @@ describe('APPLY_PRESET — exact write surface (catches drift in both directions
   // the old test only compared a hand-built map against the local fixture's own key
   // set — never against what the reducer actually writes. This test instead seeds
   // EVERY field of EVERY slice with a sentinel a real write can never produce, dispatches
-  // for real, and asserts the walked set of changed fields against the 22-field
-  // contract this action documents: a stray write grows the changed set past 22, a
-  // dropped write shrinks it below 22, and the failure message names the field either
+  // for real, and asserts the walked set of changed fields against the 21-field
+  // contract this action documents: a stray write grows the changed set past 21, a
+  // dropped write shrinks it below 21, and the failure message names the field either
   // way.
-  it('changes exactly the 22 documented fields, plus the two history fields', () => {
+  it('changes exactly the 21 documented fields, plus the two history fields', () => {
     const before = makeSentinelState();
     const after = reducer(before, { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
     const changed = changedFieldKeys(before, after);
@@ -522,7 +520,7 @@ describe('APPLY_PRESET — exact write surface (catches drift in both directions
       'build.ecuInjectorCc', 'build.octaneIdx', 'build.exhaustDiaIdx', 'build.mafScalar',
       'build.presetId', 'build.presetPrompt',
       'tune.ve', 'tune.timing', 'tune.afr', 'tune.tablesDirty', 'tune.selection',
-      'session.result', 'session.prevResult', 'session.pullScores',
+      'session.result', 'session.pullScores',
       // APPLY_PRESET is undoable, so it records a snapshot in the same pass. These two
       // belong in the exact-write-surface contract like any other field it touches.
       'history.past', 'history.future',
@@ -779,10 +777,9 @@ describe('LIVE_STEP and LIVE_PATCH', () => {
 
 describe('BANK_PULL', () => {
   // Mirrors the tail of doRun (EcuLab.jsx:868-896): a completed dyno pull's result
-  // rotates into prevResult, the engine wears by the pull's own wear figures, and the
-  // career score/pull count advance — all in one pass instead of six ordered setState
-  // calls where getting `setPrevResult(result)` before `setResult(r)` backwards would
-  // silently corrupt prevResult.
+  // installs as the current one, the engine wears by the pull's own wear figures, and
+  // the career score/pull count advance — all in one pass instead of several ordered
+  // setState calls.
   const result = { peakHp: 410, wear: { piston: 3, bearing: 2, valve: 1 } };
   // What `doRun` computes and hands over: the two score breakdowns and the signature
   // of the car they were measured on. `pull` and `wasBest` are the reducer's to add.
@@ -804,11 +801,10 @@ describe('BANK_PULL', () => {
    */
   const bank = (pullScore) => ({ type: ACTIONS.BANK_PULL, result, pullScore, scores, run });
 
-  it('rotates the previous result into prevResult and installs the new one', () => {
+  it('installs the new result', () => {
     const ran = { ...makeInitialState() };
     ran.session = { ...ran.session, result: { peakHp: 380 } };
     const s = reducer(ran, bank(50));
-    expect(s.session.prevResult).toEqual({ peakHp: 380 });
     expect(s.session.result).toBe(result);
   });
 
@@ -1000,21 +996,16 @@ describe('UNDO / REDO', () => {
   it('does not restore dyno results', () => {
     // A deliberate asymmetry, spec'd: undo brings back hardware and calibration, but
     // re-showing a banked score beside a build that was just reverted would state
-    // something false. Both result AND prevResult must stay cleared — a snapshot that
-    // dropped only one of the pair would leave the OTHER field's stale score sitting
-    // next to the reverted build.
+    // something false.
     const withResult = { ...makeInitialState() };
     withResult.session = {
       ...withResult.session,
       result: { peakHp: 400 },
-      prevResult: { peakHp: 350 },
     };
     const loaded = reducer(withResult, { type: ACTIONS.APPLY_PRESET, preset: N54_PRESET });
     expect(loaded.session.result).toBeNull();
-    expect(loaded.session.prevResult).toBeNull();
     const undone = reducer(loaded, { type: ACTIONS.UNDO });
     expect(undone.session.result).toBeNull();
-    expect(undone.session.prevResult).toBeNull();
   });
 
   it('preserves the entry label when moving it between past and future', () => {

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -983,6 +983,35 @@ describe('RESTORE_CAREER', () => {
     // The second-oldest loaded run ('loaded-18') should survive.
     expect(s.session.runs.map((r) => r.id)).toContain('loaded-18');
   });
+
+  it('caps an over-length loaded runs array at RUN_LIMIT even into a pristine session', () => {
+    // Every other cap test here has a banked session run present, so `s.runs.length`
+    // is always truthy in them. A merge written as
+    // `s.runs.length ? [...s.runs, ...c.runs].slice(0, RUN_LIMIT) : c.runs` passes
+    // all of them while letting an over-length loaded array through UNSLICED into a
+    // pristine session — and back out to disk on the next save. This restores
+    // RUN_LIMIT + 5 loaded runs into makeInitialState() (no banked pull at all) to
+    // catch exactly that.
+    const loadedRuns = [];
+    for (let i = 0; i < RUN_LIMIT + 5; i += 1) {
+      loadedRuns.push({
+        id: `loaded-${i}`, n: 100 - i, at: 2000 - i, label: 'VQ35DE',
+        peakHp: 300, peakTq: 260, knocks: 0,
+        scores: { tuning: 70, engineer: 65, pull: 400 },
+        points: [], inputs: { build: {}, tune: {}, loadKpa: 100 },
+      });
+    }
+    const career = { best: 0, total: 0, pulls: 0, runs: loadedRuns, pinnedRunId: null };
+    const s = reducer(makeInitialState(), { type: ACTIONS.RESTORE_CAREER, career });
+
+    expect(s.session.runs).toHaveLength(RUN_LIMIT);
+    // The newest RUN_LIMIT survive, in order...
+    expect(s.session.runs.map((r) => r.id)).toEqual(loadedRuns.slice(0, RUN_LIMIT).map((r) => r.id));
+    // ...and every one of the oldest 5 is gone, not some other 5.
+    for (let i = RUN_LIMIT; i < RUN_LIMIT + 5; i += 1) {
+      expect(s.session.runs.some((r) => r.id === `loaded-${i}`)).toBe(false);
+    }
+  });
 });
 
 describe('UNDO / REDO', () => {

--- a/tests/ui/state/reducer.test.js
+++ b/tests/ui/state/reducer.test.js
@@ -1677,6 +1677,15 @@ describe('run log', () => {
   it('pins and unpins a run', () => {
     const pinned = reducer(makeInitialState(), { type: ACTIONS.PIN_RUN, id: '7' });
     expect(pinned.session.pinnedRunId).toBe('7');
+
+    // A second PIN_RUN overwrites the pin rather than stacking — there is only
+    // ever one, per the UNPIN_RUN typedef's "no payload" note.
+    const repinned = reducer(pinned, { type: ACTIONS.PIN_RUN, id: '9' });
+    expect(repinned.session.pinnedRunId).toBe('9');
+
+    // Pinning is bookkeeping over the log, not a write to it.
+    expect(repinned.session.runs).toBe(pinned.session.runs);
+
     expect(reducer(pinned, { type: ACTIONS.UNPIN_RUN }).session.pinnedRunId).toBe(null);
   });
 

--- a/tests/ui/state/runLog.test.js
+++ b/tests/ui/state/runLog.test.js
@@ -1,0 +1,168 @@
+/**
+ * The run log — pure, no DOM.
+ *
+ * Every test here names the mutation it exists to catch. PR 4a shipped seven suites
+ * that each passed against a broken implementation, always in one of five shapes; the
+ * two that bite hardest here are "asserts a count but not which end" (a FIFO undo
+ * stack passed 871 tests) and "pins one side of a pair". Both are held below by
+ * asserting the surviving IDS, not the surviving length.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { RUN_LIMIT, ghostLabel, ghostRun, makeRunRecord, pushRun, sparklinePath } from '../../../src/ui/state/runLog.js';
+
+/** A minimal sweep result, shaped like `simulateSweep`'s output. */
+function fakeResult({ peakHp = 300, peakTq = 280, knocks = 0 } = {}) {
+  return {
+    peakHp,
+    peakTq,
+    points: [
+      { rpm: 1500, hp: 100, torque: 200, afr: 12.5, timing: 20 },
+      { rpm: 1600, hp: 120, torque: 210, afr: 12.4, timing: 21 },
+      { rpm: 1700, hp: 140, torque: 220, afr: 12.3, timing: 22 },
+    ],
+    events: [
+      ...Array.from({ length: knocks }, () => ({ type: 'knock', severity: 3 })),
+      { type: 'lean', severity: 2 },
+    ],
+  };
+}
+
+/** A run record with a caller-chosen id, so ordering assertions can name it. */
+function run(id, over = {}) {
+  return makeRunRecord({
+    id, n: Number(id), at: 1000 + Number(id), label: 'VQ35DE',
+    result: fakeResult(over.result ?? {}),
+    scores: { tuning: { score: 80 }, engineer: { score: 70 } },
+    pullScore: 640,
+    inputs: { build: {}, tune: {}, loadKpa: 100 },
+  });
+}
+
+describe('makeRunRecord', () => {
+  it('keeps only rpm, hp and torque from each point', () => {
+    // Mutation caught: storing `result.points` whole. That is 50 fields per point
+    // against 3 — a 20x storage cost, which is the reason the record is slim at all.
+    const r = run('1');
+    expect(r.points).toEqual([
+      { rpm: 1500, hp: 100, torque: 200 },
+      { rpm: 1600, hp: 120, torque: 210 },
+      { rpm: 1700, hp: 140, torque: 220 },
+    ]);
+  });
+
+  it('counts knock events only, not every event', () => {
+    // Mutation caught: `result.events.length`. The fixture always carries one 'lean'
+    // event, so a total-count implementation reads 3 where the answer is 2.
+    expect(run('1', { result: { knocks: 2 } }).knocks).toBe(2);
+  });
+
+  it('reduces each score object to its number', () => {
+    // Mutation caught: storing the score OBJECTS, which carry `deductions` arrays and
+    // would roughly double the record.
+    expect(run('1').scores).toEqual({ tuning: 80, engineer: 70, pull: 640 });
+  });
+});
+
+describe('pushRun', () => {
+  it('puts the newest run at index 0', () => {
+    const runs = pushRun(pushRun([], run('1')), run('2'));
+    expect(runs.map((r) => r.id)).toEqual(['2', '1']);
+  });
+
+  it('evicts the OLDEST run, not the newest, at the cap', () => {
+    // Mutation caught: `.slice(-RUN_LIMIT)` or appending instead of prepending —
+    // either keeps the wrong end. Asserting `runs.length === RUN_LIMIT` alone would
+    // pass under both, which is exactly how a FIFO undo stack survived 871 tests.
+    let runs = [];
+    for (let i = 1; i <= RUN_LIMIT + 1; i += 1) runs = pushRun(runs, run(String(i)));
+    expect(runs).toHaveLength(RUN_LIMIT);
+    expect(runs[0].id).toBe(String(RUN_LIMIT + 1));
+    expect(runs[runs.length - 1].id).toBe('2');
+    expect(runs.some((r) => r.id === '1')).toBe(false);
+  });
+
+  it('does not mutate the array it is given', () => {
+    const before = [run('1')];
+    pushRun(before, run('2'));
+    expect(before.map((r) => r.id)).toEqual(['1']);
+  });
+});
+
+describe('ghostRun', () => {
+  const runs = [run('3'), run('2'), run('1')];
+
+  it('returns the pinned run when one is pinned', () => {
+    // Half one of the pair.
+    expect(ghostRun(runs, '1')?.id).toBe('1');
+  });
+
+  it('falls back to the previous run when nothing is pinned', () => {
+    // Half two. Index 1, not 0: index 0 is the pull just banked, which IS the current
+    // result — a ghost of it would draw the live curve twice.
+    expect(ghostRun(runs, null)?.id).toBe('2');
+  });
+
+  it('falls back to the previous run when the pinned run has been evicted', () => {
+    // Mutation caught: `runs.find(...)` returned straight through, which is
+    // `undefined` for an evicted pin and crashes at the first `.points` read.
+    expect(ghostRun(runs, 'gone')?.id).toBe('2');
+  });
+
+  it('returns null when there is no previous run', () => {
+    expect(ghostRun([run('1')], null)).toBe(null);
+    expect(ghostRun([], null)).toBe(null);
+  });
+});
+
+describe('ghostLabel', () => {
+  const runs = [run('3'), run('2'), run('1')];
+
+  it('names the run when it is the pinned one', () => {
+    expect(ghostLabel(ghostRun(runs, '1'), '1')).toBe('Run 1');
+  });
+
+  it('says "Prev" when nothing is pinned', () => {
+    // The other half. A label expression that always produced `Run ${n}` would pass a
+    // test that only checked the pinned case, and the chart would then claim every
+    // default comparison was a deliberate pin.
+    expect(ghostLabel(ghostRun(runs, null), null)).toBe('Prev');
+  });
+
+  it('says "Prev" when the pin points at an evicted run', () => {
+    // The pin is gone, so the ghost is the previous run and must be labelled as one.
+    expect(ghostLabel(ghostRun(runs, 'gone'), 'gone')).toBe('Prev');
+  });
+
+  it('returns null when there is no ghost to label', () => {
+    expect(ghostLabel(null, null)).toBe(null);
+  });
+});
+
+describe('sparklinePath', () => {
+  it('spans the full width and height of the box', () => {
+    const path = sparklinePath(
+      [{ rpm: 1500, hp: 0, torque: 0 }, { rpm: 1600, hp: 50, torque: 0 }, { rpm: 1700, hp: 100, torque: 0 }],
+      100, 20,
+    );
+    // Lowest hp sits on the bottom edge, highest on the top edge, first x at 0 and
+    // last x at the full width.
+    expect(path).toBe('M0.00,20.00 L50.00,10.00 L100.00,0.00');
+  });
+
+  it('draws a flat line rather than dividing by zero when every point is equal', () => {
+    // Mutation caught: `(hp - min) / (max - min)` with no guard is 0/0 = NaN, which
+    // renders nothing and logs no error.
+    const path = sparklinePath(
+      [{ rpm: 1500, hp: 42, torque: 0 }, { rpm: 1600, hp: 42, torque: 0 }],
+      100, 20,
+    );
+    expect(path).not.toMatch(/NaN/);
+    expect(path).toBe('M0.00,20.00 L100.00,20.00');
+  });
+
+  it('returns an empty string for no points', () => {
+    expect(sparklinePath([], 100, 20)).toBe('');
+  });
+});

--- a/tests/ui/state/runLog.test.js
+++ b/tests/ui/state/runLog.test.js
@@ -40,6 +40,16 @@ function run(id, over = {}) {
   });
 }
 
+describe('RUN_LIMIT', () => {
+  it('is 20 — every test here derives its expectations from the constant, so a change to it would otherwise pass unnoticed', () => {
+    // The user-facing promise is "twenty runs". Every cap test in this file computes
+    // its own expectations from RUN_LIMIT rather than the literal 20, which proves
+    // the cap logic is right but says nothing about what the cap actually IS —
+    // shrinking it to 5 keeps the whole suite green while shrinking the promise.
+    expect(RUN_LIMIT).toBe(20);
+  });
+});
+
 describe('makeRunRecord', () => {
   it('keeps only rpm, hp and torque from each point', () => {
     // Mutation caught: storing `result.points` whole. That is 50 fields per point


### PR DESCRIPTION
Keeps every dyno pull as a browsable, persisted record, lets any of them be pinned as the chart's comparison, and makes that comparison curve legible for the first time.

**Part 1 of 3 for #61** — deliberately does not close it. Events plotted at their RPM (5b) and the post-pull scrubber (5c) ship separately; 5b needs a `src/sim/sweep.js` change this PR is not allowed to make.

## Three of the issue's claims were stale

Written against the pre-PR-3 tree, corrected in the spec rather than carried forward:

- The ghost curve is not at `EcuLab.jsx:2105` — that file is 1083 lines now. It was `ResultScreen.jsx:55`.
- It is not drawn in `#3a4149`; that literal is gone. It was `T.ink3`.
- **"Nearly invisible" was the right conclusion for the wrong reason.** `#5c6880` on the panel is 3.17:1, which passes the 3:1 floor for non-text graphics. The real defect: `T.ink3` is *also* the axis, tick-label and `afrCommanded` colour, so the ghost was indistinguishable from chart furniture rather than too dim to see.

I also withdrew a bug I flagged early. There is no index-vs-RPM misalignment: `SWEEP_START_RPM` and `SWEEP_STEP_RPM` are constants, so `points[i].rpm` is always `1500 + 100i` and the index join *was* an RPM join. It is now keyed by RPM explicitly anyway, because a pinned run may be any length.

## What changed

- **`src/ui/state/runLog.js`** (new) — the run record and its pure operations. A full sweep result is 46,459 bytes of JSON (61 points × 50 fields); the record keeps `{rpm, hp, torque}` plus peaks, scores, a knock count and the measured inputs, at ~4 KB. That 20× cut is what makes a persisted 20-run log affordable at ~80 KB.
- **`pullSignature.js`** — gains `measuredInputs` and `diffMeasuredInputs`. Its header used to argue it must *never* answer "which input moved". The timeline needs that, so the charter is widened deliberately and the header rewritten to say so. The key arrays stay private, and both answers derive from them, so the diff cannot drift from the signature.
- **Store** — `session.runs` (newest first, capped at 20) and `session.pinnedRunId`. **`session.prevResult` is deleted**; `runs[1]` is the same fact and two representations drift.
- **Ghost curve** — each ghost line now takes its live series' own hue at half opacity, dashed. Hue carries series identity, opacity carries time.
- **`storage.js`** — persists `runs` and `pinnedRunId`. A save written before this feature has no `runs` key and loads as `[]`/`null`. The adapter stays UI-agnostic: it validates shape but does not know `RUN_LIMIT`.
- **DYNO > HISTORY** — a fifth section at `#/dyno/history`: sparkline, peaks, delta, what changed since the previous run, and a pin toggle.

## Two defects worth calling out

**A restore could overwrite a just-banked pull, and persist the rollback.** Converting career persistence from an imperative call into a reactive effect turned a pre-existing display-only race into a disk-write one, carrying the whole run log. Reachable on the `artifact` backend, whose read is a real round trip. Fixed with one atomic `RESTORE_CAREER` that *merges* — max for best, sums for totals, session runs in front. Skipping the restore instead would have been worse: the session would hold only this-session values, which the effect then writes over the real career. The evidence the race is gone is that a settle-wait added to work around it could be removed.

**The persisted log was unreachable after a reload.** `EcuLab.jsx` gated the whole DYNO body — nav row included — on `result`, which is session-only and never persisted. Twenty restored runs sat in the store with no button to open them. That gate is pre-existing and correct for the four sections whose data *is* `result`; HISTORY is the first whose data outlives it. Found only by the whole-branch review, because it lives at the seam between the new screen and old shell code.

## Verification

1055 tests across 34 files; `npm run lint` (`--max-warnings 0`), `npm run typecheck` and `npm run build` all clean, run at HEAD.

`src/sim`, `tests/fixtures/fingerprint.sha256` and `tests/ui/characterisation.test.jsx` are **0 lines different from `main`**.

Every behavioural test here was watched failing under a mutation that targets exactly what it claims to hold, one variable at a time. That discipline caught a vacuous assertion mid-branch: a merge test compared 500 banked against 700 loaded, where `max()` and a plain overwrite agree, so it could not fail. It now banks 900.

## Known limitations, accepted

- `pinnedRunId` uses `null` for both "untouched" and "deliberately cleared", so an unpin performed inside the restore window is lost. Documented in the reducer; a tri-state costs more than the bug is worth.
- The delta panel compares against the previous pull while the ghost compares against the pinned run, so pinning an older run leaves the chart and the numbers describing two different comparisons. My spec specified this; it needs a design decision rather than a patch.