### PR TITLE
Release v1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ecu-lab",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ecu-lab",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "lucide-react": "^0.460.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecu-lab",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "An engine management and tuning simulator. Design an engine, edit the same three calibration tables a real tuner edits, run a dyno pull, and read a log that explains what went right or wrong.",
   "keywords": [
     "engine",

--- a/src/version.js
+++ b/src/version.js
@@ -5,4 +5,4 @@
  * GENERATED — do not edit by hand. Run `npm version <patch|minor|major>`, which
  * rewrites this file from package.json via scripts/sync-version.js.
  */
-export const BUILD_VERSION = 'v1.6.0';
+export const BUILD_VERSION = 'v1.7.0';


### PR DESCRIPTION
The version bump for v1.7.0, pushed by the weekly release workflow. Closes #97.

**This is the step that was skipped, and it is why the live site still says 1.6.0.** The `v1.7.0` tag was placed on `3ec30a9` — the merge of #69 — where `package.json` and `src/version.js` both still read 1.6.0. That deploy ran and succeeded, so the site is serving exactly what was tagged. It was just tagged before the bump existed.

The diff is three files and nothing else: `package.json`, `package-lock.json`, and the generated `src/version.js`. Fifty-four non-merge commits since `v1.6.0` are already on `main` and unchanged by this.

Once this merges, the `v1.7.0` tag moves onto the merge commit and is pushed again, which retriggers the deploy. The published tree will differ from what is live now only by the version string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Fds6SnAmhQhxzMXyzxswg
